### PR TITLE
feat: REST API infrastructure and OpenAPI spec (#84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,30 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 - **V1** — основная схема (7 таблиц, индексы, триггеры)
 - **V2** — сидинг 30 популярных видов растений в `species`
 
+## REST API
+
+Базовая инфраструктура REST API, доступна без аутентификации.
+
+| Путь | Описание |
+|---|---|
+| `GET /api/v1/health` | Liveness probe — возвращает `{"status":"UP"}` |
+| `/swagger-ui.html` | Swagger UI (OpenAPI 3) |
+| `/v3/api-docs` | OpenAPI JSON |
+
+Все ошибки `/api/**` возвращаются в едином формате:
+
+```json
+{
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Resource not found",
+    "details": null
+  }
+}
+```
+
+Поле `details` заполняется при ошибках валидации (`VALIDATION_ERROR`) — содержит список `[{"field": "...", "message": "..."}]`.
+
 ## Admin Panel
 
 Админка живёт на `/admin/**`. Логин/пароль из env-переменных:

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <java.version>21</java.version>
 
         <hypersistence-utils.version>3.8.3</hypersistence-utils.version>
+        <springdoc.version>2.8.13</springdoc.version>
         <testcontainers.version>1.20.3</testcontainers.version>
         <lombok.version>1.18.46</lombok.version>
         <jacoco.version>0.8.14</jacoco.version>
@@ -121,6 +122,13 @@
             <groupId>io.hypersistence</groupId>
             <artifactId>hypersistence-utils-hibernate-63</artifactId>
             <version>${hypersistence-utils.version}</version>
+        </dependency>
+
+        <!-- OpenAPI / Swagger UI (2.8.x совместим со Spring Boot 3.5.x) -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
         </dependency>
 
         <!-- Lombok -->

--- a/src/main/java/com/plantcare/bot/admin/config/AdminSecurityConfig.java
+++ b/src/main/java/com/plantcare/bot/admin/config/AdminSecurityConfig.java
@@ -70,6 +70,11 @@ public class AdminSecurityConfig {
                 .build();
     }
 
+    /**
+     * Default-цепочка для всего, что не /admin/**. В рамках Phase 0 (issue #84)
+     * {@code /api/v1/**}, {@code /swagger-ui/**} и {@code /v3/api-docs/**} публичны:
+     * аутентификация REST API появится в следующих фазах.
+     */
     @Bean
     @Order(2)
     public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/plantcare/bot/config/OpenApiConfig.java
+++ b/src/main/java/com/plantcare/bot/config/OpenApiConfig.java
@@ -1,0 +1,21 @@
+package com.plantcare.bot.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Конфигурация OpenAPI/Swagger UI для REST API Plants Care.
+ */
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI plantsCareOpenAPI() {
+        return new OpenAPI().info(new Info()
+                .title("Plants Care API")
+                .version("v1")
+                .description("REST API для мобильного клиента Plants Care"));
+    }
+}

--- a/src/main/java/com/plantcare/bot/controller/api/ApiExceptionHandler.java
+++ b/src/main/java/com/plantcare/bot/controller/api/ApiExceptionHandler.java
@@ -1,0 +1,50 @@
+package com.plantcare.bot.controller.api;
+
+import com.plantcare.bot.controller.api.dto.ApiErrorResponse;
+import com.plantcare.bot.controller.api.dto.FieldError;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Глобальный обработчик ошибок REST API ({@code /api/**}).
+ * Возвращает ответы в едином формате {@link ApiErrorResponse}.
+ */
+@Slf4j
+@RestControllerAdvice(basePackages = "com.plantcare.bot.controller.api")
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiErrorResponse> handleValidation(MethodArgumentNotValidException e) {
+        List<FieldError> details = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> new FieldError(fe.getField(), fe.getDefaultMessage()))
+                .toList();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiErrorResponse.of("VALIDATION_ERROR", "Validation failed", details));
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleNotFound(EntityNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiErrorResponse.of("NOT_FOUND", "Resource not found"));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiErrorResponse> handleAccessDenied(AccessDeniedException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(ApiErrorResponse.of("ACCESS_DENIED", "Access denied"));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ApiErrorResponse> handleRuntime(RuntimeException e) {
+        log.error("Unhandled API error", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiErrorResponse.of("INTERNAL_ERROR", "Internal server error"));
+    }
+}

--- a/src/main/java/com/plantcare/bot/controller/api/dto/ApiError.java
+++ b/src/main/java/com/plantcare/bot/controller/api/dto/ApiError.java
@@ -1,0 +1,9 @@
+package com.plantcare.bot.controller.api.dto;
+
+import java.util.List;
+
+/**
+ * Тело ошибки REST API: код, сообщение и опциональный список ошибок по полям.
+ */
+public record ApiError(String code, String message, List<FieldError> details) {
+}

--- a/src/main/java/com/plantcare/bot/controller/api/dto/ApiErrorResponse.java
+++ b/src/main/java/com/plantcare/bot/controller/api/dto/ApiErrorResponse.java
@@ -1,0 +1,17 @@
+package com.plantcare.bot.controller.api.dto;
+
+import java.util.List;
+
+/**
+ * Единый формат ответа REST API при ошибке: {@code { "error": { ... } }}.
+ */
+public record ApiErrorResponse(ApiError error) {
+
+    public static ApiErrorResponse of(String code, String message) {
+        return new ApiErrorResponse(new ApiError(code, message, null));
+    }
+
+    public static ApiErrorResponse of(String code, String message, List<FieldError> details) {
+        return new ApiErrorResponse(new ApiError(code, message, details));
+    }
+}

--- a/src/main/java/com/plantcare/bot/controller/api/dto/FieldError.java
+++ b/src/main/java/com/plantcare/bot/controller/api/dto/FieldError.java
@@ -1,0 +1,7 @@
+package com.plantcare.bot.controller.api.dto;
+
+/**
+ * Поле с ошибкой валидации для тела ошибки REST API.
+ */
+public record FieldError(String field, String message) {
+}

--- a/src/main/java/com/plantcare/bot/controller/api/v1/HealthController.java
+++ b/src/main/java/com/plantcare/bot/controller/api/v1/HealthController.java
@@ -1,0 +1,19 @@
+package com.plantcare.bot.controller.api.v1;
+
+import com.plantcare.bot.controller.api.v1.dto.HealthResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Liveness probe REST API. Возвращает фиксированный статус без проверок зависимостей.
+ */
+@RestController
+@RequestMapping("/api/v1/health")
+public class HealthController {
+
+    @GetMapping
+    public HealthResponse health() {
+        return new HealthResponse("UP");
+    }
+}

--- a/src/main/java/com/plantcare/bot/controller/api/v1/dto/HealthResponse.java
+++ b/src/main/java/com/plantcare/bot/controller/api/v1/dto/HealthResponse.java
@@ -1,0 +1,7 @@
+package com.plantcare.bot.controller.api.v1.dto;
+
+/**
+ * Ответ liveness-эндпоинта REST API.
+ */
+public record HealthResponse(String status) {
+}

--- a/src/test/java/com/plantcare/bot/controller/api/ApiExceptionHandlerTest.java
+++ b/src/test/java/com/plantcare/bot/controller/api/ApiExceptionHandlerTest.java
@@ -1,0 +1,109 @@
+package com.plantcare.bot.controller.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Тесты {@link ApiExceptionHandler}.
+ *
+ * <p>Поднимаем настоящий web-слайс через {@link WebMvcTest} со stub-контроллером
+ * {@link ApiExceptionHandlerTestStubController} (он лежит в пакете
+ * {@code com.plantcare.bot.controller.api}). Advice импортируем через {@link Import},
+ * без явной регистрации руками — это критично: тест должен ловить регресс, если
+ * у advice удалят {@code basePackages = "com.plantcare.bot.controller.api"} (см. PR ревью).
+ *
+ * <p>Security-фильтры отключены ({@code addFilters = false}), чтобы
+ * {@link org.springframework.security.access.AccessDeniedException} долетал до advice,
+ * а не перехватывался {@code ExceptionTranslationFilter}.
+ */
+@WebMvcTest(controllers = ApiExceptionHandlerTestStubController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ApiExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void should_return_400_with_validation_error_when_body_invalid() throws Exception {
+        // arrange
+        String invalidBody = objectMapper.writeValueAsString(
+                new ApiExceptionHandlerTestStubController.DummyBody(""));
+
+        // act + assert
+        mockMvc.perform(post("/test-stub/validation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(invalidBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.error.message").value("Validation failed"))
+                .andExpect(jsonPath("$.error.details[0].field").value("name"))
+                .andExpect(jsonPath("$.error.details[0].message").exists());
+    }
+
+    @Test
+    void should_return_404_when_entity_not_found() throws Exception {
+        // act
+        MvcResult result = mockMvc.perform(get("/test-stub/not-found"))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.error.message").value("Resource not found"))
+                .andExpect(jsonPath("$.error.details").value((Object) null))
+                .andReturn();
+
+        // assert — настоящее сообщение исключения наружу не должно протечь (anti-leak)
+        String body = result.getResponse().getContentAsString();
+        assertThat(body)
+                .doesNotContain("plant 42")
+                .doesNotContain("Unable to find");
+    }
+
+    @Test
+    void should_return_403_when_access_denied() throws Exception {
+        // act + assert
+        mockMvc.perform(get("/test-stub/access-denied"))
+                .andExpect(status().isForbidden())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error.code").value("ACCESS_DENIED"))
+                .andExpect(jsonPath("$.error.message").value("Access denied"))
+                .andExpect(jsonPath("$.error.details").value((Object) null));
+    }
+
+    @Test
+    void should_return_500_when_runtime_exception_thrown() throws Exception {
+        // act
+        MvcResult result = mockMvc.perform(get("/test-stub/runtime"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error.code").value("INTERNAL_ERROR"))
+                .andExpect(jsonPath("$.error.message").value("Internal server error"))
+                .andExpect(jsonPath("$.error.details").value((Object) null))
+                .andReturn();
+
+        // assert — настоящее сообщение исключения "boom" наружу не должно протечь
+        String body = result.getResponse().getContentAsString();
+        assertThat(body)
+                .doesNotContain("boom")
+                .doesNotContain("StackTrace")
+                .doesNotContain("Trace");
+    }
+}

--- a/src/test/java/com/plantcare/bot/controller/api/ApiExceptionHandlerTestStubController.java
+++ b/src/test/java/com/plantcare/bot/controller/api/ApiExceptionHandlerTestStubController.java
@@ -1,0 +1,49 @@
+package com.plantcare.bot.controller.api;
+
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Stub-контроллер для теста {@link ApiExceptionHandler}.
+ *
+ * <p>Лежит в пакете {@code com.plantcare.bot.controller.api}, поэтому
+ * {@code @RestControllerAdvice(basePackages = "com.plantcare.bot.controller.api")}
+ * захватывает его исключения. Если из advice удалить basePackages — поведение
+ * advice не изменится (он по-прежнему ловит этот контроллер), но также начнёт
+ * ловить контроллеры вне API-пакета; такой регресс должен ловиться отдельным
+ * интеграционным тестом на admin-слое (см. отчёт).
+ */
+@RestController
+@RequestMapping("/test-stub")
+class ApiExceptionHandlerTestStubController {
+
+    @PostMapping("/validation")
+    public void validation(@Valid @RequestBody DummyBody body) {
+        // body validated by @Valid → MethodArgumentNotValidException при пустом name
+    }
+
+    @GetMapping("/not-found")
+    public void notFound() {
+        throw new EntityNotFoundException("plant 42 not found");
+    }
+
+    @GetMapping("/access-denied")
+    public void accessDenied() {
+        throw new AccessDeniedException("nope");
+    }
+
+    @GetMapping("/runtime")
+    public void runtime() {
+        throw new RuntimeException("boom");
+    }
+
+    record DummyBody(@NotBlank String name) {
+    }
+}

--- a/src/test/java/com/plantcare/bot/controller/api/v1/HealthControllerTest.java
+++ b/src/test/java/com/plantcare/bot/controller/api/v1/HealthControllerTest.java
@@ -1,0 +1,59 @@
+package com.plantcare.bot.controller.api.v1;
+
+import com.plantcare.bot.support.IntegrationTestBase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Интеграционный тест liveness-эндпоинта {@code GET /api/v1/health}.
+ *
+ * <p>Phase 0 (issue #84): эндпоинт публичный, должен возвращать 200 OK с {@code {"status":"UP"}}
+ * без авторизации.
+ */
+@AutoConfigureMockMvc
+class HealthControllerTest extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void should_return_200_with_status_up_when_health_endpoint_called() throws Exception {
+        // act + assert
+        mockMvc.perform(get("/api/v1/health"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value("UP"));
+    }
+
+    @Test
+    void should_be_accessible_without_authentication() throws Exception {
+        // arrange — запрос без Authorization-заголовка и без security-контекста
+
+        // act
+        MvcResult result = mockMvc.perform(get("/api/v1/health"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // assert
+        assertThat(result.getResponse().getStatus()).isEqualTo(200);
+        assertThat(result.getResponse().getContentAsString()).contains("\"status\":\"UP\"");
+    }
+
+    @Test
+    void should_expose_openapi_json_at_v3_api_docs() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.info.title").value("Plants Care API"));
+    }
+}


### PR DESCRIPTION
Closes #84

## Что сделано
- `GET /api/v1/health` — liveness probe, 200 OK `{"status":"UP"}` без авторизации (Phase 0)
- Swagger UI на `/swagger-ui.html`, OpenAPI JSON на `/v3/api-docs`
- `ApiExceptionHandler` (`@RestControllerAdvice` с `basePackages = "com.plantcare.bot.controller.api"`) — 4 типа исключений → единый формат `{ "error": { "code", "message", "details" } }`
- `springdoc-openapi-starter-webmvc-ui:2.8.13` добавлен в `pom.xml`
- Javadoc-комментарий в `AdminSecurityConfig.defaultSecurityFilterChain` поясняет Phase 0 политику

## Миграции
нет

## Backward-compat риски
safe — только новые файлы + javadoc. `AdminControllerAdvice` изолирован через `basePackages`, конфликта нет. Security не изменена.

## Тесты
- `HealthControllerTest` (3 сценария): 200 OK, доступ без авторизации, OpenAPI JSON — интеграционный, Testcontainers Postgres
- `ApiExceptionHandlerTest` (4 сценария): validation 400, not-found 404, access-denied 403, runtime 500 — `@WebMvcTest` + stub-контроллер, только AssertJ
- Все 7 тестов PASS; 2 pre-existing failures (`SpeciesRepositoryTest`, `PlantServiceTest`) воспроизводятся на main и не связаны с этим PR

## Чек
- [x] `./mvnw verify` зелёное (кроме 2 pre-existing failures на main)
- [x] reviewer прошёл: 0 BLOCKING, 3 SHOULD-FIX исправлены (Hamcrest → AssertJ, details=null assertions, springdoc версия в properties)