### PR TITLE
feat: i18n infrastructure + command package migration (#20)

### DIFF
--- a/src/main/java/com/plantcare/bot/command/impl/AddPlantCommand.java
+++ b/src/main/java/com/plantcare/bot/command/impl/AddPlantCommand.java
@@ -4,6 +4,7 @@ import com.plantcare.bot.command.interfaces.BotCommand;
 import com.plantcare.bot.domain.Species;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.ConversationState;
+import com.plantcare.bot.service.MessageService;
 import com.plantcare.bot.service.PlantService;
 import com.plantcare.bot.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,7 @@ public class AddPlantCommand implements BotCommand {
 
     private final UserService userService;
     private final PlantService plantService;
+    private final MessageService messageService;
 
     @Override
     public String getCommandName() {
@@ -46,9 +48,8 @@ public class AddPlantCommand implements BotCommand {
 
         SendMessage message = SendMessage.builder()
                 .chatId(chatId.toString())
-                .text("🌿 Давай добавим новое растение!\n\n" +
-                        "Что за растение? Вот популярные виды:")
-                .replyMarkup(buildSpeciesKeyboard(popular))
+                .text(messageService.get(chatId, "command.add.prompt"))
+                .replyMarkup(buildSpeciesKeyboard(chatId, popular))
                 .build();
 
         try {
@@ -59,7 +60,7 @@ public class AddPlantCommand implements BotCommand {
         }
     }
 
-    private InlineKeyboardMarkup buildSpeciesKeyboard(List<Species> species) {
+    private InlineKeyboardMarkup buildSpeciesKeyboard(Long chatId, List<Species> species) {
         InlineKeyboardMarkup.InlineKeyboardMarkupBuilder<?, ?> builder = InlineKeyboardMarkup.builder();
 
         // Популярные виды (по 2 в ряду)
@@ -86,21 +87,21 @@ public class AddPlantCommand implements BotCommand {
         // Дополнительные опции
         builder.keyboardRow(new InlineKeyboardRow(List.of(
                 InlineKeyboardButton.builder()
-                        .text("⭐ Из моих шаблонов")
+                        .text(messageService.get(chatId, "command.add.button.my_templates"))
                         .callbackData("SPECIES:MY_TEMPLATES")
                         .build()
         )));
 
         builder.keyboardRow(new InlineKeyboardRow(List.of(
                 InlineKeyboardButton.builder()
-                        .text("🔍 Поиск")
+                        .text(messageService.get(chatId, "command.add.button.search"))
                         .callbackData("SPECIES:SEARCH")
                         .build()
         )));
 
         builder.keyboardRow(new InlineKeyboardRow(List.of(
                 InlineKeyboardButton.builder()
-                        .text("✨ Своё без шаблона")
+                        .text(messageService.get(chatId, "command.add.button.custom"))
                         .callbackData("SPECIES:CUSTOM")
                         .build()
         )));

--- a/src/main/java/com/plantcare/bot/command/impl/CancelCommand.java
+++ b/src/main/java/com/plantcare/bot/command/impl/CancelCommand.java
@@ -2,6 +2,7 @@ package com.plantcare.bot.command.impl;
 
 import com.plantcare.bot.command.interfaces.BotCommand;
 import com.plantcare.bot.domain.User;
+import com.plantcare.bot.service.MessageService;
 import com.plantcare.bot.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +18,7 @@ import org.telegram.telegrambots.meta.generics.TelegramClient;
 public class CancelCommand implements BotCommand {
 
     private final UserService userService;
+    private final MessageService messageService;
 
     @Override
     public String getCommandName() {
@@ -33,7 +35,7 @@ public class CancelCommand implements BotCommand {
 
         SendMessage message = SendMessage.builder()
                 .chatId(chatId.toString())
-                .text("Действие отменено. Я готов к новым командам.")
+                .text(messageService.get(chatId, "command.cancel.confirmation"))
                 .build();
 
         try {

--- a/src/main/java/com/plantcare/bot/command/impl/HelpCommand.java
+++ b/src/main/java/com/plantcare/bot/command/impl/HelpCommand.java
@@ -1,6 +1,8 @@
 package com.plantcare.bot.command.impl;
 
 import com.plantcare.bot.command.interfaces.BotCommand;
+import com.plantcare.bot.service.MessageService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
@@ -10,7 +12,10 @@ import org.telegram.telegrambots.meta.generics.TelegramClient;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class HelpCommand implements BotCommand {
+
+    private final MessageService messageService;
 
     @Override
     public String getCommandName() {
@@ -21,24 +26,9 @@ public class HelpCommand implements BotCommand {
     public void execute(Update update, TelegramClient client) {
         Long chatId = update.getMessage().getChatId();
 
-        String text = """
-                🌿 *Plants Care Bot — Помощь*
-                
-                Доступные команды:
-                /start — Начать или вернуться в главное меню
-                /menu — Главное меню (растения + задачи на сегодня)
-                /add — Добавить новое растение
-                /calendar — Календарь ухода на неделю вперёд
-                /cancel — Отменить текущее действие
-                /help — Эта справка
-                
-                Бот присылает напоминания о поливе, опрыскивании и удобрении. \
-                Вы можете настроить тихие часы, чтобы уведомления не приходили ночью.
-                """;
-
         SendMessage message = SendMessage.builder()
                 .chatId(chatId.toString())
-                .text(text)
+                .text(messageService.get(chatId, "command.help.text"))
                 .parseMode("Markdown")
                 .build();
 

--- a/src/main/java/com/plantcare/bot/command/impl/SomethingWrongCommand.java
+++ b/src/main/java/com/plantcare/bot/command/impl/SomethingWrongCommand.java
@@ -1,6 +1,8 @@
 package com.plantcare.bot.command.impl;
 
 import com.plantcare.bot.command.interfaces.BotCommand;
+import com.plantcare.bot.service.MessageService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
@@ -10,7 +12,10 @@ import org.telegram.telegrambots.meta.generics.TelegramClient;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class SomethingWrongCommand implements BotCommand {
+
+    private final MessageService messageService;
 
     @Override
     public String getCommandName() {
@@ -23,7 +28,7 @@ public class SomethingWrongCommand implements BotCommand {
 
         SendMessage message = SendMessage.builder()
                 .chatId(chatId.toString())
-                .text("Извини, что-то пошло не так( Мы уже чиним. Попробуй /help.")
+                .text(messageService.get(chatId, "command.something_wrong.text"))
                 .build();
 
         try {

--- a/src/main/java/com/plantcare/bot/command/impl/StartCommand.java
+++ b/src/main/java/com/plantcare/bot/command/impl/StartCommand.java
@@ -2,6 +2,7 @@ package com.plantcare.bot.command.impl;
 
 import com.plantcare.bot.command.interfaces.BotCommand;
 import com.plantcare.bot.domain.User;
+import com.plantcare.bot.service.MessageService;
 import com.plantcare.bot.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +21,7 @@ public class StartCommand implements BotCommand {
 
     private final UserService userService;
     private final MenuCommand menuCommand;
+    private final MessageService messageService;
 
     @Override
     public String getCommandName() {
@@ -49,11 +51,7 @@ public class StartCommand implements BotCommand {
     private void sendGreeting(Long chatId, TelegramClient client) {
         SendMessage greeting = SendMessage.builder()
                 .chatId(chatId.toString())
-                .text("""
-                        Привет! Я бот проекта Plants-care 🌱
-                        
-                        Я помогу тебе ухаживать за растениями и напомню, когда их нужно полить, опрыскать или удобрить.
-                        """)
+                .text(messageService.get(chatId, "command.start.greeting"))
                 .build();
 
         try {

--- a/src/main/java/com/plantcare/bot/command/impl/UnknownCommand.java
+++ b/src/main/java/com/plantcare/bot/command/impl/UnknownCommand.java
@@ -1,6 +1,8 @@
 package com.plantcare.bot.command.impl;
 
 import com.plantcare.bot.command.interfaces.BotCommand;
+import com.plantcare.bot.service.MessageService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
@@ -10,7 +12,10 @@ import org.telegram.telegrambots.meta.generics.TelegramClient;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class UnknownCommand implements BotCommand {
+
+    private final MessageService messageService;
 
     @Override
     public String getCommandName() {
@@ -23,7 +28,7 @@ public class UnknownCommand implements BotCommand {
 
         SendMessage message = SendMessage.builder()
                 .chatId(chatId.toString())
-                .text("Извини, я не знаю такой команды. Попробуй /help.")
+                .text(messageService.get(chatId, "command.unknown.text"))
                 .build();
 
         try {

--- a/src/main/java/com/plantcare/bot/service/MessageService.java
+++ b/src/main/java/com/plantcare/bot/service/MessageService.java
@@ -1,0 +1,38 @@
+package com.plantcare.bot.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Service;
+
+import java.util.Locale;
+
+/**
+ * Резолвер локализованных строк для Telegram-слоя.
+ *
+ * <p>Сейчас локаль всегда {@code ru}. Перегрузки с {@code chatId} оставлены как точка расширения
+ * для будущего выбора локали по пользователю (issue #20 — follow-up).
+ */
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+
+    private static final Locale DEFAULT_LOCALE = Locale.of("ru");
+
+    private final MessageSource messageSource;
+
+    public String get(String key) {
+        return messageSource.getMessage(key, null, DEFAULT_LOCALE);
+    }
+
+    public String get(String key, Object... args) {
+        return messageSource.getMessage(key, args, DEFAULT_LOCALE);
+    }
+
+    public String get(Long chatId, String key) {
+        return get(key);
+    }
+
+    public String get(Long chatId, String key, Object... args) {
+        return get(key, args);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 spring:
   application:
     name: plants-care
+  messages:
+    basename: messages
+    encoding: UTF-8
+    fallback-to-system-locale: false
   datasource:
     # Локально читается DB_URL/DB_USERNAME/DB_PASSWORD.
     # На Railway автоматически проставляются PGHOST/PGPORT/PGDATABASE/PGUSER/PGPASSWORD,

--- a/src/main/resources/messages_ru.properties
+++ b/src/main/resources/messages_ru.properties
@@ -1,0 +1,20 @@
+# StartCommand
+command.start.greeting=Привет! Я бот проекта Plants-care 🌱\n\nЯ помогу тебе ухаживать за растениями и напомню, когда их нужно полить, опрыскать или удобрить.\n
+
+# HelpCommand
+command.help.text=🌿 *Plants Care Bot — Помощь*\n\nДоступные команды:\n/start — Начать или вернуться в главное меню\n/menu — Главное меню (растения + задачи на сегодня)\n/add — Добавить новое растение\n/calendar — Календарь ухода на неделю вперёд\n/cancel — Отменить текущее действие\n/help — Эта справка\n\nБот присылает напоминания о поливе, опрыскивании и удобрении. Вы можете настроить тихие часы, чтобы уведомления не приходили ночью.\n
+
+# AddPlantCommand
+command.add.prompt=🌿 Давай добавим новое растение!\n\nЧто за растение? Вот популярные виды:
+command.add.button.my_templates=⭐ Из моих шаблонов
+command.add.button.search=🔍 Поиск
+command.add.button.custom=✨ Своё без шаблона
+
+# CancelCommand
+command.cancel.confirmation=Действие отменено. Я готов к новым командам.
+
+# SomethingWrongCommand
+command.something_wrong.text=Извини, что-то пошло не так( Мы уже чиним. Попробуй /help.
+
+# UnknownCommand
+command.unknown.text=Извини, я не знаю такой команды. Попробуй /help.

--- a/src/test/java/com/plantcare/bot/command/impl/AddPlantCommandTest.java
+++ b/src/test/java/com/plantcare/bot/command/impl/AddPlantCommandTest.java
@@ -3,6 +3,7 @@ package com.plantcare.bot.command.impl;
 import com.plantcare.bot.domain.Species;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.ConversationState;
+import com.plantcare.bot.service.MessageService;
 import com.plantcare.bot.service.PlantService;
 import com.plantcare.bot.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,6 +14,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
@@ -26,9 +29,12 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 @DisplayName("Unit-тесты для AddPlantCommand (/add)")
 class AddPlantCommandTest {
 
@@ -47,6 +53,9 @@ class AddPlantCommandTest {
     @Mock
     private PlantService plantService;
 
+    @Mock
+    private MessageService messageService;
+
     @InjectMocks
     private AddPlantCommand addPlantCommand;
 
@@ -61,6 +70,15 @@ class AddPlantCommandTest {
         when(update.getMessage()).thenReturn(message);
         when(message.getChatId()).thenReturn(chatId);
         when(userService.findByChatId(chatId)).thenReturn(Optional.of(testUser));
+
+        when(messageService.get(anyLong(), eq("command.add.prompt")))
+                .thenReturn("🌿 Давай добавим новое растение!\n\nЧто за растение? Вот популярные виды:");
+        when(messageService.get(anyLong(), eq("command.add.button.my_templates")))
+                .thenReturn("⭐ Из моих шаблонов");
+        when(messageService.get(anyLong(), eq("command.add.button.search")))
+                .thenReturn("🔍 Поиск");
+        when(messageService.get(anyLong(), eq("command.add.button.custom")))
+                .thenReturn("✨ Своё без шаблона");
     }
 
     @Test

--- a/src/test/java/com/plantcare/bot/command/impl/HelpCommandTest.java
+++ b/src/test/java/com/plantcare/bot/command/impl/HelpCommandTest.java
@@ -1,5 +1,6 @@
 package com.plantcare.bot.command.impl;
 
+import com.plantcare.bot.service.MessageService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,8 @@ import org.telegram.telegrambots.meta.generics.TelegramClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -25,9 +28,22 @@ import static org.mockito.Mockito.*;
 @DisplayName("Unit-тесты для HelpCommand (/help)")
 class HelpCommandTest {
 
+    private static final String HELP_TEXT = """
+            🌿 *Plants Care Bot — Помощь*
+
+            Доступные команды:
+            /start — Начать или вернуться в главное меню
+            /menu — Главное меню (растения + задачи на сегодня)
+            /add — Добавить новое растение
+            /calendar — Календарь ухода на неделю вперёд
+            /cancel — Отменить текущее действие
+            /help — Эта справка
+            """;
+
     @Mock private TelegramClient telegramClient;
     @Mock private Update update;
     @Mock private Message message;
+    @Mock private MessageService messageService;
 
     @InjectMocks
     private HelpCommand helpCommand;
@@ -38,6 +54,7 @@ class HelpCommandTest {
     void setUp() {
         when(update.getMessage()).thenReturn(message);
         when(message.getChatId()).thenReturn(chatId);
+        when(messageService.get(anyLong(), eq("command.help.text"))).thenReturn(HELP_TEXT);
     }
 
     @Test

--- a/src/test/java/com/plantcare/bot/command/impl/StartCommandTest.java
+++ b/src/test/java/com/plantcare/bot/command/impl/StartCommandTest.java
@@ -1,6 +1,7 @@
 package com.plantcare.bot.command.impl;
 
 import com.plantcare.bot.domain.User;
+import com.plantcare.bot.service.MessageService;
 import com.plantcare.bot.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,6 +40,9 @@ class StartCommandTest {
 
     @Mock
     private MenuCommand menuCommand;
+
+    @Mock
+    private MessageService messageService;
 
     @InjectMocks
     private StartCommand startCommand;
@@ -62,6 +67,7 @@ class StartCommandTest {
         when(update.getMessage()).thenReturn(message);
         when(message.getChatId()).thenReturn(chatId);
         when(userService.findByChatId(chatId)).thenReturn(Optional.of(user));
+        when(messageService.get(eq(chatId), eq("command.start.greeting"))).thenReturn("greeting text");
 
         startCommand.execute(update, telegramClient);
 

--- a/src/test/java/com/plantcare/bot/command/impl/UnknownCommandTest.java
+++ b/src/test/java/com/plantcare/bot/command/impl/UnknownCommandTest.java
@@ -1,5 +1,6 @@
 package com.plantcare.bot.command.impl;
 
+import com.plantcare.bot.service.MessageService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +16,8 @@ import org.telegram.telegrambots.meta.generics.TelegramClient;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,6 +32,9 @@ class UnknownCommandTest {
 
     @Mock
     private Message message;
+
+    @Mock
+    private MessageService messageService;
 
     @InjectMocks
     private UnknownCommand unknownCommand;
@@ -46,6 +52,8 @@ class UnknownCommandTest {
         Long chatId = 12345L;
         when(update.getMessage()).thenReturn(message);
         when(message.getChatId()).thenReturn(chatId);
+        when(messageService.get(anyLong(), eq("command.unknown.text")))
+                .thenReturn("Извини, я не знаю такой команды. Попробуй /help.");
 
         // When
         unknownCommand.execute(update, telegramClient);
@@ -53,7 +61,7 @@ class UnknownCommandTest {
         // Then
         ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
         verify(telegramClient, times(1)).execute(captor.capture());
-        
+
         SendMessage sentMessage = captor.getValue();
         assertEquals(chatId.toString(), sentMessage.getChatId());
         assertEquals("Извини, я не знаю такой команды. Попробуй /help.", sentMessage.getText());
@@ -65,6 +73,7 @@ class UnknownCommandTest {
         // Given
         when(update.getMessage()).thenReturn(message);
         when(message.getChatId()).thenReturn(999L);
+        when(messageService.get(anyLong(), eq("command.unknown.text"))).thenReturn("unknown");
         // Настраиваем мок так, чтобы он выбрасывал исключение
         when(telegramClient.execute(any(SendMessage.class))).thenThrow(new TelegramApiException("API Error"));
 

--- a/src/test/java/com/plantcare/bot/service/MessageServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/MessageServiceTest.java
@@ -1,0 +1,155 @@
+package com.plantcare.bot.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.MessageSource;
+import org.springframework.context.NoSuchMessageException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.support.ResourceBundleMessageSource;
+import org.springframework.context.support.StaticMessageSource;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit-тесты на {@link MessageService}.
+ *
+ * Поднимает минимальный Spring-контекст с реальным {@link ResourceBundleMessageSource},
+ * настроенным на боевой basename {@code messages}. Это проверяет, что:
+ *  - {@code messages_ru.properties} лежит в classpath и читается;
+ *  - ключи резолвятся в локали {@code ru};
+ *  - fallback на system locale выключен (отсутствующий ключ кидает {@link NoSuchMessageException}).
+ *
+ * Тест на интерполяцию аргументов использует отдельный экземпляр {@link MessageService},
+ * собранный поверх {@link StaticMessageSource}, чтобы не засорять боевые properties
+ * чисто тестовыми ключами.
+ */
+@SpringBootTest(classes = {MessageService.class, MessageServiceTest.TestConfig.class})
+@DisplayName("Unit-тесты для MessageService (i18n wrapper)")
+class MessageServiceTest {
+
+    @Autowired
+    private MessageService messageService;
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        MessageSource messageSource() {
+            ResourceBundleMessageSource source = new ResourceBundleMessageSource();
+            source.setBasename("messages");
+            source.setDefaultEncoding("UTF-8");
+            source.setFallbackToSystemLocale(false);
+            return source;
+        }
+    }
+
+    @Test
+    @DisplayName("Возвращает строку приветствия для command.start.greeting")
+    void should_return_string_for_known_key_when_key_exists_in_properties() {
+        String result = messageService.get("command.start.greeting");
+
+        assertThat(result)
+                .isNotBlank()
+                .contains("Plants-care");
+    }
+
+    @Test
+    @DisplayName("Возвращает справочный текст для command.help.text со списком команд")
+    void should_return_help_text_when_help_key_requested() {
+        String result = messageService.get("command.help.text");
+
+        assertThat(result)
+                .isNotBlank()
+                .contains("/start")
+                .contains("/menu")
+                .contains("/help");
+    }
+
+    @Test
+    @DisplayName("Перегрузка с chatId возвращает ту же строку, что и без chatId")
+    void should_return_same_value_for_chatId_overload_when_locale_is_ignored() {
+        String withoutChatId = messageService.get("command.start.greeting");
+        String withChatId = messageService.get(12345L, "command.start.greeting");
+
+        assertThat(withChatId).isEqualTo(withoutChatId);
+    }
+
+    @Test
+    @DisplayName("Резолвит все 9 ключей из messages_ru.properties без исключений")
+    void should_resolve_all_documented_keys_when_keys_exist_in_properties() {
+        String[] keys = {
+                "command.start.greeting",
+                "command.help.text",
+                "command.add.prompt",
+                "command.add.button.my_templates",
+                "command.add.button.search",
+                "command.add.button.custom",
+                "command.cancel.confirmation",
+                "command.something_wrong.text",
+                "command.unknown.text"
+        };
+
+        for (String key : keys) {
+            assertThat(messageService.get(key))
+                    .as("ключ %s должен быть в messages_ru.properties", key)
+                    .isNotBlank();
+        }
+    }
+
+    @Test
+    @DisplayName("Бросает NoSuchMessageException, если ключа нет в properties")
+    void should_throw_when_key_missing_in_properties() {
+        assertThatThrownBy(() -> messageService.get("nonexistent.key.foo"))
+                .isInstanceOf(NoSuchMessageException.class)
+                .hasMessageContaining("nonexistent.key.foo");
+    }
+
+    @Test
+    @DisplayName("Перегрузка с chatId также бросает NoSuchMessageException для отсутствующего ключа")
+    void should_throw_when_key_missing_with_chatId_overload() {
+        assertThatThrownBy(() -> messageService.get(42L, "another.missing.key"))
+                .isInstanceOf(NoSuchMessageException.class)
+                .hasMessageContaining("another.missing.key");
+    }
+
+    @Test
+    @DisplayName("Интерполирует аргументы {0} и {1} в шаблоне")
+    void should_interpolate_arguments_when_placeholders_present() {
+        StaticMessageSource staticSource = new StaticMessageSource();
+        staticSource.addMessage("test.placeholder.demo", Locale.of("ru"), "Привет, {0}! У тебя {1} растений.");
+        MessageService localService = new MessageService(staticSource);
+
+        String result = localService.get("test.placeholder.demo", "Антон", 5);
+
+        assertThat(result).isEqualTo("Привет, Антон! У тебя 5 растений.");
+    }
+
+    @Test
+    @DisplayName("Перегрузка get(chatId, key, args) также интерполирует аргументы")
+    void should_interpolate_arguments_when_called_via_chatId_overload() {
+        StaticMessageSource staticSource = new StaticMessageSource();
+        staticSource.addMessage("test.placeholder.demo", Locale.of("ru"), "У {0} {1} полива(ов)");
+        MessageService localService = new MessageService(staticSource);
+
+        String result = localService.get(999L, "test.placeholder.demo", "фикуса", 3);
+
+        assertThat(result).isEqualTo("У фикуса 3 полива(ов)");
+    }
+
+    @Test
+    @DisplayName("Корректно декодирует UTF-8 кириллицу из messages_ru.properties")
+    void should_decode_cyrillic_correctly_when_utf8_encoding_configured() {
+        String result = messageService.get("command.cancel.confirmation");
+
+        assertThat(result)
+                .isNotBlank()
+                .contains("Действие отменено")
+                .doesNotContain("?")
+                .doesNotContain("�");
+    }
+}


### PR DESCRIPTION
Closes #20

## Что сделано

- `MessageService` — обёртка над Spring `MessageSource` с `chatId`-overloads (chatId сейчас игнорируется, плейсхолдер для будущей per-user локали)
- `messages_ru.properties` с 9 ключами для пакета `command/`
- `messages.properties` (пустой fallback) + конфиг в `application.yml` (`basename=messages`, `encoding=UTF-8`, `fallback-to-system-locale=false`)
- Мигрированы 6 файлов в `com.plantcare.bot.command.impl`: StartCommand, HelpCommand, AddPlantCommand, CancelCommand, SomethingWrongCommand, UnknownCommand
- Тесты `MessageServiceTest` (9 сценариев) + обновлены существующие тесты команд (mock `MessageService`)

## Миграции

Нет

## Backward-compat риски

Safe — только новая инфраструктура и обёртки. Тексты команд остались байт-в-байт идентичными (вынесены в `messages_ru.properties` без изменения содержимого).

## Тесты

- `MessageServiceTest` — 9 сценариев: happy path, все 9 ключей резолвятся, missing key → `NoSuchMessageException`, эквивалентность chatId/non-chatId overloads, интерполяция аргументов, UTF-8 декодинг кириллицы
- `StartCommandTest`, `HelpCommandTest`, `AddPlantCommandTest`, `UnknownCommandTest` — обновлены под мок `MessageService`

## Что НЕ сделано (follow-up issues нужны)

По договорённости scope был ограничен только пакетом `command/`, чтобы PR оставался ревьюабельным. Migration ещё ~55 файлов:

- `com.plantcare.bot.state.*` — 28 handlers (самый крупный follow-up)
- `com.plantcare.bot.diagnosis.*` — 10 файлов с метками
- `com.plantcare.bot.service.*MenuService` + `*CallbackService` — текст меню и плюрализация
- `com.plantcare.bot.util.LocationEmojiKeyboard` — пресеты локаций
- `com.plantcare.bot.beans.PlantsCareBot`, `config.BotCommandsRegistrar`
- Bean Validation сообщения в DTO → `ValidationMessages.properties`
- Admin Thymeleaf (если решим тоже i18n'ить)

Логи (`log.info/warn/error`) i18n'у не подлежат — это антипаттерн для мониторинга.

## Чек

- [x] `./mvnw clean verify` зелёное (558 тестов, 0 падений)
- [x] reviewer прошёл, APPROVED (3 NIT'а, без BLOCKING)