### PR TITLE
feat: Plants and Locations REST CRUD (#85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,37 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 
 ## REST API
 
-Базовая инфраструктура REST API, доступна без аутентификации.
+Все запросы к `/api/v1/plants` и `/api/v1/locations` требуют заголовка `X-User-Id: {userId}` (временная заглушка до #88).
+
+### Служебные эндпоинты
 
 | Путь | Описание |
 |---|---|
 | `GET /api/v1/health` | Liveness probe — возвращает `{"status":"UP"}` |
 | `/swagger-ui.html` | Swagger UI (OpenAPI 3) |
 | `/v3/api-docs` | OpenAPI JSON |
+
+### Plants
+
+| Метод | Путь | Описание |
+|---|---|---|
+| `GET` | `/api/v1/plants` | Список растений. Параметры: `locationId` (фильтр), `offset` (по умолч. 0), `limit` (по умолч. 20, макс. 100) |
+| `GET` | `/api/v1/plants/{id}` | Одно растение |
+| `POST` | `/api/v1/plants` | Создать растение (без расписания полива) |
+| `PUT` | `/api/v1/plants/{id}` | Обновить растение. PATCH-семантика: обновляются только переданные поля (`name`, `notes`, `locationId`) |
+| `DELETE` | `/api/v1/plants/{id}` | Soft-delete: выставляет `archivedAt`, из выборок не возвращается |
+
+### Locations
+
+| Метод | Путь | Описание |
+|---|---|---|
+| `GET` | `/api/v1/locations` | Список всех локаций пользователя |
+| `GET` | `/api/v1/locations/{id}` | Одна локация |
+| `POST` | `/api/v1/locations` | Создать локацию |
+| `PUT` | `/api/v1/locations/{id}` | Обновить имя и/или emoji |
+| `DELETE` | `/api/v1/locations/{id}` | Удалить локацию. Если в ней есть растения, обязателен параметр `targetLocationId` — растения переносятся в указанную локацию перед удалением |
+
+### Формат ошибок
 
 Все ошибки `/api/**` возвращаются в едином формате:
 

--- a/src/main/java/com/plantcare/bot/controller/api/ApiExceptionHandler.java
+++ b/src/main/java/com/plantcare/bot/controller/api/ApiExceptionHandler.java
@@ -41,6 +41,12 @@ public class ApiExceptionHandler {
                 .body(ApiErrorResponse.of("ACCESS_DENIED", "Access denied"));
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiErrorResponse> handleIllegalArgument(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiErrorResponse.of("BAD_REQUEST", e.getMessage()));
+    }
+
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ApiErrorResponse> handleRuntime(RuntimeException e) {
         log.error("Unhandled API error", e);

--- a/src/main/java/com/plantcare/bot/controller/api/v1/LocationController.java
+++ b/src/main/java/com/plantcare/bot/controller/api/v1/LocationController.java
@@ -1,0 +1,155 @@
+package com.plantcare.bot.controller.api.v1;
+
+import com.plantcare.bot.controller.api.dto.ApiErrorResponse;
+import com.plantcare.bot.controller.api.v1.dto.LocationCreateRequest;
+import com.plantcare.bot.controller.api.v1.dto.LocationDto;
+import com.plantcare.bot.controller.api.v1.dto.LocationUpdateRequest;
+import com.plantcare.bot.domain.Location;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.service.LocationService;
+import com.plantcare.bot.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * REST API для управления локациями (issue #85).
+ */
+@Tag(name = "Locations", description = "Location CRUD")
+@RestController
+@RequestMapping("/api/v1/locations")
+@RequiredArgsConstructor
+public class LocationController {
+
+    private final LocationService locationService;
+    private final UserService userService;
+
+    @Operation(summary = "List all locations for the authenticated user")
+    @ApiResponse(responseCode = "200", description = "List returned")
+    @GetMapping
+    public List<LocationDto> listLocations(
+            @Parameter(description = "Caller user ID", required = true)
+            @RequestHeader("X-User-Id") Long userId
+    ) {
+        return locationService.getUserLocations(userId).stream()
+                .map(LocationDto::from)
+                .toList();
+    }
+
+    @Operation(summary = "Get a single location by ID")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Location found"),
+            @ApiResponse(responseCode = "404", description = "Location not found")
+    })
+    @GetMapping("/{id}")
+    public LocationDto getLocation(
+            @Parameter(description = "Caller user ID", required = true)
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long id
+    ) {
+        Location location = getLocationOrThrow(userId, id);
+        return LocationDto.from(location);
+    }
+
+    @Operation(summary = "Create a new location")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Location created"),
+            @ApiResponse(responseCode = "400", description = "Validation failed or duplicate name")
+    })
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public LocationDto createLocation(
+            @Parameter(description = "Caller user ID", required = true)
+            @RequestHeader("X-User-Id") Long userId,
+            @Valid @RequestBody LocationCreateRequest request
+    ) {
+        User user = userService.getByIdOrThrow(userId);
+        Location location = locationService.createLocation(user, request.name(), request.emoji());
+        return LocationDto.from(location);
+    }
+
+    @Operation(summary = "Update a location (name and/or emoji)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Location updated"),
+            @ApiResponse(responseCode = "400", description = "Validation failed"),
+            @ApiResponse(responseCode = "404", description = "Location not found")
+    })
+    @PutMapping("/{id}")
+    public LocationDto updateLocation(
+            @Parameter(description = "Caller user ID", required = true)
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long id,
+            @Valid @RequestBody LocationUpdateRequest request
+    ) {
+        try {
+            Location updated = locationService.updateLocation(userId, id, request.name(), request.emoji());
+            return LocationDto.from(updated);
+        } catch (IllegalArgumentException e) {
+            throw new jakarta.persistence.EntityNotFoundException("Location not found: " + id);
+        }
+    }
+
+    @Operation(summary = "Delete a location. If it has plants, provide targetLocationId to move them first.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Location deleted"),
+            @ApiResponse(responseCode = "400", description = "Location has plants and no targetLocationId provided"),
+            @ApiResponse(responseCode = "404", description = "Location not found")
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteLocation(
+            @Parameter(description = "Caller user ID", required = true)
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long id,
+            @Parameter(description = "Location to move plants into (required if location has plants)")
+            @RequestParam(required = false) Long targetLocationId
+    ) {
+        getLocationOrThrow(userId, id);
+        long plantCount = locationService.countPlantsInLocation(userId, id);
+
+        if (plantCount > 0) {
+            if (targetLocationId == null) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(ApiErrorResponse.of(
+                                "LOCATION_NOT_EMPTY",
+                                "Provide targetLocationId to move plants"));
+            }
+            locationService.deleteLocation(userId, id, targetLocationId);
+        } else {
+            locationService.deleteEmptyLocation(userId, id);
+        }
+
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Получить локацию пользователя или бросить EntityNotFoundException (→ 404).
+     * LocationService бросает IllegalArgumentException (→ 400), поэтому для REST
+     * выполняем явное преобразование.
+     */
+    private Location getLocationOrThrow(Long userId, Long locationId) {
+        try {
+            return locationService.getUserLocationOrThrow(userId, locationId);
+        } catch (IllegalArgumentException e) {
+            throw new jakarta.persistence.EntityNotFoundException("Location not found: " + locationId);
+        }
+    }
+}

--- a/src/main/java/com/plantcare/bot/controller/api/v1/PlantController.java
+++ b/src/main/java/com/plantcare/bot/controller/api/v1/PlantController.java
@@ -1,0 +1,137 @@
+package com.plantcare.bot.controller.api.v1;
+
+import com.plantcare.bot.controller.api.v1.dto.PageResponse;
+import com.plantcare.bot.controller.api.v1.dto.PlantCreateRequest;
+import com.plantcare.bot.controller.api.v1.dto.PlantDto;
+import com.plantcare.bot.controller.api.v1.dto.PlantUpdateRequest;
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.service.PlantService;
+import com.plantcare.bot.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * REST API для управления растениями (issue #85).
+ */
+@Tag(name = "Plants", description = "Plant CRUD")
+@RestController
+@RequestMapping("/api/v1/plants")
+@RequiredArgsConstructor
+public class PlantController {
+
+    private final PlantService plantService;
+    private final UserService userService;
+
+    @Operation(summary = "List plants for the authenticated user")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List returned"),
+            @ApiResponse(responseCode = "400", description = "Invalid query parameters")
+    })
+    @GetMapping
+    public PageResponse<PlantDto> listPlants(
+            @Parameter(description = "Caller user ID", required = true)
+            @RequestHeader("X-User-Id") Long userId,
+            @Parameter(description = "Filter by location ID")
+            @RequestParam(required = false) Long locationId,
+            @Parameter(description = "Pagination offset", example = "0")
+            @RequestParam(defaultValue = "0") int offset,
+            @Parameter(description = "Page size (max 100)", example = "20")
+            @RequestParam(defaultValue = "20") int limit
+    ) {
+        int safeLimit = Math.min(Math.max(limit, 1), 100);
+        int safeOffset = Math.max(offset, 0);
+
+        List<Plant> plants = plantService.listPlants(userId, locationId, safeOffset, safeLimit);
+        long total = plantService.countPlants(userId, locationId);
+
+        List<PlantDto> items = plants.stream().map(PlantDto::from).toList();
+        return new PageResponse<>(items, (int) total, safeOffset, safeLimit);
+    }
+
+    @Operation(summary = "Get a single plant by ID")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Plant found"),
+            @ApiResponse(responseCode = "403", description = "Plant belongs to another user"),
+            @ApiResponse(responseCode = "404", description = "Plant not found")
+    })
+    @GetMapping("/{id}")
+    public PlantDto getPlant(
+            @Parameter(description = "Caller user ID", required = true)
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long id
+    ) {
+        Plant plant = plantService.getPlantOrThrow(userId, id);
+        return PlantDto.from(plant);
+    }
+
+    @Operation(summary = "Create a new plant")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Plant created"),
+            @ApiResponse(responseCode = "400", description = "Validation failed")
+    })
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public PlantDto createPlant(
+            @Parameter(description = "Caller user ID", required = true)
+            @RequestHeader("X-User-Id") Long userId,
+            @Valid @RequestBody PlantCreateRequest request
+    ) {
+        User user = userService.getByIdOrThrow(userId);
+        Plant plant = plantService.createPlant(user, request.name(), request.notes(), request.locationId());
+        return PlantDto.from(plant);
+    }
+
+    @Operation(summary = "Update a plant (PATCH-style: only provided fields are updated)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Plant updated"),
+            @ApiResponse(responseCode = "400", description = "Validation failed"),
+            @ApiResponse(responseCode = "403", description = "Plant belongs to another user"),
+            @ApiResponse(responseCode = "404", description = "Plant not found")
+    })
+    @PutMapping("/{id}")
+    public PlantDto updatePlant(
+            @Parameter(description = "Caller user ID", required = true)
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long id,
+            @Valid @RequestBody PlantUpdateRequest request
+    ) {
+        Plant updated = plantService.updatePlant(userId, id, request.name(), request.notes(), request.locationId());
+        return PlantDto.from(updated);
+    }
+
+    @Operation(summary = "Soft-delete (archive) a plant")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Plant archived"),
+            @ApiResponse(responseCode = "403", description = "Plant belongs to another user"),
+            @ApiResponse(responseCode = "404", description = "Plant not found")
+    })
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deletePlant(
+            @Parameter(description = "Caller user ID", required = true)
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long id
+    ) {
+        plantService.archivePlant(userId, id);
+    }
+}

--- a/src/main/java/com/plantcare/bot/controller/api/v1/dto/LocationCreateRequest.java
+++ b/src/main/java/com/plantcare/bot/controller/api/v1/dto/LocationCreateRequest.java
@@ -1,0 +1,21 @@
+package com.plantcare.bot.controller.api.v1.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request DTO для создания локации.
+ */
+@Schema(description = "Request to create a location")
+public record LocationCreateRequest(
+        @NotBlank
+        @Size(max = 30)
+        @Schema(description = "Location name", example = "Living room", requiredMode = Schema.RequiredMode.REQUIRED)
+        String name,
+
+        @Size(max = 16)
+        @Schema(description = "Location emoji (optional)", example = "🌿")
+        String emoji
+) {
+}

--- a/src/main/java/com/plantcare/bot/controller/api/v1/dto/LocationDto.java
+++ b/src/main/java/com/plantcare/bot/controller/api/v1/dto/LocationDto.java
@@ -1,0 +1,32 @@
+package com.plantcare.bot.controller.api.v1.dto;
+
+import com.plantcare.bot.domain.Location;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+/**
+ * Response DTO для локации.
+ */
+@Schema(description = "Location details")
+public record LocationDto(
+        @Schema(description = "Location ID", example = "1") Long id,
+        @Schema(description = "Location name", example = "Living room") String name,
+        @Schema(description = "Location emoji", example = "🪴") String emoji,
+        @Schema(description = "Whether this is the default location") boolean defaultLocation,
+        @Schema(description = "Creation timestamp (UTC)") Instant createdAt
+) {
+
+    public static LocationDto from(Location location) {
+        return new LocationDto(
+                location.getId(),
+                location.getName(),
+                location.getEmoji(),
+                location.isDefaultLocation(),
+                location.getCreatedAt() != null
+                        ? location.getCreatedAt().toInstant(ZoneOffset.UTC)
+                        : null
+        );
+    }
+}

--- a/src/main/java/com/plantcare/bot/controller/api/v1/dto/LocationUpdateRequest.java
+++ b/src/main/java/com/plantcare/bot/controller/api/v1/dto/LocationUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.plantcare.bot.controller.api.v1.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request DTO для обновления локации (все поля опциональные).
+ */
+@Schema(description = "Request to update a location (all fields optional)")
+public record LocationUpdateRequest(
+        @Size(max = 30)
+        @Schema(description = "New location name", example = "Bedroom")
+        String name,
+
+        @Size(max = 16)
+        @Schema(description = "New location emoji", example = "🌱")
+        String emoji
+) {
+}

--- a/src/main/java/com/plantcare/bot/controller/api/v1/dto/PageResponse.java
+++ b/src/main/java/com/plantcare/bot/controller/api/v1/dto/PageResponse.java
@@ -1,0 +1,17 @@
+package com.plantcare.bot.controller.api.v1.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * Pagination wrapper для списковых ответов REST API.
+ */
+@Schema(description = "Paginated response wrapper")
+public record PageResponse<T>(
+        @Schema(description = "Items on the current page") List<T> items,
+        @Schema(description = "Total number of matching items", example = "42") int total,
+        @Schema(description = "Current offset", example = "0") int offset,
+        @Schema(description = "Page size limit", example = "20") int limit
+) {
+}

--- a/src/main/java/com/plantcare/bot/controller/api/v1/dto/PlantCreateRequest.java
+++ b/src/main/java/com/plantcare/bot/controller/api/v1/dto/PlantCreateRequest.java
@@ -1,0 +1,24 @@
+package com.plantcare.bot.controller.api.v1.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request DTO для создания растения.
+ */
+@Schema(description = "Request to create a plant")
+public record PlantCreateRequest(
+        @NotBlank
+        @Size(max = 100)
+        @Schema(description = "Plant name", example = "Monstera", requiredMode = Schema.RequiredMode.REQUIRED)
+        String name,
+
+        @Size(max = 2000)
+        @Schema(description = "Notes about the plant", example = "Keep soil moist")
+        String notes,
+
+        @Schema(description = "Location ID to place the plant in (uses default if omitted)", example = "2")
+        Long locationId
+) {
+}

--- a/src/main/java/com/plantcare/bot/controller/api/v1/dto/PlantDto.java
+++ b/src/main/java/com/plantcare/bot/controller/api/v1/dto/PlantDto.java
@@ -1,0 +1,42 @@
+package com.plantcare.bot.controller.api.v1.dto;
+
+import com.plantcare.bot.domain.Plant;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+/**
+ * Response DTO для растения.
+ */
+@Schema(description = "Plant details")
+public record PlantDto(
+        @Schema(description = "Plant ID", example = "1") Long id,
+        @Schema(description = "Plant name", example = "Monstera") String name,
+        @Schema(description = "Notes", example = "Keep moist") String notes,
+        @Schema(description = "Telegram photo file_id") String photoFileId,
+        @Schema(description = "Location ID", example = "2") Long locationId,
+        @Schema(description = "Location name", example = "Living room") String locationName,
+        @Schema(description = "Species ID", example = "5") Long speciesId,
+        @Schema(description = "Species name", example = "Monstera deliciosa") String speciesName,
+        @Schema(description = "Whether the plant is archived") boolean archived,
+        @Schema(description = "Creation timestamp (UTC)") Instant createdAt
+) {
+
+    public static PlantDto from(Plant plant) {
+        return new PlantDto(
+                plant.getId(),
+                plant.getName(),
+                plant.getNotes(),
+                plant.getPhotoFileId(),
+                plant.getLocation() != null ? plant.getLocation().getId() : null,
+                plant.getLocation() != null ? plant.getLocation().getName() : null,
+                plant.getSpecies() != null ? plant.getSpecies().getId() : null,
+                plant.getSpecies() != null ? plant.getSpecies().getName() : null,
+                plant.isArchived(),
+                plant.getCreatedAt() != null
+                        ? plant.getCreatedAt().toInstant(ZoneOffset.UTC)
+                        : null
+        );
+    }
+}

--- a/src/main/java/com/plantcare/bot/controller/api/v1/dto/PlantUpdateRequest.java
+++ b/src/main/java/com/plantcare/bot/controller/api/v1/dto/PlantUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.plantcare.bot.controller.api.v1.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request DTO для обновления растения (PATCH-семантика через PUT: обновляются только присутствующие поля).
+ */
+@Schema(description = "Request to update a plant (all fields optional)")
+public record PlantUpdateRequest(
+        @Size(max = 100)
+        @Schema(description = "New plant name", example = "Monstera deliciosa")
+        String name,
+
+        @Size(max = 2000)
+        @Schema(description = "Updated notes", example = "Water twice a week")
+        String notes,
+
+        @Schema(description = "New location ID", example = "3")
+        Long locationId
+) {
+}

--- a/src/main/java/com/plantcare/bot/repository/PlantRepository.java
+++ b/src/main/java/com/plantcare/bot/repository/PlantRepository.java
@@ -1,6 +1,7 @@
 package com.plantcare.bot.repository;
 
 import com.plantcare.bot.domain.Plant;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,6 +15,14 @@ import java.util.Optional;
 public interface PlantRepository extends JpaRepository<Plant, Long> {
 
     List<Plant> findAllByUserIdAndArchivedAtIsNullOrderByNameAsc(Long userId);
+
+    List<Plant> findAllByUserIdAndArchivedAtIsNullOrderByNameAsc(Long userId, Pageable pageable);
+
+    List<Plant> findAllByUserIdAndLocationIdAndArchivedAtIsNullOrderByNameAsc(
+            Long userId,
+            Long locationId,
+            Pageable pageable
+    );
 
     Optional<Plant> findByUserIdAndIdAndArchivedAtIsNull(Long userId, Long plantId);
 

--- a/src/main/java/com/plantcare/bot/service/LocationService.java
+++ b/src/main/java/com/plantcare/bot/service/LocationService.java
@@ -248,6 +248,50 @@ public class LocationService {
         return saved;
     }
 
+    /**
+     * Обновить имя и/или emoji локации (REST API, issue #85).
+     * Логика инлайновая — вызов через this.renameLocation / this.changeEmoji
+     * обходил бы Spring-прокси и игнорировал их @Transactional,
+     * а также приводил к лишним запросам к БД (до 3× getUserLocationOrThrow).
+     */
+    @Transactional
+    public Location updateLocation(Long userId, Long locationId, String name, String emoji) {
+        Location location = getUserLocationOrThrow(userId, locationId);
+        if (name != null && !name.isBlank()) {
+            String normalizedName = normalizeName(name);
+            validateLocationName(normalizedName);
+            boolean duplicateExists = locationRepository.existsByUserIdAndNameIgnoreCaseAndIdNot(
+                    userId, normalizedName, locationId);
+            if (duplicateExists) {
+                throw new IllegalArgumentException("Такая комната уже есть");
+            }
+            location.setName(normalizedName);
+        }
+        if (emoji != null && !emoji.isBlank()) {
+            String normalizedEmoji = normalizeEmoji(emoji);
+            validateEmoji(normalizedEmoji);
+            location.setEmoji(normalizedEmoji);
+        }
+        return locationRepository.save(location);
+    }
+
+    /**
+     * Удалить пустую локацию (без активных растений). REST API, issue #85.
+     */
+    @Transactional
+    public void deleteEmptyLocation(Long userId, Long locationId) {
+        Location location = getUserLocationOrThrow(userId, locationId);
+        if (location.isDefaultLocation()) {
+            throw new IllegalArgumentException("Cannot delete default location");
+        }
+        long plantCount = plantRepository.countByUserIdAndLocationIdAndArchivedAtIsNull(userId, locationId);
+        if (plantCount > 0) {
+            throw new IllegalArgumentException("Location has plants, provide targetLocationId");
+        }
+        locationRepository.delete(location);
+        log.info("Deleted empty location {} for user {}", locationId, userId);
+    }
+
     @Transactional
     public void deleteLocation(Long userId, Long locationId, Long targetLocationId) {
         Location locationToDelete = getUserLocationOrThrow(userId, locationId);

--- a/src/main/java/com/plantcare/bot/service/PlantService.java
+++ b/src/main/java/com/plantcare/bot/service/PlantService.java
@@ -2,6 +2,7 @@ package com.plantcare.bot.service;
 
 import com.plantcare.bot.domain.CareHistory;
 import com.plantcare.bot.domain.CareSchedule;
+import com.plantcare.bot.domain.Location;
 import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.Species;
 import com.plantcare.bot.domain.User;
@@ -10,9 +11,14 @@ import com.plantcare.bot.repository.CareHistoryRepository;
 import com.plantcare.bot.repository.CareScheduleRepository;
 import com.plantcare.bot.repository.PlantRepository;
 import com.plantcare.bot.repository.SpeciesRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Limit;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +36,84 @@ public class PlantService {
     private final CareHistoryRepository careHistoryRepository;
     private final SpeciesRepository speciesRepository;
     private final LocationService locationService;
+
+    // =================================================================
+    // REST API CRUD (issue #85)
+    // =================================================================
+
+    @Transactional(readOnly = true)
+    public List<Plant> listPlants(Long userId, Long locationId, int offset, int limit) {
+        int safeLimit = Math.max(1, Math.min(limit, 100));
+        int safeOffset = Math.max(0, offset);
+        if (safeOffset % safeLimit != 0) {
+            throw new IllegalArgumentException("offset must be a multiple of limit");
+        }
+        int page = safeOffset / safeLimit;
+        Pageable pageable = PageRequest.of(page, safeLimit, Sort.by("name").ascending());
+        if (locationId != null) {
+            return plantRepository.findAllByUserIdAndLocationIdAndArchivedAtIsNullOrderByNameAsc(
+                    userId, locationId, pageable);
+        }
+        return plantRepository.findAllByUserIdAndArchivedAtIsNullOrderByNameAsc(userId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Plant getPlantOrThrow(Long userId, Long plantId) {
+        Plant plant = plantRepository.findById(plantId)
+                .orElseThrow(() -> new EntityNotFoundException("Plant not found: " + plantId));
+        if (!plant.getUser().getId().equals(userId)) {
+            throw new AccessDeniedException("Access denied");
+        }
+        if (plant.isArchived()) {
+            throw new EntityNotFoundException("Plant not found: " + plantId);
+        }
+        return plant;
+    }
+
+    @Transactional(readOnly = true)
+    public long countPlants(Long userId, Long locationId) {
+        if (locationId != null) {
+            return plantRepository.countByUserIdAndLocationIdAndArchivedAtIsNull(userId, locationId);
+        }
+        return plantRepository.countByUserIdAndArchivedAtIsNull(userId);
+    }
+
+    @Transactional
+    public Plant createPlant(User user, String name, String notes, Long locationId) {
+        Location location;
+        if (locationId != null) {
+            location = locationService.getUserLocationOrThrow(user.getId(), locationId);
+        } else {
+            location = locationService.getOrCreateDefaultLocation(user);
+        }
+        Plant plant = Plant.builder()
+                .user(user)
+                .location(location)
+                .name(name)
+                .notes(notes)
+                .build();
+        Plant saved = plantRepository.save(plant);
+        log.info("Created plant '{}' (id={}) via REST API for user {}", name, saved.getId(), user.getId());
+        return saved;
+    }
+
+    @Transactional
+    public Plant updatePlant(Long userId, Long plantId, String name, String notes, Long locationId) {
+        Plant plant = getPlantOrThrow(userId, plantId);
+        if (name != null) {
+            plant.setName(name);
+        }
+        if (notes != null) {
+            plant.setNotes(notes);
+        }
+        if (locationId != null) {
+            Location location = locationService.getUserLocationOrThrow(userId, locationId);
+            plant.setLocation(location);
+        }
+        Plant saved = plantRepository.save(plant);
+        log.info("Updated plant {} via REST API (user {})", plantId, userId);
+        return saved;
+    }
 
     /**
      * Получить топ популярных видов для отображения на первом экране.
@@ -366,11 +450,11 @@ public class PlantService {
 
     /**
      * Архивирует растение (soft-delete). История ухода остаётся для статистики.
+     * Используется как из Telegram-бота, так и из REST API (issue #85).
      */
     @Transactional
     public void archivePlant(Long userId, Long plantId) {
-        Plant plant = plantRepository.findByUserIdAndIdAndArchivedAtIsNull(userId, plantId)
-                .orElseThrow(() -> new IllegalArgumentException("Растение не найдено"));
+        Plant plant = getPlantOrThrow(userId, plantId);
 
         plant.archive();
         plantRepository.save(plant);

--- a/src/main/java/com/plantcare/bot/service/UserService.java
+++ b/src/main/java/com/plantcare/bot/service/UserService.java
@@ -34,6 +34,12 @@ public class UserService {
         return userRepository.findByTelegramChatId(chatId);
     }
 
+    @Transactional(readOnly = true)
+    public User getByIdOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new jakarta.persistence.EntityNotFoundException("User not found: " + userId));
+    }
+
     @Transactional
     public void updateState(User user, ConversationState newState) {
         log.info(

--- a/src/test/java/com/plantcare/bot/controller/api/v1/LocationControllerTest.java
+++ b/src/test/java/com/plantcare/bot/controller/api/v1/LocationControllerTest.java
@@ -1,0 +1,260 @@
+package com.plantcare.bot.controller.api.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.plantcare.bot.controller.api.ApiExceptionHandler;
+import com.plantcare.bot.domain.Location;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.service.LocationService;
+import com.plantcare.bot.service.UserService;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @WebMvcTest for {@link LocationController} — covers list, get, create, update,
+ * delete (empty and with target), validation, 403/404 error paths (issue #85).
+ */
+@WebMvcTest(LocationController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class LocationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private LocationService locationService;
+
+    @MockitoBean
+    private UserService userService;
+
+    // ------------------------------------------------------------------ helpers
+
+    private Location mockLocation(long id, long userId, String name, String emoji) {
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(userId);
+
+        Location location = mock(Location.class);
+        when(location.getId()).thenReturn(id);
+        when(location.getName()).thenReturn(name);
+        when(location.getEmoji()).thenReturn(emoji);
+        when(location.isDefaultLocation()).thenReturn(false);
+        when(location.getCreatedAt()).thenReturn(null);
+
+        return location;
+    }
+
+    // ------------------------------------------------------------------ tests
+
+    @Test
+    void should_return_locations_list() throws Exception {
+        // arrange
+        Location loc1 = mockLocation(1L, 1L, "Living Room", "🌿");
+        Location loc2 = mockLocation(2L, 1L, "Bedroom", "🛏");
+
+        when(locationService.getUserLocations(1L)).thenReturn(List.of(loc1, loc2));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/locations")
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].name").value("Living Room"))
+                .andExpect(jsonPath("$[1].name").value("Bedroom"));
+    }
+
+    @Test
+    void should_return_location_when_found() throws Exception {
+        // arrange
+        Location loc = mockLocation(1L, 1L, "Living Room", "🌿");
+
+        when(locationService.getUserLocationOrThrow(1L, 1L)).thenReturn(loc);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/locations/1")
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.name").value("Living Room"))
+                .andExpect(jsonPath("$.emoji").value("🌿"));
+    }
+
+    @Test
+    void should_return_404_when_location_not_found() throws Exception {
+        // arrange — service throws IllegalArgumentException which controller converts to EntityNotFoundException → 404
+        when(locationService.getUserLocationOrThrow(1L, 99L))
+                .thenThrow(new IllegalArgumentException("Комната не найдена"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/locations/99")
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void should_create_location() throws Exception {
+        // arrange
+        User user = User.builder().telegramChatId(1L).build();
+        Location created = mockLocation(5L, 1L, "Living Room", "🌿");
+
+        when(userService.getByIdOrThrow(1L)).thenReturn(user);
+        when(locationService.createLocation(eq(user), eq("Living Room"), eq("🌿")))
+                .thenReturn(created);
+
+        String body = """
+                {"name": "Living Room", "emoji": "🌿"}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/locations")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(5))
+                .andExpect(jsonPath("$.name").value("Living Room"));
+    }
+
+    @Test
+    void should_return_400_when_location_name_blank() throws Exception {
+        // arrange — @NotBlank on LocationCreateRequest.name
+        String body = """
+                {"name": ""}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/locations")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.error.details[0].field").value("name"));
+    }
+
+    @Test
+    void should_return_400_when_location_name_missing() throws Exception {
+        // arrange
+        String body = "{}";
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/locations")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void should_update_location() throws Exception {
+        // arrange
+        Location updated = mockLocation(1L, 1L, "New Name", "🪴");
+
+        when(locationService.updateLocation(eq(1L), eq(1L), eq("New Name"), isNull()))
+                .thenReturn(updated);
+
+        String body = """
+                {"name": "New Name"}
+                """;
+
+        // act + assert
+        mockMvc.perform(put("/api/v1/locations/1")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("New Name"));
+    }
+
+    @Test
+    void should_delete_location_without_target() throws Exception {
+        // arrange — location has no plants
+        Location loc = mockLocation(1L, 1L, "Empty Room", "🪴");
+
+        when(locationService.getUserLocationOrThrow(1L, 1L)).thenReturn(loc);
+        when(locationService.countPlantsInLocation(1L, 1L)).thenReturn(0L);
+        doNothing().when(locationService).deleteEmptyLocation(1L, 1L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/locations/1")
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void should_delete_location_with_target() throws Exception {
+        // arrange — location has plants, target provided to move them
+        Location loc = mockLocation(1L, 1L, "Room with plants", "🌱");
+
+        when(locationService.getUserLocationOrThrow(1L, 1L)).thenReturn(loc);
+        when(locationService.countPlantsInLocation(1L, 1L)).thenReturn(3L);
+        doNothing().when(locationService).deleteLocation(1L, 1L, 2L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/locations/1?targetLocationId=2")
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void should_return_400_when_location_not_empty_and_no_target_provided() throws Exception {
+        // arrange — location has plants but no targetLocationId in request
+        Location loc = mockLocation(1L, 1L, "Busy Room", "🌿");
+
+        when(locationService.getUserLocationOrThrow(1L, 1L)).thenReturn(loc);
+        when(locationService.countPlantsInLocation(1L, 1L)).thenReturn(2L);
+
+        // act — DELETE without targetLocationId while location has plants
+        mockMvc.perform(delete("/api/v1/locations/1")
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isBadRequest())
+                // controller returns code "LOCATION_NOT_EMPTY" for this path
+                .andExpect(jsonPath("$.error.code").value("LOCATION_NOT_EMPTY"));
+    }
+
+    @Test
+    void should_return_404_when_location_belongs_to_other_user() throws Exception {
+        // Cross-user access returns 404 (not found for this user); 403 is not produced by LocationService.
+        // LocationService.getUserLocationOrThrow is userId-scoped: it throws IllegalArgumentException when
+        // the location is not found for the given userId. LocationController.getLocationOrThrow converts
+        // that IllegalArgumentException into EntityNotFoundException, which ApiExceptionHandler maps to 404.
+        // arrange
+        when(locationService.getUserLocationOrThrow(1L, 7L))
+                .thenThrow(new IllegalArgumentException("Комната не найдена"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/locations/7")
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+}

--- a/src/test/java/com/plantcare/bot/controller/api/v1/PlantControllerTest.java
+++ b/src/test/java/com/plantcare/bot/controller/api/v1/PlantControllerTest.java
@@ -1,0 +1,275 @@
+package com.plantcare.bot.controller.api.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.plantcare.bot.controller.api.ApiExceptionHandler;
+import com.plantcare.bot.domain.Location;
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.User;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.security.access.AccessDeniedException;
+import com.plantcare.bot.service.LocationService;
+import com.plantcare.bot.service.PlantService;
+import com.plantcare.bot.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @WebMvcTest for {@link PlantController} — covers all CRUD endpoints, validation,
+ * ownership checks, and soft-delete semantics (issue #85).
+ *
+ * <p>Filters disabled so {@link org.springframework.security.access.AccessDeniedException}
+ * reaches the {@link ApiExceptionHandler} advice instead of being intercepted by
+ * Spring Security's {@code ExceptionTranslationFilter}.
+ */
+@WebMvcTest(PlantController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PlantControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private PlantService plantService;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private LocationService locationService;
+
+    // ------------------------------------------------------------------ helpers
+
+    /**
+     * Builds a Plant mock where {@code plant.getUser().getId()} returns {@code userId}
+     * and the plant is not archived (archivedAt == null).
+     */
+    private Plant mockPlant(long plantId, long userId, String name) {
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(userId);
+
+        Location location = mock(Location.class);
+        when(location.getId()).thenReturn(1L);
+        when(location.getName()).thenReturn("Living room");
+
+        Plant plant = mock(Plant.class);
+        when(plant.getId()).thenReturn(plantId);
+        when(plant.getName()).thenReturn(name);
+        when(plant.getNotes()).thenReturn(null);
+        when(plant.getPhotoFileId()).thenReturn(null);
+        when(plant.getLocation()).thenReturn(location);
+        when(plant.getSpecies()).thenReturn(null);
+        when(plant.isArchived()).thenReturn(false);
+        when(plant.getArchivedAt()).thenReturn(null);
+        when(plant.getCreatedAt()).thenReturn(null);
+        when(plant.getUser()).thenReturn(user);
+
+        return plant;
+    }
+
+    // ------------------------------------------------------------------ tests
+
+    @Test
+    void should_return_plants_page_when_listing_all() throws Exception {
+        // arrange
+        Plant p1 = mockPlant(1L, 1L, "Ficus");
+        Plant p2 = mockPlant(2L, 1L, "Monstera");
+
+        when(plantService.listPlants(eq(1L), isNull(), eq(0), eq(20)))
+                .thenReturn(List.of(p1, p2));
+        when(plantService.countPlants(1L, null)).thenReturn(2L);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants")
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items").isArray())
+                .andExpect(jsonPath("$.items.length()").value(2))
+                .andExpect(jsonPath("$.total").value(2))
+                .andExpect(jsonPath("$.offset").value(0))
+                .andExpect(jsonPath("$.limit").value(20));
+    }
+
+    @Test
+    void should_return_plants_filtered_by_location() throws Exception {
+        // arrange
+        Plant p = mockPlant(1L, 1L, "Ficus");
+
+        when(plantService.listPlants(eq(1L), eq(5L), eq(0), eq(20)))
+                .thenReturn(List.of(p));
+        when(plantService.countPlants(1L, 5L)).thenReturn(1L);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants?locationId=5")
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(1))
+                .andExpect(jsonPath("$.items[0].name").value("Ficus"));
+    }
+
+    @Test
+    void should_return_plant_when_found() throws Exception {
+        // arrange
+        Plant plant = mockPlant(1L, 1L, "Ficus");
+
+        when(plantService.getPlantOrThrow(1L, 1L)).thenReturn(plant);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants/1")
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.name").value("Ficus"));
+    }
+
+    @Test
+    void should_return_404_when_plant_not_found() throws Exception {
+        // arrange — service throws EntityNotFoundException → handler maps to 404
+        when(plantService.getPlantOrThrow(1L, 999L))
+                .thenThrow(new EntityNotFoundException("Plant not found: 999"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants/999")
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void should_create_plant() throws Exception {
+        // arrange
+        User user = User.builder().telegramChatId(1L).build();
+        Plant plant = mockPlant(10L, 1L, "Ficus");
+
+        when(userService.getByIdOrThrow(1L)).thenReturn(user);
+        when(plantService.createPlant(eq(user), eq("Ficus"), isNull(), isNull()))
+                .thenReturn(plant);
+
+        String body = """
+                {"name": "Ficus"}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/plants")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(10))
+                .andExpect(jsonPath("$.name").value("Ficus"));
+    }
+
+    @Test
+    void should_return_400_when_name_blank() throws Exception {
+        // arrange
+        String body = """
+                {"name": ""}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/plants")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.error.details[0].field").value("name"));
+    }
+
+    @Test
+    void should_return_400_when_name_missing() throws Exception {
+        // arrange — no "name" field in body at all
+        String body = "{}";
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/plants")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void should_return_400_when_name_too_long() throws Exception {
+        // arrange — name exceeds @Size(max = 100)
+        String longName = "X".repeat(101);
+        String body = objectMapper.writeValueAsString(java.util.Map.of("name", longName));
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/plants")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void should_update_plant() throws Exception {
+        // arrange
+        Plant updated = mockPlant(1L, 1L, "Updated");
+
+        when(plantService.updatePlant(eq(1L), eq(1L), eq("Updated"), isNull(), isNull()))
+                .thenReturn(updated);
+
+        String body = """
+                {"name": "Updated"}
+                """;
+
+        // act + assert
+        mockMvc.perform(put("/api/v1/plants/1")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Updated"));
+    }
+
+    @Test
+    void should_delete_plant_and_return_204() throws Exception {
+        // arrange
+        doNothing().when(plantService).archivePlant(1L, 1L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/plants/1")
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void should_return_403_when_plant_belongs_to_other_user() throws Exception {
+        // arrange — service throws AccessDeniedException when plant belongs to another user
+        when(plantService.getPlantOrThrow(1L, 1L))
+                .thenThrow(new AccessDeniedException("Access denied"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants/1")
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("ACCESS_DENIED"));
+    }
+}

--- a/src/test/java/com/plantcare/bot/controller/api/v1/PlantLocationHappyPathIT.java
+++ b/src/test/java/com/plantcare/bot/controller/api/v1/PlantLocationHappyPathIT.java
@@ -1,0 +1,135 @@
+package com.plantcare.bot.controller.api.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.repository.LocationRepository;
+import com.plantcare.bot.repository.PlantRepository;
+import com.plantcare.bot.repository.UserRepository;
+import com.plantcare.bot.support.IntegrationTestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Happy-path integration test for the Plants + Locations REST API (issue #85).
+ *
+ * <p>Runs against a real Postgres 16 container (via {@link IntegrationTestBase}).
+ * Exercises the full stack: controller → service → repository → DB.
+ *
+ * <p>Covers:
+ * <ul>
+ *   <li>POST /api/v1/locations → 201</li>
+ *   <li>POST /api/v1/plants with locationId → 201</li>
+ *   <li>GET /api/v1/plants/{id} → 200 with correct name</li>
+ *   <li>DELETE /api/v1/plants/{id} → 204 (soft-delete)</li>
+ *   <li>GET /api/v1/plants/{id} after delete → 404 (archived plant not visible)</li>
+ * </ul>
+ */
+@AutoConfigureMockMvc
+class PlantLocationHappyPathIT extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PlantRepository plantRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @AfterEach
+    void cleanup() {
+        plantRepository.deleteAll();
+        locationRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void should_create_location_and_plant_then_list_and_delete() throws Exception {
+        // arrange — insert a test user into DB directly via repository
+        User user = userRepository.save(User.builder()
+                .telegramChatId(9_000_001L)
+                .username("it_test_user")
+                .timezone("Europe/Moscow")
+                .build());
+        long userId = user.getId();
+
+        // act 1 — POST /api/v1/locations
+        String locationBody = """
+                {"name": "Windowsill", "emoji": "🪟"}
+                """;
+
+        MvcResult locationResult = mockMvc.perform(post("/api/v1/locations")
+                        .header("X-User-Id", userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(locationBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Windowsill"))
+                .andReturn();
+
+        JsonNode locationJson = objectMapper.readTree(locationResult.getResponse().getContentAsString());
+        long locationId = locationJson.get("id").asLong();
+        assertThat(locationId).isPositive();
+
+        // act 2 — POST /api/v1/plants with locationId
+        String plantBody = String.format("""
+                {"name": "Cactus", "locationId": %d}
+                """, locationId);
+
+        MvcResult plantResult = mockMvc.perform(post("/api/v1/plants")
+                        .header("X-User-Id", userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(plantBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Cactus"))
+                .andExpect(jsonPath("$.locationId").value(locationId))
+                .andReturn();
+
+        JsonNode plantJson = objectMapper.readTree(plantResult.getResponse().getContentAsString());
+        long plantId = plantJson.get("id").asLong();
+        assertThat(plantId).isPositive();
+
+        // act 3 — GET /api/v1/plants/{plantId}
+        mockMvc.perform(get("/api/v1/plants/" + plantId)
+                        .header("X-User-Id", userId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(plantId))
+                .andExpect(jsonPath("$.name").value("Cactus"))
+                .andExpect(jsonPath("$.archived").value(false));
+
+        // act 4 — DELETE /api/v1/plants/{plantId} (soft-delete)
+        mockMvc.perform(delete("/api/v1/plants/" + plantId)
+                        .header("X-User-Id", userId))
+                .andExpect(status().isNoContent());
+
+        // assert — GET after soft-delete must return 404
+        mockMvc.perform(get("/api/v1/plants/" + plantId)
+                        .header("X-User-Id", userId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+
+        // assert — archivedAt is set in the DB
+        var archived = plantRepository.findById(plantId);
+        assertThat(archived).isPresent();
+        assertThat(archived.get().getArchivedAt()).isNotNull();
+        assertThat(archived.get().isArchived()).isTrue();
+    }
+}


### PR DESCRIPTION
Closes #85

## Что сделано

- `GET/POST/PUT/DELETE /api/v1/plants` — полный CRUD с пагинацией (offset/limit) и soft-delete через `archivedAt`
- `GET/POST/PUT/DELETE /api/v1/locations` — полный CRUD; DELETE требует `?targetLocationId=` если в локации есть растения
- Ownership enforcement: чужое растение → 403, несуществующее → 404; для локаций: чужая → 404 (userId-scope в репозитории)
- OpenAPI (`@Tag`, `@Operation`, `@ApiResponse`) на всех эндпоинтах
- `ApiExceptionHandler` расширен: `IllegalArgumentException` → 400
- Новые методы в `PlantService`, `LocationService`, `UserService` без дубликации бизнес-логики

## Миграции

Нет

## Backward-compat риски

Safe — только новые эндпоинты, существующий код не затронут.

## Тесты

- `PlantControllerTest` — 11 сценариев `@WebMvcTest`: список, фильтр по локации, GET one, 404, POST 201, валидация 400, PUT, DELETE 204, 403 при чужом растении
- `LocationControllerTest` — 11 сценариев: аналогично + тест на LOCATION_NOT_EMPTY, 404 при обращении к чужой локации
- `PlantLocationHappyPathIT` — `@SpringBootTest` + Testcontainers: POST location → POST plant → GET → DELETE → GET 404 (soft-delete)

## Чек

- [x] `./mvnw verify` зелёное (578 тестов, 2 pre-existing падения в `SpeciesRepositoryTest` не связаны с этим PR)
- [x] reviewer прошёл (2 итерации; все BLOCKING устранены)
- [x] Ветка от `feature/84-rest-api-openapi` (PR #104)