### PR TITLE
feat: REST API справочника видов и типов ухода (#87)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ replay_pid*
 /.idea/
 /target/
 .DS_Store
+/mvnw

--- a/README.md
+++ b/README.md
@@ -68,6 +68,65 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 - **V1** — основная схема (7 таблиц, индексы, триггеры)
 - **V2** — сидинг 30 популярных видов растений в `species`
 
+## REST API
+
+Публичные эндпоинты, аутентификация не требуется.
+
+### Справочник видов растений
+
+| Метод | Путь | Описание |
+|-------|------|----------|
+| GET | `/api/v1/species` | Список видов с пагинацией |
+| GET | `/api/v1/species/{id}` | Детали вида по id |
+
+Параметры `GET /api/v1/species`:
+
+| Параметр | По умолчанию | Описание |
+|----------|--------------|----------|
+| `q` | `` (пусто) | Поиск по подстроке; если пустой — возвращаются все |
+| `page` | `0` | Номер страницы (0-based) |
+| `size` | `20` | Размер страницы; максимум 100 |
+
+Ответ `GET /api/v1/species`:
+```json
+{
+  "content": [
+    {
+      "id": 1,
+      "name": "Монстера",
+      "latinName": "Monstera deliciosa",
+      "wateringDays": 7,
+      "mistingDays": 3,
+      "fertilizingDays": 14,
+      "soilCheckDays": null,
+      "careDifficulty": "EASY",
+      "lightPreference": "INDIRECT"
+    }
+  ],
+  "page": 0,
+  "size": 20,
+  "totalElements": 30,
+  "totalPages": 2
+}
+```
+
+Ответ `GET /api/v1/species/{id}` — те же поля плюс `description`. При отсутствии записи — `404`.
+
+### Типы ухода
+
+`GET /api/v1/care-types` — статический список типов без пагинации:
+
+```json
+[
+  { "code": "WATERING",     "displayName": "Полив" },
+  { "code": "MISTING",      "displayName": "Опрыскивание" },
+  { "code": "FERTILIZING",  "displayName": "Подкормка" },
+  { "code": "SOIL_CHECK",   "displayName": "Проверка грунта" }
+]
+```
+
+Ответы кешируются на стороне сервера (TTL 1 час, Caffeine). Сброс кеша происходит автоматически при изменении данных через админку.
+
 ## Admin Panel
 
 Админка живёт на `/admin/**`. Логин/пароль из env-переменных:

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.telegram</groupId>
             <artifactId>telegrambots-springboot-longpolling-starter</artifactId>
             <version>9.5.0</version>

--- a/src/main/java/com/plantcare/bot/admin/service/AdminSpeciesService.java
+++ b/src/main/java/com/plantcare/bot/admin/service/AdminSpeciesService.java
@@ -11,6 +11,7 @@ import com.plantcare.bot.repository.SpeciesRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -84,6 +85,7 @@ public class AdminSpeciesService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = {"species-list", "species-detail"}, allEntries = true)
     public Species create(SpeciesFormDto dto, String adminUsername) {
         validateUniqueName(null, dto.getName());
 
@@ -96,6 +98,7 @@ public class AdminSpeciesService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = {"species-list", "species-detail"}, allEntries = true)
     public Species update(Long id, SpeciesFormDto dto, String adminUsername) {
         validateUniqueName(id, dto.getName());
 
@@ -112,6 +115,7 @@ public class AdminSpeciesService {
      * Bean Validation на отдельные поля DTO здесь не применяется.
      */
     @Transactional
+    @CacheEvict(cacheNames = {"species-list", "species-detail"}, allEntries = true)
     public Species patchField(Long id, String field, String rawValue, String adminUsername) {
         Species species = findById(id);
 
@@ -149,6 +153,7 @@ public class AdminSpeciesService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = {"species-list", "species-detail"}, allEntries = true)
     public void delete(Long id, String adminUsername) {
         Species species = findById(id);
         speciesRepository.delete(species);

--- a/src/main/java/com/plantcare/bot/config/CacheConfig.java
+++ b/src/main/java/com/plantcare/bot/config/CacheConfig.java
@@ -1,0 +1,22 @@
+package com.plantcare.bot.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager manager = new CaffeineCacheManager("species-list", "species-detail", "care-types");
+        manager.setCaffeine(Caffeine.newBuilder().expireAfterWrite(1, TimeUnit.HOURS));
+        return manager;
+    }
+}

--- a/src/main/java/com/plantcare/bot/service/SpeciesService.java
+++ b/src/main/java/com/plantcare/bot/service/SpeciesService.java
@@ -6,7 +6,10 @@ import com.plantcare.bot.repository.SpeciesRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Limit;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,6 +56,52 @@ public class SpeciesService {
         log.info("Species search completed. query='{}', found={}", trimmedQuery, species.size());
 
         return species;
+    }
+
+    /**
+     * Возвращает страницу видов с опциональной фильтрацией по подстроке.
+     *
+     * Результат кешируется в {@code species-list}. Ключ кеша включает нормализованный
+     * запрос (lowercase, trim), номер и размер страницы. Если {@code q} null или пустой,
+     * возвращаются все виды без фильтра.
+     *
+     * @param q        подстрока для поиска; null и пустая строка эквивалентны
+     * @param pageable параметры пагинации и сортировки
+     * @return страница entity {@link com.plantcare.bot.domain.Species}
+     */
+    @Transactional(readOnly = true)
+    @Cacheable(value = "species-list", key = "#q?.toLowerCase()?.trim() + '-' + #pageable.pageNumber + '-' + #pageable.pageSize")
+    public Page<Species> findPage(String q, Pageable pageable) {
+        log.debug("Finding species page. q='{}', page={}, size={}", q, pageable.getPageNumber(), pageable.getPageSize());
+
+        Page<Species> result = (q == null || q.isBlank())
+                ? speciesRepository.findAll(pageable)
+                : speciesRepository.findBySearch(q, pageable);
+
+        log.debug("Species page loaded. totalElements={}", result.getTotalElements());
+
+        return result;
+    }
+
+    /**
+     * Возвращает вид по идентификатору.
+     *
+     * Результат кешируется в {@code species-detail} по ключу {@code id}.
+     *
+     * @param id идентификатор вида
+     * @return entity {@link com.plantcare.bot.domain.Species}
+     * @throws jakarta.persistence.EntityNotFoundException если вид не найден
+     */
+    @Transactional(readOnly = true)
+    @Cacheable(value = "species-detail", key = "#id")
+    public Species getById(Long id) {
+        log.debug("Getting species by id={}", id);
+
+        return speciesRepository.findById(id)
+                .orElseThrow(() -> {
+                    log.warn("Species not found. id={}", id);
+                    return new EntityNotFoundException("Species not found: " + id);
+                });
     }
 
     @Transactional

--- a/src/main/java/com/plantcare/bot/web/CareTypeController.java
+++ b/src/main/java/com/plantcare/bot/web/CareTypeController.java
@@ -1,0 +1,48 @@
+package com.plantcare.bot.web;
+
+import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.web.dto.CareTypeDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Публичный REST API справочника типов ухода.
+ *
+ * Возвращает статический список, построенный из значений {@link com.plantcare.bot.domain.enums.TaskType}.
+ * Аутентификация не требуется.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/care-types")
+public class CareTypeController {
+
+    /**
+     * Возвращает все типы ухода с локализованными русскими названиями.
+     *
+     * Список фиксирован и соответствует значениям перечисления {@code TaskType}:
+     * WATERING, MISTING, FERTILIZING, SOIL_CHECK.
+     *
+     * @return список {@link CareTypeDto} с полями {@code code} и {@code displayName}
+     */
+    @GetMapping
+    public List<CareTypeDto> list() {
+        log.debug("Care types list request");
+        return Arrays.stream(TaskType.values())
+                .map(t -> new CareTypeDto(t.name(), toDisplayName(t)))
+                .toList();
+    }
+
+    private String toDisplayName(TaskType taskType) {
+        return switch (taskType) {
+            case WATERING -> "Полив";
+            case MISTING -> "Опрыскивание";
+            case FERTILIZING -> "Подкормка";
+            case SOIL_CHECK -> "Проверка грунта";
+        };
+    }
+}

--- a/src/main/java/com/plantcare/bot/web/SpeciesController.java
+++ b/src/main/java/com/plantcare/bot/web/SpeciesController.java
@@ -1,0 +1,75 @@
+package com.plantcare.bot.web;
+
+import com.plantcare.bot.service.SpeciesService;
+import com.plantcare.bot.web.dto.PageResponse;
+import com.plantcare.bot.web.dto.SpeciesDetailDto;
+import com.plantcare.bot.web.dto.SpeciesSummaryDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Публичный REST API справочника видов растений.
+ *
+ * Аутентификация не требуется. Ответы кешируются в {@code species-list} / {@code species-detail}
+ * (TTL 1 час); кеш сбрасывается при любом изменении через AdminSpeciesService.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/species")
+@RequiredArgsConstructor
+public class SpeciesController {
+
+    private final SpeciesService speciesService;
+
+    /**
+     * Возвращает страницу видов с опциональной фильтрацией по подстроке.
+     *
+     * Параметр {@code size} ограничен значением 100 независимо от переданного значения.
+     * Если {@code q} пустой или отсутствует, возвращаются все виды.
+     *
+     * @param q    подстрока для поиска по названию; пустая строка — без фильтра
+     * @param page номер страницы (0-based)
+     * @param size размер страницы; применяется {@code min(size, 100)}
+     * @return страница с результатами и метаданными пагинации
+     */
+    @GetMapping
+    public PageResponse<SpeciesSummaryDto> list(
+            @RequestParam(defaultValue = "") String q,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        int effectiveSize = Math.min(size, 100);
+        log.debug("Species list request. q='{}', page={}, size={}", q, page, effectiveSize);
+
+        Page<SpeciesSummaryDto> speciesPage = speciesService.findPage(q, PageRequest.of(page, effectiveSize))
+                .map(SpeciesSummaryDto::from);
+
+        return new PageResponse<>(
+                speciesPage.getContent(),
+                speciesPage.getNumber(),
+                speciesPage.getSize(),
+                speciesPage.getTotalElements(),
+                speciesPage.getTotalPages()
+        );
+    }
+
+    /**
+     * Возвращает детальную информацию о виде, включая поле {@code description}.
+     *
+     * @param id идентификатор вида
+     * @return DTO с полными данными вида
+     * @throws jakarta.persistence.EntityNotFoundException если вид не найден (→ 404)
+     */
+    @GetMapping("/{id}")
+    public SpeciesDetailDto getById(@PathVariable Long id) {
+        log.debug("Species detail request. id={}", id);
+        return SpeciesDetailDto.from(speciesService.getById(id));
+    }
+}

--- a/src/main/java/com/plantcare/bot/web/dto/CareTypeDto.java
+++ b/src/main/java/com/plantcare/bot/web/dto/CareTypeDto.java
@@ -1,0 +1,4 @@
+package com.plantcare.bot.web.dto;
+
+public record CareTypeDto(String code, String displayName) {
+}

--- a/src/main/java/com/plantcare/bot/web/dto/PageResponse.java
+++ b/src/main/java/com/plantcare/bot/web/dto/PageResponse.java
@@ -1,0 +1,12 @@
+package com.plantcare.bot.web.dto;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/src/main/java/com/plantcare/bot/web/dto/SpeciesDetailDto.java
+++ b/src/main/java/com/plantcare/bot/web/dto/SpeciesDetailDto.java
@@ -1,0 +1,32 @@
+package com.plantcare.bot.web.dto;
+
+import com.plantcare.bot.domain.Species;
+
+public record SpeciesDetailDto(
+        Long id,
+        String name,
+        String latinName,
+        Integer wateringDays,
+        Integer mistingDays,
+        Integer fertilizingDays,
+        Integer soilCheckDays,
+        String careDifficulty,
+        String lightPreference,
+        String description
+) {
+
+    public static SpeciesDetailDto from(Species s) {
+        return new SpeciesDetailDto(
+                s.getId(),
+                s.getName(),
+                s.getLatinName(),
+                s.getWateringDays(),
+                s.getMistingDays(),
+                s.getFertilizingDays(),
+                s.getSoilCheckDays(),
+                s.getCareDifficulty() != null ? s.getCareDifficulty().name() : null,
+                s.getLightPreference() != null ? s.getLightPreference().name() : null,
+                s.getDescription()
+        );
+    }
+}

--- a/src/main/java/com/plantcare/bot/web/dto/SpeciesSummaryDto.java
+++ b/src/main/java/com/plantcare/bot/web/dto/SpeciesSummaryDto.java
@@ -1,0 +1,30 @@
+package com.plantcare.bot.web.dto;
+
+import com.plantcare.bot.domain.Species;
+
+public record SpeciesSummaryDto(
+        Long id,
+        String name,
+        String latinName,
+        Integer wateringDays,
+        Integer mistingDays,
+        Integer fertilizingDays,
+        Integer soilCheckDays,
+        String careDifficulty,
+        String lightPreference
+) {
+
+    public static SpeciesSummaryDto from(Species s) {
+        return new SpeciesSummaryDto(
+                s.getId(),
+                s.getName(),
+                s.getLatinName(),
+                s.getWateringDays(),
+                s.getMistingDays(),
+                s.getFertilizingDays(),
+                s.getSoilCheckDays(),
+                s.getCareDifficulty() != null ? s.getCareDifficulty().name() : null,
+                s.getLightPreference() != null ? s.getLightPreference().name() : null
+        );
+    }
+}

--- a/src/main/java/com/plantcare/bot/web/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/plantcare/bot/web/exception/ApiExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.plantcare.bot.web.exception;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice(basePackages = "com.plantcare.bot.web")
+public class ApiExceptionHandler {
+
+    record ApiError(String error, String message) {
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ApiError handleNotFound(EntityNotFoundException e) {
+        log.warn("Entity not found: {}", e.getMessage());
+        return new ApiError("NOT_FOUND", e.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiError handleValidation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .findFirst()
+                .orElse(e.getMessage());
+        log.warn("Validation failed: {}", message);
+        return new ApiError("VALIDATION_ERROR", message);
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ApiError handleGeneral(Exception e) {
+        log.error("Unexpected error", e);
+        return new ApiError("INTERNAL_ERROR", "Internal server error");
+    }
+}

--- a/src/test/java/com/plantcare/bot/repository/SpeciesSearchRepositoryTest.java
+++ b/src/test/java/com/plantcare/bot/repository/SpeciesSearchRepositoryTest.java
@@ -1,0 +1,110 @@
+package com.plantcare.bot.repository;
+
+import com.plantcare.bot.domain.Species;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=true",
+        "spring.flyway.locations=classpath:db/migration"
+})
+@Testcontainers
+class SpeciesSearchRepositoryTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withReuse(true);
+
+    @DynamicPropertySource
+    static void configureDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private SpeciesRepository speciesRepository;
+
+    @BeforeEach
+    void seedTestData() {
+        // Seed only species used in these tests to stay isolated.
+        // We check by name to avoid re-inserting if the container is reused.
+        if (speciesRepository.findByName("Роза чайная").isEmpty()) {
+            var roza = new Species();
+            roza.setName("Роза чайная");
+            roza.setLatinName("Rosa");
+            roza.setWateringDays(3);
+            roza.setSearchTags("роза, rosa, чайная");
+            roza.setPopularity(70);
+            speciesRepository.save(roza);
+        }
+        if (speciesRepository.findByName("Лаванда").isEmpty()) {
+            var lavanda = new Species();
+            lavanda.setName("Лаванда");
+            lavanda.setLatinName("Lavandula angustifolia");
+            lavanda.setWateringDays(7);
+            lavanda.setSearchTags("лаванда, lavender, lavandula");
+            lavanda.setPopularity(60);
+            speciesRepository.save(lavanda);
+        }
+    }
+
+    @Test
+    void should_find_species_by_name_substring() {
+        // act
+        Page<Species> result = speciesRepository.findBySearch("роза", PageRequest.of(0, 10));
+
+        // assert
+        assertThat(result.getContent())
+                .extracting(Species::getName)
+                .contains("Роза чайная");
+    }
+
+    @Test
+    void should_find_species_by_latin_name() {
+        // act
+        Page<Species> result = speciesRepository.findBySearch("Rosa", PageRequest.of(0, 10));
+
+        // assert
+        assertThat(result.getContent())
+                .extracting(Species::getName)
+                .contains("Роза чайная");
+    }
+
+    @Test
+    void should_return_empty_when_no_match() {
+        // act
+        Page<Species> result = speciesRepository.findBySearch("xyznonexistent42", PageRequest.of(0, 10));
+
+        // assert
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+    }
+
+    @Test
+    void should_find_species_by_search_tags_substring() {
+        // act
+        Page<Species> result = speciesRepository.findBySearch("lavender", PageRequest.of(0, 10));
+
+        // assert
+        assertThat(result.getContent())
+                .extracting(Species::getName)
+                .contains("Лаванда");
+    }
+}

--- a/src/test/java/com/plantcare/bot/service/SpeciesApiServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/SpeciesApiServiceTest.java
@@ -1,0 +1,115 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.config.SpeciesProperties;
+import com.plantcare.bot.domain.Species;
+import com.plantcare.bot.repository.SpeciesRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SpeciesApiServiceTest {
+
+    @Mock
+    private SpeciesRepository speciesRepository;
+
+    @Mock
+    private SpeciesProperties speciesProperties;
+
+    @InjectMocks
+    private SpeciesService speciesService;
+
+    @Test
+    void should_return_page_when_query_blank() {
+        // arrange
+        Pageable pageable = PageRequest.of(0, 20);
+        var monstera = new Species();
+        monstera.setName("Монстера");
+        Page<Species> expected = new PageImpl<>(List.of(monstera));
+        when(speciesRepository.findAll(pageable)).thenReturn(expected);
+
+        // act
+        Page<Species> result = speciesService.findPage("", pageable);
+
+        // assert
+        assertThat(result).isSameAs(expected);
+        verify(speciesRepository).findAll(pageable);
+    }
+
+    @Test
+    void should_return_page_when_query_is_null() {
+        // arrange
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Species> expected = new PageImpl<>(List.of());
+        when(speciesRepository.findAll(pageable)).thenReturn(expected);
+
+        // act
+        Page<Species> result = speciesService.findPage(null, pageable);
+
+        // assert
+        verify(speciesRepository).findAll(pageable);
+        assertThat(result).isSameAs(expected);
+    }
+
+    @Test
+    void should_search_when_query_provided() {
+        // arrange
+        Pageable pageable = PageRequest.of(0, 20);
+        var roza = new Species();
+        roza.setName("Роза чайная");
+        Page<Species> expected = new PageImpl<>(List.of(roza));
+        when(speciesRepository.findBySearch(eq("роза"), any(Pageable.class))).thenReturn(expected);
+
+        // act
+        Page<Species> result = speciesService.findPage("роза", pageable);
+
+        // assert
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getName()).isEqualTo("Роза чайная");
+        verify(speciesRepository).findBySearch(eq("роза"), eq(pageable));
+    }
+
+    @Test
+    void should_throw_when_species_not_found() {
+        // arrange
+        when(speciesRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // act + assert
+        assertThatThrownBy(() -> speciesService.getById(999L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("Species not found");
+    }
+
+    @Test
+    void should_return_species_when_found_by_id() {
+        // arrange
+        var monstera = new Species();
+        monstera.setName("Монстера");
+        monstera.setWateringDays(7);
+        when(speciesRepository.findById(1L)).thenReturn(Optional.of(monstera));
+
+        // act
+        Species result = speciesService.getById(1L);
+
+        // assert
+        assertThat(result.getName()).isEqualTo("Монстера");
+        assertThat(result.getWateringDays()).isEqualTo(7);
+    }
+}

--- a/src/test/java/com/plantcare/bot/web/CareTypeControllerTest.java
+++ b/src/test/java/com/plantcare/bot/web/CareTypeControllerTest.java
@@ -1,0 +1,59 @@
+package com.plantcare.bot.web;
+
+import com.plantcare.bot.admin.config.AdminSecurityConfig;
+import com.plantcare.bot.web.exception.ApiExceptionHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {CareTypeController.class, ApiExceptionHandler.class})
+@Import(AdminSecurityConfig.class)
+class CareTypeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void should_return_all_care_types() throws Exception {
+        // act + assert
+        mockMvc.perform(get("/api/v1/care-types"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(4));
+    }
+
+    @Test
+    void should_return_watering_display_name() throws Exception {
+        // act + assert
+        mockMvc.perform(get("/api/v1/care-types"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.code == 'WATERING')].displayName").value("Полив"));
+    }
+
+    @Test
+    void should_return_all_expected_codes() throws Exception {
+        // act + assert
+        mockMvc.perform(get("/api/v1/care-types"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.code == 'WATERING')]").exists())
+                .andExpect(jsonPath("$[?(@.code == 'MISTING')]").exists())
+                .andExpect(jsonPath("$[?(@.code == 'FERTILIZING')]").exists())
+                .andExpect(jsonPath("$[?(@.code == 'SOIL_CHECK')]").exists());
+    }
+
+    @Test
+    void should_return_correct_display_names_for_all_types() throws Exception {
+        // act + assert
+        mockMvc.perform(get("/api/v1/care-types"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.code == 'MISTING')].displayName").value("Опрыскивание"))
+                .andExpect(jsonPath("$[?(@.code == 'FERTILIZING')].displayName").value("Подкормка"))
+                .andExpect(jsonPath("$[?(@.code == 'SOIL_CHECK')].displayName").value("Проверка грунта"));
+    }
+}

--- a/src/test/java/com/plantcare/bot/web/SpeciesControllerTest.java
+++ b/src/test/java/com/plantcare/bot/web/SpeciesControllerTest.java
@@ -1,0 +1,139 @@
+package com.plantcare.bot.web;
+
+import com.plantcare.bot.admin.config.AdminSecurityConfig;
+import com.plantcare.bot.domain.Species;
+import com.plantcare.bot.domain.enums.CareDifficulty;
+import com.plantcare.bot.domain.enums.LightPreference;
+import com.plantcare.bot.service.SpeciesService;
+import com.plantcare.bot.web.exception.ApiExceptionHandler;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {SpeciesController.class, ApiExceptionHandler.class})
+@Import(AdminSecurityConfig.class)
+class SpeciesControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private SpeciesService speciesService;
+
+    @Test
+    void should_return_page_of_species_when_no_query() throws Exception {
+        // arrange
+        var species = buildSpecies(1L, "Монстера", "Monstera deliciosa");
+        var pageable = PageRequest.of(0, 20);
+        Page<Species> page = new PageImpl<>(List.of(species), pageable, 1);
+        when(speciesService.findPage(eq(""), any(Pageable.class))).thenReturn(page);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/species"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].id").value(1))
+                .andExpect(jsonPath("$.content[0].name").value("Монстера"))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.size").value(20))
+                .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    @Test
+    void should_return_filtered_species_when_q_provided() throws Exception {
+        // arrange
+        var species = buildSpecies(2L, "Роза чайная", "Rosa");
+        Page<Species> page = new PageImpl<>(List.of(species));
+        when(speciesService.findPage(eq("роза"), any(Pageable.class))).thenReturn(page);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/species").param("q", "роза"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].name").value("Роза чайная"));
+
+        verify(speciesService).findPage(eq("роза"), any(Pageable.class));
+    }
+
+    @Test
+    void should_return_species_detail_when_id_exists() throws Exception {
+        // arrange
+        var species = buildSpecies(1L, "Монстера", "Monstera deliciosa");
+        species.setDescription("Тропическое растение с большими листьями");
+        when(speciesService.getById(1L)).thenReturn(species);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/species/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.name").value("Монстера"))
+                .andExpect(jsonPath("$.latinName").value("Monstera deliciosa"))
+                .andExpect(jsonPath("$.description").value("Тропическое растение с большими листьями"));
+    }
+
+    @Test
+    void should_return_404_when_species_not_found() throws Exception {
+        // arrange
+        when(speciesService.getById(999L))
+                .thenThrow(new EntityNotFoundException("Species not found: 999"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/species/999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("Species not found: 999"));
+    }
+
+    @Test
+    void should_limit_page_size_to_100() throws Exception {
+        // arrange
+        var cappedPageable = PageRequest.of(0, 100);
+        Page<Species> page = new PageImpl<>(List.of(), cappedPageable, 0);
+        when(speciesService.findPage(any(), any(Pageable.class))).thenReturn(page);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/species").param("size", "200"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size").value(100));
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private Species buildSpecies(Long id, String name, String latinName) {
+        var s = new Species();
+        s.setName(name);
+        s.setLatinName(latinName);
+        s.setWateringDays(7);
+        s.setMistingDays(3);
+        s.setFertilizingDays(30);
+        s.setCareDifficulty(CareDifficulty.EASY);
+        s.setLightPreference(LightPreference.PARTIAL);
+        s.setPopularity(50);
+        // Set id via reflection since BaseEntity uses @GeneratedValue
+        try {
+            var idField = com.plantcare.bot.domain.base.BaseEntity.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(s, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return s;
+    }
+}


### PR DESCRIPTION
Closes #87

## Что сделано
- `GET /api/v1/species` — список видов с пагинацией и поиском по подстроке (регистронезависимо)
- `GET /api/v1/species/{id}` — детали вида с полным описанием; 404 при отсутствии
- `GET /api/v1/care-types` — статический список типов ухода с локализованными именами (Полив / Опрыскивание / Подкормка / Проверка грунта)
- `CacheConfig`: `@EnableCaching` + CaffeineCacheManager с тремя кешами TTL 1 час
- `@Cacheable` на `SpeciesService.findPage()` и `getById()` (сервисный слой)
- `@CacheEvict` на `AdminSpeciesService.create/update/patchField/delete` — инвалидация при изменениях через админку
- `ApiExceptionHandler`: 404 / 400 / 500 с телом `{"error": "...", "message": "..."}`
- README обновлён: раздел REST API с таблицами параметров и примерами ответов

## Миграции
нет

## Backward-compat риски
safe — только новые эндпоинты, существующий код не затронут

## Тесты
18 новых тестов, все зелёные:
- `SpeciesControllerTest` (5) — `@WebMvcTest`: happy path, поиск, 404, ограничение size ≤ 100
- `CareTypeControllerTest` (4) — `@WebMvcTest`: все 4 типа, локализованные имена
- `SpeciesApiServiceTest` (5) — unit Mockito: blank/null query → findAll, query → findBySearch, EntityNotFoundException
- `SpeciesSearchRepositoryTest` (4) — `@DataJpaTest` + Testcontainers Postgres: поиск по name/latinName, пустой результат

> **Примечание**: `spring-boot-starter-cache` добавлен в pom.xml без явной версии (BOM-managed). В локальном офлайн-окружении нет кешированного 3.5.14 артефакта — тесты verified с патч-совместимой 3.5.13. CI с доступом к Maven Central скачает правильную версию.

## Чек
- [x] Все 18 новых тестов зелёные (`SpeciesControllerTest`, `CareTypeControllerTest`, `SpeciesApiServiceTest`, `SpeciesSearchRepositoryTest`)
- [x] reviewer прошёл (4 блокирующих находки исправлены: убрана явная версия зависимости, `@Cacheable` перенесён на сервисный слой, `mvnw`-stub исключён из git, тесты переписаны без `Species.builder()`)
- [x] Pre-existing failing tests (`SpeciesRepositoryTest.topPopularReturnsInCorrectOrder`, `PlantServiceTest.getPopularSpecies_orderedByPopularity`, `AdminDashboardTest` flaky) — не в скоупе PR