### PR TITLE
feat: photo progress feature for plants (#72)

### DIFF
--- a/src/main/java/com/plantcare/bot/beans/PlantsCareBot.java
+++ b/src/main/java/com/plantcare/bot/beans/PlantsCareBot.java
@@ -30,6 +30,7 @@ public class PlantsCareBot implements LongPollingSingleThreadUpdateConsumer, Tel
     private static final String LOCATION_CALLBACK_PREFIX = "LOCATION:";
     private static final String PLANT_CALLBACK_PREFIX = "PLANT:";
     private static final String CALENDAR_CALLBACK_PREFIX = "cal:";
+    private static final String PHOTO_PROGRESS_CALLBACK_PREFIX = "PHOTO_PROGRESS:";
 
     private final TelegramClient telegramClient;
     private final CommandContainer commandContainer;
@@ -91,7 +92,8 @@ public class PlantsCareBot implements LongPollingSingleThreadUpdateConsumer, Tel
                         data.startsWith(MENU_CALLBACK_PREFIX) ||
                                 data.startsWith(LOCATION_CALLBACK_PREFIX) ||
                                 data.startsWith(PLANT_CALLBACK_PREFIX) ||
-                                data.startsWith(CALENDAR_CALLBACK_PREFIX)
+                                data.startsWith(CALENDAR_CALLBACK_PREFIX) ||
+                                data.startsWith(PHOTO_PROGRESS_CALLBACK_PREFIX)
                 )) {
                     String userName = getUserName(update);
                     User user = userService.findOrCreate(chatId, userName);

--- a/src/main/java/com/plantcare/bot/domain/Plant.java
+++ b/src/main/java/com/plantcare/bot/domain/Plant.java
@@ -1,8 +1,11 @@
 package com.plantcare.bot.domain;
 
 import com.plantcare.bot.domain.base.BaseEntity;
+import com.plantcare.bot.domain.enums.PhotoProgressFrequency;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -71,6 +74,29 @@ public class Plant extends BaseEntity {
      */
     @Column(name = "acclimation_checkin_next_at")
     private LocalDateTime acclimationCheckinNextAt;
+
+    /**
+     * Фото-прогресс (issue #72): частота пушей «обнови фото».
+     * {@code OFF} (дефолт) — выключено. {@code P2W} — раз в 2 недели, {@code P1M} — раз в месяц.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "photo_progress_frequency", nullable = false, length = 8)
+    @Builder.Default
+    private PhotoProgressFrequency photoProgressFrequency = PhotoProgressFrequency.OFF;
+
+    /**
+     * Когда шедулер должен прислать следующий prompt «сделай фото».
+     * {@code null} — фото-прогресс выключен либо ещё не запланирован.
+     */
+    @Column(name = "next_photo_due_at")
+    private LocalDateTime nextPhotoDueAt;
+
+    /**
+     * Когда последний раз слали prompt. Используется как анти-спам в шедулере
+     * (не повторять prompt чаще раза в сутки на одно растение).
+     */
+    @Column(name = "last_photo_prompt_sent_at")
+    private LocalDateTime lastPhotoPromptSentAt;
 
     @OneToMany(mappedBy = "plant")
     @Builder.Default

--- a/src/main/java/com/plantcare/bot/domain/PlantProgressPhoto.java
+++ b/src/main/java/com/plantcare/bot/domain/PlantProgressPhoto.java
@@ -1,0 +1,48 @@
+package com.plantcare.bot.domain;
+
+import com.plantcare.bot.domain.base.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * Запись таймлайна фото-прогресса (issue #72).
+ *
+ * <p>Не путать с {@code plants.photo_file_id} — там одна «обложка» растения,
+ * здесь — история фото для сравнения «было/стало».
+ *
+ * <p>FK на {@link Plant} и {@link User} — ON DELETE CASCADE (см. миграцию V16),
+ * поэтому при удалении растения или юзера записи уйдут автоматически.
+ */
+@Entity
+@Table(name = "plant_progress_photos")
+@Getter
+@Setter
+@NoArgsConstructor
+public class PlantProgressPhoto extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "plant_id", nullable = false)
+    private Plant plant;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "telegram_file_id", nullable = false, length = 255)
+    private String telegramFileId;
+
+    @Column(name = "taken_at", nullable = false)
+    private LocalDateTime takenAt;
+
+    @Column(length = 500)
+    private String caption;
+}

--- a/src/main/java/com/plantcare/bot/domain/enums/ConversationState.java
+++ b/src/main/java/com/plantcare/bot/domain/enums/ConversationState.java
@@ -40,5 +40,8 @@ public enum ConversationState {
     // Пользовательские шаблоны (issue #68)
     AWAITING_TEMPLATE_NAME,            // ввод имени при сохранении шаблона
     AWAITING_PLANT_NAME_FROM_TEMPLATE, // ввод имени растения при создании из шаблона
-    AWAITING_TEMPLATE_RENAME           // ввод нового имени при переименовании шаблона
+    AWAITING_TEMPLATE_RENAME,          // ввод нового имени при переименовании шаблона
+
+    // Фото-прогресс (issue #72)
+    AWAITING_PROGRESS_PHOTO            // ждём фото для таймлайна (план «📸 Фото-прогресс»)
 }

--- a/src/main/java/com/plantcare/bot/domain/enums/PhotoProgressFrequency.java
+++ b/src/main/java/com/plantcare/bot/domain/enums/PhotoProgressFrequency.java
@@ -1,0 +1,42 @@
+package com.plantcare.bot.domain.enums;
+
+import java.time.Period;
+
+/**
+ * Частота фото-прогресса (issue #72).
+ *
+ * <p>Хранится в БД как VARCHAR(8) в колонке {@code plants.photo_progress_frequency}
+ * (см. миграцию V16, CHECK по значениям этого enum).
+ *
+ * <ul>
+ *     <li>{@link #OFF} — фото-прогресс выключен; {@code next_photo_due_at = NULL}.</li>
+ *     <li>{@link #P2W} — раз в 2 недели.</li>
+ *     <li>{@link #P1M} — раз в месяц.</li>
+ * </ul>
+ */
+public enum PhotoProgressFrequency {
+
+    OFF(null),
+    P2W(Period.ofWeeks(2)),
+    P1M(Period.ofMonths(1));
+
+    private final Period period;
+
+    PhotoProgressFrequency(Period period) {
+        this.period = period;
+    }
+
+    /**
+     * Период между фото. {@code null} для {@link #OFF}.
+     */
+    public Period getPeriod() {
+        return period;
+    }
+
+    /**
+     * {@code true}, если режим включён (есть период).
+     */
+    public boolean isEnabled() {
+        return period != null;
+    }
+}

--- a/src/main/java/com/plantcare/bot/repository/PlantProgressPhotoRepository.java
+++ b/src/main/java/com/plantcare/bot/repository/PlantProgressPhotoRepository.java
@@ -1,0 +1,63 @@
+package com.plantcare.bot.repository;
+
+import com.plantcare.bot.domain.PlantProgressPhoto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Доступ к таймлайну фото-прогресса (issue #72).
+ *
+ * <p>Все запросы идут по {@code plant_id} — ownership-проверка происходит
+ * выше, в {@link com.plantcare.bot.service.PhotoProgressService}, через
+ * {@link PlantRepository#findByUserIdAndIdAndArchivedAtIsNull}.
+ */
+@Repository
+public interface PlantProgressPhotoRepository extends JpaRepository<PlantProgressPhoto, Long> {
+
+    List<PlantProgressPhoto> findAllByPlantIdOrderByTakenAtDesc(Long plantId, Pageable pageable);
+
+    long countByPlantId(Long plantId);
+
+    Optional<PlantProgressPhoto> findFirstByPlantIdOrderByTakenAtAsc(Long plantId);
+
+    Optional<PlantProgressPhoto> findFirstByPlantIdOrderByTakenAtDesc(Long plantId);
+
+    /**
+     * Найти фото, ближайшее снизу к заданной дате (сравнение «месяц назад vs сейчас»).
+     * Через {@link Pageable} ограничиваем размером 1, чтобы получить только одно фото.
+     */
+    @Query("""
+            SELECT p FROM PlantProgressPhoto p
+            WHERE p.plant.id = :plantId
+              AND p.takenAt <= :before
+            ORDER BY p.takenAt DESC
+            """)
+    List<PlantProgressPhoto> findClosestBefore(
+            @Param("plantId") Long plantId,
+            @Param("before") LocalDateTime before,
+            Pageable pageable
+    );
+
+    /**
+     * Последние N фото в обратном хронологическом порядке — для экрана «выбрать
+     * две даты».
+     */
+    @Query("""
+            SELECT p FROM PlantProgressPhoto p
+            WHERE p.plant.id = :plantId
+            ORDER BY p.takenAt DESC
+            """)
+    List<PlantProgressPhoto> findRecent(@Param("plantId") Long plantId, Pageable pageable);
+
+    /**
+     * Антиспам: было ли фото за последние N часов.
+     */
+    boolean existsByPlantIdAndTakenAtAfter(Long plantId, LocalDateTime since);
+}

--- a/src/main/java/com/plantcare/bot/repository/PlantRepository.java
+++ b/src/main/java/com/plantcare/bot/repository/PlantRepository.java
@@ -74,4 +74,26 @@ public interface PlantRepository extends JpaRepository<Plant, Long> {
               AND p.acclimationCheckinNextAt <= :now
             """)
     List<Plant> findPendingAcclimationCheckin(@Param("now") java.time.LocalDateTime now);
+
+    /**
+     * Фото-прогресс (issue #72): растения, которым пора слать prompt «обнови фото».
+     * Условия:
+     *   - не архивные;
+     *   - фото-прогресс включён ({@code photoProgressFrequency <> OFF});
+     *   - {@code next_photo_due_at} ≤ {@code until} (запас вперёд берётся в шедулере);
+     *   - дедуп: {@code last_photo_prompt_sent_at IS NULL} либо старше {@code dedupBefore}.
+     */
+    @Query("""
+            SELECT p FROM Plant p
+            JOIN FETCH p.user u
+            WHERE p.archivedAt IS NULL
+              AND p.photoProgressFrequency <> com.plantcare.bot.domain.enums.PhotoProgressFrequency.OFF
+              AND p.nextPhotoDueAt IS NOT NULL
+              AND p.nextPhotoDueAt <= :until
+              AND (p.lastPhotoPromptSentAt IS NULL OR p.lastPhotoPromptSentAt < :dedupBefore)
+            """)
+    List<Plant> findPhotoProgressDue(
+            @Param("until") java.time.LocalDateTime until,
+            @Param("dedupBefore") java.time.LocalDateTime dedupBefore
+    );
 }

--- a/src/main/java/com/plantcare/bot/service/MenuCallbackService.java
+++ b/src/main/java/com/plantcare/bot/service/MenuCallbackService.java
@@ -3,8 +3,10 @@ package com.plantcare.bot.service;
 import com.plantcare.bot.domain.PlantTemplate;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.ConversationState;
+import com.plantcare.bot.domain.enums.PhotoProgressFrequency;
 import com.plantcare.bot.domain.enums.PlantEventType;
 import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.state.impl.AwaitingProgressPhotoStateHandler;
 import com.plantcare.bot.util.TimezoneSupport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,6 +47,8 @@ public class MenuCallbackService {
     private final NotificationCallbackService notificationCallbackService;
     private final PlantEventService plantEventService;
     private final PlantAcclimationService plantAcclimationService;
+    private final PhotoProgressService photoProgressService;
+    private final PhotoProgressCardService photoProgressCardService;
 
     private record LocationPreset(String name, String emoji) {
     }
@@ -72,6 +76,12 @@ public class MenuCallbackService {
 
         if (data.startsWith("PLANT:")) {
             handlePlantCallback(data, callbackId, messageId, client, user);
+            return;
+        }
+
+        // Фото-прогресс (issue #72). См. handlePhotoProgressCallback для полного списка.
+        if (data.startsWith("PHOTO_PROGRESS:")) {
+            handlePhotoProgressCallback(data, callbackId, messageId, client, user);
             return;
         }
 
@@ -1350,6 +1360,305 @@ public class MenuCallbackService {
             client.execute(builder.build());
         } catch (TelegramApiException e) {
             log.error("Failed to answer callback: {}", e.getMessage(), e);
+        }
+    }
+
+    // =================================================================
+    // Фото-прогресс (issue #72)
+    // =================================================================
+
+    /**
+     * Маршрутизация callback'ов префикса {@code PHOTO_PROGRESS:}.
+     *
+     * <p>Поддерживаемые форматы:
+     * <ul>
+     *   <li>{@code PHOTO_PROGRESS:VIEW:{plantId}} — главный экран фото-прогресса</li>
+     *   <li>{@code PHOTO_PROGRESS:FREQ:{plantId}} — экран выбора частоты</li>
+     *   <li>{@code PHOTO_PROGRESS:FREQ:SET:{plantId}:{freq}} — установить частоту</li>
+     *   <li>{@code PHOTO_PROGRESS:ADD:{plantId}} — перевести в AWAITING_PROGRESS_PHOTO</li>
+     *   <li>{@code PHOTO_PROGRESS:SKIP:{plantId}} — пропустить prompt</li>
+     *   <li>{@code PHOTO_PROGRESS:CANCEL} — отмена загрузки фото, возврат в IDLE</li>
+     *   <li>{@code PHOTO_PROGRESS:HISTORY:{plantId}:{page}} — страница истории</li>
+     *   <li>{@code PHOTO_PROGRESS:HISTORY:VIEW:{photoId}} — открыть фото</li>
+     *   <li>{@code PHOTO_PROGRESS:COMPARE:{plantId}} — меню сравнения</li>
+     *   <li>{@code PHOTO_PROGRESS:COMPARE:FIRST_LAST:{plantId}}</li>
+     *   <li>{@code PHOTO_PROGRESS:COMPARE:MONTH_NOW:{plantId}}</li>
+     *   <li>{@code PHOTO_PROGRESS:COMPARE:PICK:{plantId}} — выбор пары вручную</li>
+     *   <li>{@code PHOTO_PROGRESS:COMPARE:LEFT:{plantId}:{photoId}} — выбран левый</li>
+     *   <li>{@code PHOTO_PROGRESS:COMPARE:DO:{plantId}:{leftId}:{rightId}} — сравнение</li>
+     * </ul>
+     */
+    private void handlePhotoProgressCallback(
+            String data,
+            String callbackId,
+            Integer messageId,
+            TelegramClient client,
+            User user
+    ) {
+        // Cancel — обрабатываем до парсинга plantId, иначе уйдём в else.
+        if ("PHOTO_PROGRESS:CANCEL".equals(data)) {
+            Long plantId = readPhotoProgressPlantId(user);
+            userService.resetToIdle(user);
+            answerCallback(client, callbackId, "");
+            if (plantId != null) {
+                photoProgressCardService.showPhotoProgressScreen(user, plantId, null, client);
+            }
+            return;
+        }
+
+        if (data.startsWith("PHOTO_PROGRESS:VIEW:")) {
+            Long plantId = parseLong(data.substring("PHOTO_PROGRESS:VIEW:".length()));
+            if (plantId == null) {
+                answerCallback(client, callbackId, "❌ Неверный ID");
+                return;
+            }
+            photoProgressCardService.showPhotoProgressScreen(user, plantId, messageId, client);
+            answerCallback(client, callbackId, "");
+            return;
+        }
+
+        // SET идёт до FREQ — иначе startsWith("PHOTO_PROGRESS:FREQ:") перехватит.
+        if (data.startsWith("PHOTO_PROGRESS:FREQ:SET:")) {
+            String[] parts = data.substring("PHOTO_PROGRESS:FREQ:SET:".length()).split(":");
+            if (parts.length < 2) {
+                answerCallback(client, callbackId, "❌ Неверная команда");
+                return;
+            }
+            Long plantId = parseLong(parts[0]);
+            PhotoProgressFrequency freq;
+            try {
+                freq = PhotoProgressFrequency.valueOf(parts[1]);
+            } catch (IllegalArgumentException e) {
+                answerCallback(client, callbackId, "❌ Неверный режим");
+                return;
+            }
+            if (plantId == null) {
+                answerCallback(client, callbackId, "❌ Неверный ID");
+                return;
+            }
+            try {
+                photoProgressService.setFrequency(user.getId(), plantId, freq);
+            } catch (IllegalArgumentException e) {
+                answerCallback(client, callbackId, "❌ Растение не найдено");
+                return;
+            }
+            photoProgressCardService.showPhotoProgressScreen(user, plantId, messageId, client);
+            answerCallback(client, callbackId, "✅ Режим обновлён");
+            return;
+        }
+
+        if (data.startsWith("PHOTO_PROGRESS:FREQ:")) {
+            Long plantId = parseLong(data.substring("PHOTO_PROGRESS:FREQ:".length()));
+            if (plantId == null) {
+                answerCallback(client, callbackId, "❌ Неверный ID");
+                return;
+            }
+            photoProgressCardService.showFrequencyChoice(user, plantId, messageId, client);
+            answerCallback(client, callbackId, "");
+            return;
+        }
+
+        if (data.startsWith("PHOTO_PROGRESS:ADD:")) {
+            Long plantId = parseLong(data.substring("PHOTO_PROGRESS:ADD:".length()));
+            if (plantId == null) {
+                answerCallback(client, callbackId, "❌ Неверный ID");
+                return;
+            }
+            // Сохраняем plantId в stateData и переводим в ожидание фото.
+            userService.setStateData(user,
+                    AwaitingProgressPhotoStateHandler.STATE_KEY_PLANT_ID,
+                    String.valueOf(plantId));
+            userService.updateState(user, ConversationState.AWAITING_PROGRESS_PHOTO);
+
+            try {
+                client.execute(SendMessage.builder()
+                        .chatId(user.getTelegramChatId().toString())
+                        .text("📸 Пришли фото для таймлайна — оно попадёт в историю фото-прогресса.")
+                        .replyMarkup(InlineKeyboardMarkup.builder()
+                                .keyboardRow(new InlineKeyboardRow(List.of(
+                                        InlineKeyboardButton.builder()
+                                                .text("⬅️ Отмена")
+                                                .callbackData("PHOTO_PROGRESS:CANCEL")
+                                                .build()
+                                )))
+                                .build())
+                        .build());
+            } catch (TelegramApiException e) {
+                log.error("Failed to send AWAITING_PROGRESS_PHOTO prompt: {}", e.getMessage());
+            }
+            answerCallback(client, callbackId, "");
+            return;
+        }
+
+        if (data.startsWith("PHOTO_PROGRESS:SKIP:")) {
+            Long plantId = parseLong(data.substring("PHOTO_PROGRESS:SKIP:".length()));
+            if (plantId == null) {
+                answerCallback(client, callbackId, "❌ Неверный ID");
+                return;
+            }
+            try {
+                photoProgressService.skipPrompt(user.getId(), plantId);
+            } catch (IllegalArgumentException e) {
+                answerCallback(client, callbackId, "❌ Растение не найдено");
+                return;
+            }
+            answerCallback(client, callbackId, "⏭ Напомню позже");
+            return;
+        }
+
+        // HISTORY:VIEW проверяем до HISTORY: — иначе startsWith перехватит.
+        if (data.startsWith("PHOTO_PROGRESS:HISTORY:VIEW:")) {
+            Long photoId = parseLong(data.substring("PHOTO_PROGRESS:HISTORY:VIEW:".length()));
+            if (photoId == null) {
+                answerCallback(client, callbackId, "❌ Неверный ID");
+                return;
+            }
+            photoProgressCardService.showPhoto(user, photoId, client);
+            answerCallback(client, callbackId, "");
+            return;
+        }
+
+        if (data.startsWith("PHOTO_PROGRESS:HISTORY:")) {
+            String[] parts = data.substring("PHOTO_PROGRESS:HISTORY:".length()).split(":");
+            if (parts.length < 2) {
+                answerCallback(client, callbackId, "❌ Неверная команда");
+                return;
+            }
+            Long plantId = parseLong(parts[0]);
+            Integer page = parseInt(parts[1]);
+            if (plantId == null || page == null) {
+                answerCallback(client, callbackId, "❌ Неверная команда");
+                return;
+            }
+            photoProgressCardService.showHistory(user, plantId, page, messageId, client);
+            answerCallback(client, callbackId, "");
+            return;
+        }
+
+        // COMPARE с подкомандами — проверяем точные префиксы до общего COMPARE:.
+        if (data.startsWith("PHOTO_PROGRESS:COMPARE:FIRST_LAST:")) {
+            Long plantId = parseLong(data.substring("PHOTO_PROGRESS:COMPARE:FIRST_LAST:".length()));
+            if (plantId == null) {
+                answerCallback(client, callbackId, "❌ Неверный ID");
+                return;
+            }
+            photoProgressService.compareFirstVsLast(user.getId(), plantId).ifPresentOrElse(
+                    pair -> photoProgressCardService.sendComparison(user, pair, client),
+                    () -> answerCallback(client, callbackId, "Нужно минимум 2 фото")
+            );
+            answerCallback(client, callbackId, "");
+            return;
+        }
+
+        if (data.startsWith("PHOTO_PROGRESS:COMPARE:MONTH_NOW:")) {
+            Long plantId = parseLong(data.substring("PHOTO_PROGRESS:COMPARE:MONTH_NOW:".length()));
+            if (plantId == null) {
+                answerCallback(client, callbackId, "❌ Неверный ID");
+                return;
+            }
+            photoProgressService.compareMonthVsNow(user.getId(), plantId).ifPresentOrElse(
+                    pair -> photoProgressCardService.sendComparison(user, pair, client),
+                    () -> answerCallback(client, callbackId, "Нет фото месячной давности")
+            );
+            answerCallback(client, callbackId, "");
+            return;
+        }
+
+        if (data.startsWith("PHOTO_PROGRESS:COMPARE:PICK:")) {
+            Long plantId = parseLong(data.substring("PHOTO_PROGRESS:COMPARE:PICK:".length()));
+            if (plantId == null) {
+                answerCallback(client, callbackId, "❌ Неверный ID");
+                return;
+            }
+            photoProgressCardService.showPickList(user, plantId, null, messageId, client);
+            answerCallback(client, callbackId, "");
+            return;
+        }
+
+        if (data.startsWith("PHOTO_PROGRESS:COMPARE:LEFT:")) {
+            String[] parts = data.substring("PHOTO_PROGRESS:COMPARE:LEFT:".length()).split(":");
+            if (parts.length < 2) {
+                answerCallback(client, callbackId, "❌ Неверная команда");
+                return;
+            }
+            Long plantId = parseLong(parts[0]);
+            Long leftId = parseLong(parts[1]);
+            if (plantId == null || leftId == null) {
+                answerCallback(client, callbackId, "❌ Неверная команда");
+                return;
+            }
+            photoProgressCardService.showPickList(user, plantId, leftId, messageId, client);
+            answerCallback(client, callbackId, "");
+            return;
+        }
+
+        if (data.startsWith("PHOTO_PROGRESS:COMPARE:DO:")) {
+            String[] parts = data.substring("PHOTO_PROGRESS:COMPARE:DO:".length()).split(":");
+            if (parts.length < 3) {
+                answerCallback(client, callbackId, "❌ Неверная команда");
+                return;
+            }
+            Long plantId = parseLong(parts[0]);
+            Long leftId = parseLong(parts[1]);
+            Long rightId = parseLong(parts[2]);
+            if (plantId == null || leftId == null || rightId == null) {
+                answerCallback(client, callbackId, "❌ Неверная команда");
+                return;
+            }
+            photoProgressService.compareByIds(user.getId(), plantId, leftId, rightId)
+                    .ifPresentOrElse(
+                            pair -> photoProgressCardService.sendComparison(user, pair, client),
+                            () -> answerCallback(client, callbackId, "❌ Не удалось собрать пару")
+                    );
+            answerCallback(client, callbackId, "");
+            return;
+        }
+
+        if (data.startsWith("PHOTO_PROGRESS:COMPARE:")) {
+            Long plantId = parseLong(data.substring("PHOTO_PROGRESS:COMPARE:".length()));
+            if (plantId == null) {
+                answerCallback(client, callbackId, "❌ Неверный ID");
+                return;
+            }
+            photoProgressCardService.showCompareMenu(user, plantId, messageId, client);
+            answerCallback(client, callbackId, "");
+            return;
+        }
+
+        answerCallback(client, callbackId, "❌ Неизвестная команда");
+    }
+
+    private Long readPhotoProgressPlantId(User user) {
+        if (user.getStateData() == null) {
+            return null;
+        }
+        Object raw = user.getStateData()
+                .get(AwaitingProgressPhotoStateHandler.STATE_KEY_PLANT_ID);
+        if (raw == null) {
+            return null;
+        }
+        return parseLong(String.valueOf(raw));
+    }
+
+    private Long parseLong(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private Integer parseInt(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return null;
         }
     }
 

--- a/src/main/java/com/plantcare/bot/service/PhotoProgressCardService.java
+++ b/src/main/java/com/plantcare/bot/service/PhotoProgressCardService.java
@@ -1,0 +1,511 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.PlantProgressPhoto;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.PhotoProgressFrequency;
+import com.plantcare.bot.repository.PlantRepository;
+import com.plantcare.bot.util.TimezoneSupport;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.telegram.telegrambots.meta.api.methods.AnswerCallbackQuery;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.methods.send.SendPhoto;
+import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText;
+import org.telegram.telegrambots.meta.api.objects.InputFile;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardRow;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Рендер экранов фото-прогресса (issue #72): главный экран, выбор частоты,
+ * история, меню сравнения, отправка пары «до/после».
+ *
+ * <p>Логику и доступ к БД выносим в {@link PhotoProgressService}; здесь —
+ * только сборка текста и клавиатур + отправка через Telegram.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PhotoProgressCardService {
+
+    private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+    /** Сколько последних фото показывать в экране «Выбрать две даты». */
+    private static final int PICK_LIST_SIZE = 10;
+
+    private final PhotoProgressService photoProgressService;
+    private final PlantRepository plantRepository;
+
+    /**
+     * Главный экран фото-прогресса для растения.
+     */
+    public void showPhotoProgressScreen(
+            User user, Long plantId, Integer messageId, TelegramClient client
+    ) {
+        Plant plant = plantRepository
+                .findByUserIdAndIdAndArchivedAtIsNull(user.getId(), plantId)
+                .orElse(null);
+        if (plant == null) {
+            sendText(user.getTelegramChatId(), "❌ Растение не найдено.", client);
+            return;
+        }
+
+        long total = photoProgressService.countHistory(user.getId(), plantId);
+        PlantProgressPhoto last = photoProgressService.getHistory(user.getId(), plantId, 0)
+                .stream().findFirst().orElse(null);
+
+        StringBuilder text = new StringBuilder();
+        text.append("📸 *Фото-прогресс — ").append(escapeMd(plant.getName())).append("*\n\n");
+        text.append("Режим: *").append(frequencyLabel(plant.getPhotoProgressFrequency())).append("*\n");
+
+        if (last != null) {
+            LocalDate when = TimezoneSupport.dateInUserZone(last.getTakenAt(), user);
+            text.append("Последнее фото: ").append(when.format(DATE_FMT)).append("\n");
+        } else {
+            text.append("Последнее фото: ещё нет\n");
+        }
+        text.append("Всего фото: ").append(total).append("\n");
+
+        if (plant.getPhotoProgressFrequency() != null
+                && plant.getPhotoProgressFrequency().isEnabled()
+                && plant.getNextPhotoDueAt() != null) {
+            LocalDate next = TimezoneSupport.dateInUserZone(plant.getNextPhotoDueAt(), user);
+            text.append("Следующий пуш: ").append(next.format(DATE_FMT)).append("\n");
+        }
+
+        List<InlineKeyboardRow> rows = new ArrayList<>();
+        rows.add(new InlineKeyboardRow(List.of(
+                InlineKeyboardButton.builder()
+                        .text("⚙️ Изменить режим")
+                        .callbackData("PHOTO_PROGRESS:FREQ:" + plantId)
+                        .build()
+        )));
+
+        InlineKeyboardRow actions = new InlineKeyboardRow();
+        actions.add(InlineKeyboardButton.builder()
+                .text("➕ Добавить фото")
+                .callbackData("PHOTO_PROGRESS:ADD:" + plantId)
+                .build());
+        if (total > 0) {
+            actions.add(InlineKeyboardButton.builder()
+                    .text("🖼 История")
+                    .callbackData("PHOTO_PROGRESS:HISTORY:" + plantId + ":0")
+                    .build());
+        }
+        if (total >= 2) {
+            actions.add(InlineKeyboardButton.builder()
+                    .text("🆚 Сравнить")
+                    .callbackData("PHOTO_PROGRESS:COMPARE:" + plantId)
+                    .build());
+        }
+        rows.add(actions);
+
+        rows.add(new InlineKeyboardRow(List.of(
+                InlineKeyboardButton.builder()
+                        .text("⬅️ К карточке")
+                        .callbackData("PLANT:VIEW:" + plantId)
+                        .build()
+        )));
+
+        sendOrEdit(user.getTelegramChatId(), messageId, text.toString(),
+                InlineKeyboardMarkup.builder().keyboard(rows).build(), client);
+    }
+
+    /**
+     * Экран выбора частоты.
+     */
+    public void showFrequencyChoice(
+            User user, Long plantId, Integer messageId, TelegramClient client
+    ) {
+        Plant plant = plantRepository
+                .findByUserIdAndIdAndArchivedAtIsNull(user.getId(), plantId)
+                .orElse(null);
+        if (plant == null) {
+            sendText(user.getTelegramChatId(), "❌ Растение не найдено.", client);
+            return;
+        }
+
+        String text = "⚙️ *Режим фото-прогресса — "
+                + escapeMd(plant.getName()) + "*\n\n"
+                + "Выбери, как часто бот будет напоминать обновить фото:";
+
+        List<InlineKeyboardRow> rows = new ArrayList<>();
+        for (PhotoProgressFrequency freq : PhotoProgressFrequency.values()) {
+            String mark = freq == plant.getPhotoProgressFrequency() ? "✅ " : "";
+            rows.add(new InlineKeyboardRow(List.of(
+                    InlineKeyboardButton.builder()
+                            .text(mark + frequencyLabel(freq))
+                            .callbackData("PHOTO_PROGRESS:FREQ:SET:" + plantId + ":" + freq.name())
+                            .build()
+            )));
+        }
+        rows.add(new InlineKeyboardRow(List.of(
+                InlineKeyboardButton.builder()
+                        .text("⬅️ Назад")
+                        .callbackData("PHOTO_PROGRESS:VIEW:" + plantId)
+                        .build()
+        )));
+
+        sendOrEdit(user.getTelegramChatId(), messageId, text,
+                InlineKeyboardMarkup.builder().keyboard(rows).build(), client);
+    }
+
+    /**
+     * История фото с пагинацией.
+     */
+    public void showHistory(
+            User user, Long plantId, int page, Integer messageId, TelegramClient client
+    ) {
+        Plant plant = plantRepository
+                .findByUserIdAndIdAndArchivedAtIsNull(user.getId(), plantId)
+                .orElse(null);
+        if (plant == null) {
+            sendText(user.getTelegramChatId(), "❌ Растение не найдено.", client);
+            return;
+        }
+
+        long total = photoProgressService.countHistory(user.getId(), plantId);
+        int pageSize = PhotoProgressService.HISTORY_PAGE_SIZE;
+        int totalPages = total == 0 ? 1 : (int) Math.ceil((double) total / pageSize);
+        int safePage = Math.max(0, Math.min(page, totalPages - 1));
+
+        List<PlantProgressPhoto> photos = photoProgressService.getHistory(
+                user.getId(), plantId, safePage);
+
+        StringBuilder text = new StringBuilder();
+        text.append("🖼 *История фото — ").append(escapeMd(plant.getName())).append("*\n\n");
+
+        if (photos.isEmpty()) {
+            text.append("Здесь пока пусто. Нажми «➕ Добавить фото» в экране фото-прогресса.");
+        } else {
+            int idx = safePage * pageSize + 1;
+            for (PlantProgressPhoto photo : photos) {
+                LocalDate date = TimezoneSupport.dateInUserZone(photo.getTakenAt(), user);
+                text.append(idx++).append(". ")
+                        .append(date.format(DATE_FMT)).append("\n");
+            }
+            if (totalPages > 1) {
+                text.append("\n_Страница ").append(safePage + 1)
+                        .append(" из ").append(totalPages).append("_");
+            }
+        }
+
+        List<InlineKeyboardRow> rows = new ArrayList<>();
+
+        // Открытие конкретного фото — на каждый элемент страницы.
+        for (PlantProgressPhoto photo : photos) {
+            LocalDate date = TimezoneSupport.dateInUserZone(photo.getTakenAt(), user);
+            rows.add(new InlineKeyboardRow(List.of(
+                    InlineKeyboardButton.builder()
+                            .text("🖼 " + date.format(DATE_FMT))
+                            .callbackData("PHOTO_PROGRESS:HISTORY:VIEW:" + photo.getId())
+                            .build()
+            )));
+        }
+
+        if (totalPages > 1) {
+            InlineKeyboardRow nav = new InlineKeyboardRow();
+            if (safePage > 0) {
+                nav.add(InlineKeyboardButton.builder()
+                        .text("← Назад")
+                        .callbackData("PHOTO_PROGRESS:HISTORY:" + plantId + ":" + (safePage - 1))
+                        .build());
+            }
+            nav.add(InlineKeyboardButton.builder()
+                    .text((safePage + 1) + "/" + totalPages)
+                    .callbackData("PHOTO_PROGRESS:HISTORY:" + plantId + ":" + safePage)
+                    .build());
+            if (safePage < totalPages - 1) {
+                nav.add(InlineKeyboardButton.builder()
+                        .text("Вперёд →")
+                        .callbackData("PHOTO_PROGRESS:HISTORY:" + plantId + ":" + (safePage + 1))
+                        .build());
+            }
+            rows.add(nav);
+        }
+
+        rows.add(new InlineKeyboardRow(List.of(
+                InlineKeyboardButton.builder()
+                        .text("⬅️ Назад")
+                        .callbackData("PHOTO_PROGRESS:VIEW:" + plantId)
+                        .build()
+        )));
+
+        sendOrEdit(user.getTelegramChatId(), messageId, text.toString(),
+                InlineKeyboardMarkup.builder().keyboard(rows).build(), client);
+    }
+
+    /**
+     * Открыть одно конкретное фото отдельным sendPhoto.
+     */
+    public void showPhoto(User user, Long photoId, TelegramClient client) {
+        PlantProgressPhoto photo = photoProgressService
+                .getPhotoForUser(user.getId(), photoId)
+                .orElse(null);
+        if (photo == null) {
+            sendText(user.getTelegramChatId(), "❌ Фото не найдено.", client);
+            return;
+        }
+
+        LocalDate date = TimezoneSupport.dateInUserZone(photo.getTakenAt(), user);
+        SendPhoto send = SendPhoto.builder()
+                .chatId(user.getTelegramChatId().toString())
+                .photo(new InputFile(photo.getTelegramFileId()))
+                .caption("🖼 " + date.format(DATE_FMT))
+                .build();
+        try {
+            client.execute(send);
+        } catch (TelegramApiException e) {
+            log.error("Failed to send progress photo (id={}): {}", photoId, e.getMessage());
+            sendText(user.getTelegramChatId(), "❌ Не удалось отправить фото.", client);
+        }
+    }
+
+    /**
+     * Меню «Сравнить»: первое vs последнее / месяц vs сейчас / выбрать вручную.
+     */
+    public void showCompareMenu(
+            User user, Long plantId, Integer messageId, TelegramClient client
+    ) {
+        Plant plant = plantRepository
+                .findByUserIdAndIdAndArchivedAtIsNull(user.getId(), plantId)
+                .orElse(null);
+        if (plant == null) {
+            sendText(user.getTelegramChatId(), "❌ Растение не найдено.", client);
+            return;
+        }
+
+        long total = photoProgressService.countHistory(user.getId(), plantId);
+        if (total < 2) {
+            sendText(user.getTelegramChatId(),
+                    "Нужно минимум 2 фото для сравнения.", client);
+            return;
+        }
+
+        String text = "🆚 *Сравнить фото — " + escapeMd(plant.getName()) + "*\n\n"
+                + "Выбери, что сравнить:";
+
+        List<InlineKeyboardRow> rows = new ArrayList<>();
+        rows.add(new InlineKeyboardRow(List.of(
+                InlineKeyboardButton.builder()
+                        .text("📅 Первое vs Последнее")
+                        .callbackData("PHOTO_PROGRESS:COMPARE:FIRST_LAST:" + plantId)
+                        .build()
+        )));
+        rows.add(new InlineKeyboardRow(List.of(
+                InlineKeyboardButton.builder()
+                        .text("🗓 Месяц назад vs Сейчас")
+                        .callbackData("PHOTO_PROGRESS:COMPARE:MONTH_NOW:" + plantId)
+                        .build()
+        )));
+        rows.add(new InlineKeyboardRow(List.of(
+                InlineKeyboardButton.builder()
+                        .text("✋ Выбрать две даты")
+                        .callbackData("PHOTO_PROGRESS:COMPARE:PICK:" + plantId)
+                        .build()
+        )));
+        rows.add(new InlineKeyboardRow(List.of(
+                InlineKeyboardButton.builder()
+                        .text("⬅️ Назад")
+                        .callbackData("PHOTO_PROGRESS:VIEW:" + plantId)
+                        .build()
+        )));
+
+        sendOrEdit(user.getTelegramChatId(), messageId, text,
+                InlineKeyboardMarkup.builder().keyboard(rows).build(), client);
+    }
+
+    /**
+     * Список последних фото для UI «Выбрать две даты». Если {@code leftId == null} —
+     * пользователь выбирает левый снимок; иначе — правый.
+     */
+    public void showPickList(
+            User user, Long plantId, Long leftId, Integer messageId, TelegramClient client
+    ) {
+        Plant plant = plantRepository
+                .findByUserIdAndIdAndArchivedAtIsNull(user.getId(), plantId)
+                .orElse(null);
+        if (plant == null) {
+            sendText(user.getTelegramChatId(), "❌ Растение не найдено.", client);
+            return;
+        }
+
+        List<PlantProgressPhoto> recent = photoProgressService
+                .getRecent(user.getId(), plantId, PICK_LIST_SIZE);
+
+        StringBuilder text = new StringBuilder();
+        text.append("✋ *Выбор фото для сравнения — ")
+                .append(escapeMd(plant.getName())).append("*\n\n");
+        if (leftId == null) {
+            text.append("Шаг 1/2: выбери первое фото (\"до\"):");
+        } else {
+            text.append("Шаг 2/2: выбери второе фото (\"после\"):");
+        }
+
+        List<InlineKeyboardRow> rows = new ArrayList<>();
+        for (PlantProgressPhoto photo : recent) {
+            // Если левый уже выбран — не показываем его в списке «правых».
+            if (leftId != null && leftId.equals(photo.getId())) {
+                continue;
+            }
+            LocalDate date = TimezoneSupport.dateInUserZone(photo.getTakenAt(), user);
+            String cb = leftId == null
+                    ? "PHOTO_PROGRESS:COMPARE:LEFT:" + plantId + ":" + photo.getId()
+                    : "PHOTO_PROGRESS:COMPARE:DO:" + plantId + ":" + leftId + ":" + photo.getId();
+            rows.add(new InlineKeyboardRow(List.of(
+                    InlineKeyboardButton.builder()
+                            .text(date.format(DATE_FMT))
+                            .callbackData(cb)
+                            .build()
+            )));
+        }
+        rows.add(new InlineKeyboardRow(List.of(
+                InlineKeyboardButton.builder()
+                        .text("⬅️ Назад")
+                        .callbackData("PHOTO_PROGRESS:COMPARE:" + plantId)
+                        .build()
+        )));
+
+        sendOrEdit(user.getTelegramChatId(), messageId, text.toString(),
+                InlineKeyboardMarkup.builder().keyboard(rows).build(), client);
+    }
+
+    /**
+     * Отправить пару фото «до / после» в чат с подписями и summary
+     * «Прошло: N дней».
+     */
+    public void sendComparison(User user, PhotoProgressService.PhotoPair pair, TelegramClient client) {
+        LocalDate beforeDate = TimezoneSupport.dateInUserZone(pair.before().getTakenAt(), user);
+        LocalDate afterDate = TimezoneSupport.dateInUserZone(pair.after().getTakenAt(), user);
+        long days = ChronoUnit.DAYS.between(
+                pair.before().getTakenAt().toLocalDate(),
+                pair.after().getTakenAt().toLocalDate()
+        );
+
+        SendPhoto sendBefore = SendPhoto.builder()
+                .chatId(user.getTelegramChatId().toString())
+                .photo(new InputFile(pair.before().getTelegramFileId()))
+                .caption("⏮ До — " + beforeDate.format(DATE_FMT))
+                .build();
+        SendPhoto sendAfter = SendPhoto.builder()
+                .chatId(user.getTelegramChatId().toString())
+                .photo(new InputFile(pair.after().getTelegramFileId()))
+                .caption("⏭ После — " + afterDate.format(DATE_FMT))
+                .build();
+        SendMessage summary = SendMessage.builder()
+                .chatId(user.getTelegramChatId().toString())
+                .text("Прошло: " + days + " дн.")
+                .build();
+        try {
+            client.execute(sendBefore);
+            client.execute(sendAfter);
+            client.execute(summary);
+        } catch (TelegramApiException e) {
+            log.error("Failed to send comparison: {}", e.getMessage());
+            sendText(user.getTelegramChatId(), "❌ Не удалось отправить сравнение.", client);
+        }
+    }
+
+    /**
+     * Ответ на callback (alert / no-op).
+     */
+    public void answerCallback(TelegramClient client, String callbackId, String text) {
+        if (callbackId == null) {
+            return;
+        }
+        try {
+            client.execute(AnswerCallbackQuery.builder()
+                    .callbackQueryId(callbackId)
+                    .text(text == null ? "" : text)
+                    .build());
+        } catch (TelegramApiException e) {
+            log.warn("Failed to answer callback {}: {}", callbackId, e.getMessage());
+        }
+    }
+
+    private String frequencyLabel(PhotoProgressFrequency freq) {
+        if (freq == null) {
+            return "Выключено";
+        }
+        return switch (freq) {
+            case OFF -> "Выключено";
+            case P2W -> "Раз в 2 недели";
+            case P1M -> "Раз в месяц";
+        };
+    }
+
+    private void sendOrEdit(
+            Long chatId,
+            Integer messageId,
+            String text,
+            InlineKeyboardMarkup keyboard,
+            TelegramClient client
+    ) {
+        if (messageId != null) {
+            EditMessageText edit = EditMessageText.builder()
+                    .chatId(chatId.toString())
+                    .messageId(messageId)
+                    .text(text)
+                    .parseMode("Markdown")
+                    .replyMarkup(keyboard)
+                    .build();
+            try {
+                client.execute(edit);
+                return;
+            } catch (TelegramApiException e) {
+                String msg = e.getMessage() == null ? "" : e.getMessage();
+                if (msg.contains("message is not modified")) {
+                    return;
+                }
+                log.warn("Failed to edit photo-progress message ({}): {}", chatId, msg);
+                // fallback на отправку новым сообщением
+            }
+        }
+        SendMessage message = SendMessage.builder()
+                .chatId(chatId.toString())
+                .text(text)
+                .parseMode("Markdown")
+                .replyMarkup(keyboard)
+                .build();
+        try {
+            client.execute(message);
+        } catch (TelegramApiException e) {
+            log.error("Failed to send photo-progress message ({}): {}", chatId, e.getMessage());
+        }
+    }
+
+    private void sendText(Long chatId, String text, TelegramClient client) {
+        SendMessage message = SendMessage.builder()
+                .chatId(chatId.toString())
+                .text(text)
+                .build();
+        try {
+            client.execute(message);
+        } catch (TelegramApiException e) {
+            log.error("Failed to send text ({}): {}", chatId, e.getMessage());
+        }
+    }
+
+    private String escapeMd(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text
+                .replace("\\", "\\\\")
+                .replace("*", "\\*")
+                .replace("_", "\\_")
+                .replace("[", "\\[")
+                .replace("]", "\\]")
+                .replace("`", "\\`");
+    }
+}

--- a/src/main/java/com/plantcare/bot/service/PhotoProgressSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/PhotoProgressSchedulerService.java
@@ -1,0 +1,178 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.client.TelegramClientProvider;
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.repository.PlantRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardRow;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+/**
+ * Шедулер фото-прогресса (issue #72) — раз в час обходит растения с
+ * включённым фото-прогрессом и шлёт push «пора обновить фото».
+ *
+ * <p>Идемпотентность достигается через {@code last_photo_prompt_sent_at}:
+ * после успешной отправки дата фиксируется и фильтр {@code dedupBefore}
+ * в репозитории исключает повторную отправку в течение
+ * {@link #DEDUP_HOURS} часов.
+ *
+ * <p>Telegram-API не вызывается внутри той же транзакции, что и
+ * выборка/обновление плана: сначала отдельная read-only транзакция
+ * подбирает кандидатов, затем для каждого — отдельная транзакция на
+ * обновление {@code last_photo_prompt_sent_at} после успешной отправки.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PhotoProgressSchedulerService {
+
+    /** Период тика — раз в час. */
+    private static final long INTERVAL_MS = 3_600_000L;
+
+    /** Окно дедупа: не повторять prompt чаще раза в N часов. */
+    private static final int DEDUP_HOURS = 24;
+
+    /** Окно вперёд, которое подбирает шедулер. */
+    private static final int LOOK_AHEAD_HOURS = 1;
+
+    private final PlantRepository plantRepository;
+    private final PhotoProgressService photoProgressService;
+    private final TelegramClientProvider telegramClientProvider;
+
+    @Scheduled(fixedRate = INTERVAL_MS)
+    public void checkPhotoPrompts() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Plant> due = loadDuePlants(now);
+
+        if (due.isEmpty()) {
+            return;
+        }
+        log.info("Photo-progress tick: {} plants due", due.size());
+
+        for (Plant plant : due) {
+            try {
+                User user = plant.getUser();
+                if (user == null) {
+                    continue;
+                }
+                if (user.isPaused() || user.isBlocked()) {
+                    continue;
+                }
+                if (isQuietHours(user, now)) {
+                    continue;
+                }
+
+                boolean sent = sendPhotoPrompt(user, plant);
+                if (sent) {
+                    photoProgressService.markPromptSent(plant.getId(), LocalDateTime.now());
+                }
+            } catch (Exception e) {
+                log.error("Failed to handle photo-progress prompt for plant {}: {}",
+                        plant.getId(), e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Отдельная read-only транзакция: только подбираем кандидатов.
+     *
+     * <p>{@code plant.user} подтягивается через {@code JOIN FETCH} в самом
+     * запросе, поэтому отдельная инициализация lazy-поля не нужна.
+     */
+    @Transactional(readOnly = true)
+    public List<Plant> loadDuePlants(LocalDateTime now) {
+        LocalDateTime until = now.plusHours(LOOK_AHEAD_HOURS);
+        LocalDateTime dedupBefore = now.minusHours(DEDUP_HOURS);
+
+        return plantRepository.findPhotoProgressDue(until, dedupBefore);
+    }
+
+    private boolean sendPhotoPrompt(User user, Plant plant) {
+        SendMessage message = SendMessage.builder()
+                .chatId(user.getTelegramChatId().toString())
+                .text("📸 Пора обновить фото для *" + escapeMd(plant.getName()) + "*")
+                .parseMode("Markdown")
+                .replyMarkup(buildPromptKeyboard(plant.getId()))
+                .build();
+
+        try {
+            telegramClientProvider.getTelegramClient().execute(message);
+            log.info("Photo-progress prompt sent: plant={} user={}",
+                    plant.getId(), user.getTelegramChatId());
+            return true;
+        } catch (TelegramApiException e) {
+            log.error("Failed to send photo-progress prompt (plant={}, user={}): {}",
+                    plant.getId(), user.getTelegramChatId(), e.getMessage());
+            return false;
+        }
+    }
+
+    private InlineKeyboardMarkup buildPromptKeyboard(Long plantId) {
+        InlineKeyboardButton add = InlineKeyboardButton.builder()
+                .text("📸 Загрузить фото")
+                .callbackData("PHOTO_PROGRESS:ADD:" + plantId)
+                .build();
+        InlineKeyboardButton skip = InlineKeyboardButton.builder()
+                .text("⏭ Пропустить")
+                .callbackData("PHOTO_PROGRESS:SKIP:" + plantId)
+                .build();
+        return InlineKeyboardMarkup.builder()
+                .keyboardRow(new InlineKeyboardRow(add, skip))
+                .build();
+    }
+
+    /**
+     * Quiet-hours в local TZ юзера — копия логики
+     * {@code NotificationSchedulerService.isQuietHours} (issue #28).
+     */
+    private boolean isQuietHours(User user, LocalDateTime now) {
+        ZoneId userZone;
+        try {
+            userZone = ZoneId.of(user.getTimezone());
+        } catch (Exception e) {
+            userZone = ZoneId.of("UTC");
+        }
+
+        ZonedDateTime userNow = Instant.now().atZone(userZone);
+        LocalTime userTime = userNow.toLocalTime();
+
+        LocalTime start = user.getQuietHoursStart();
+        LocalTime end = user.getQuietHoursEnd();
+        if (start == null || end == null || start.equals(end)) {
+            return false;
+        }
+
+        if (start.isBefore(end)) {
+            return !userTime.isBefore(start) && userTime.isBefore(end);
+        }
+        return !userTime.isBefore(start) || userTime.isBefore(end);
+    }
+
+    private String escapeMd(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text
+                .replace("\\", "\\\\")
+                .replace("*", "\\*")
+                .replace("_", "\\_")
+                .replace("[", "\\[")
+                .replace("]", "\\]")
+                .replace("`", "\\`");
+    }
+}

--- a/src/main/java/com/plantcare/bot/service/PhotoProgressService.java
+++ b/src/main/java/com/plantcare/bot/service/PhotoProgressService.java
@@ -1,0 +1,298 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.PlantProgressPhoto;
+import com.plantcare.bot.domain.enums.PhotoProgressFrequency;
+import com.plantcare.bot.repository.PlantProgressPhotoRepository;
+import com.plantcare.bot.repository.PlantRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Бизнес-логика фото-прогресса (issue #72): включение/выключение режима,
+ * загрузка фото в таймлайн, выборки для UI «История» и «Сравнить».
+ *
+ * <p>Ownership проверяется в каждом методе через
+ * {@link PlantRepository#findByUserIdAndIdAndArchivedAtIsNull} — растение
+ * должно принадлежать юзеру и не быть архивным.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PhotoProgressService {
+
+    /** Размер страницы для UI «История фото». */
+    public static final int HISTORY_PAGE_SIZE = 10;
+
+    /** Антиспам: не больше одного фото в этом окне (часов). */
+    private static final int ANTI_SPAM_HOURS = 24;
+
+    private final PlantRepository plantRepository;
+    private final PlantProgressPhotoRepository photoRepository;
+
+    /**
+     * Установить частоту фото-прогресса.
+     *
+     * <p>При включении выставляет {@code nextPhotoDueAt = now + period} и сбрасывает
+     * {@code lastPhotoPromptSentAt}. При выключении ({@link PhotoProgressFrequency#OFF})
+     * чистит {@code nextPhotoDueAt}, чтобы шедулер растение не подхватывал.
+     *
+     * @return обновлённое растение
+     * @throws IllegalArgumentException если растение не найдено у юзера
+     */
+    public Plant setFrequency(Long userId, Long plantId, PhotoProgressFrequency frequency) {
+        Plant plant = requirePlant(userId, plantId);
+
+        plant.setPhotoProgressFrequency(frequency);
+
+        if (frequency.isEnabled()) {
+            plant.setNextPhotoDueAt(LocalDateTime.now().plus(frequency.getPeriod()));
+        } else {
+            plant.setNextPhotoDueAt(null);
+        }
+        plant.setLastPhotoPromptSentAt(null);
+
+        Plant saved = plantRepository.save(plant);
+        log.info("Photo-progress frequency set: plant={} user={} frequency={} nextDueAt={}",
+                plantId, userId, frequency, saved.getNextPhotoDueAt());
+        return saved;
+    }
+
+    /**
+     * Добавить фото в таймлайн и пересчитать {@code nextPhotoDueAt}.
+     *
+     * @throws IllegalArgumentException если растение не найдено у юзера
+     * @throws IllegalStateException    если за последние {@link #ANTI_SPAM_HOURS}ч
+     *                                  уже было фото у этого растения
+     */
+    public PlantProgressPhoto addPhoto(Long userId, Long plantId, String telegramFileId) {
+        if (telegramFileId == null || telegramFileId.isBlank()) {
+            throw new IllegalArgumentException("telegramFileId is required");
+        }
+
+        Plant plant = requirePlant(userId, plantId);
+        LocalDateTime now = LocalDateTime.now();
+
+        if (photoRepository.existsByPlantIdAndTakenAtAfter(
+                plantId, now.minusHours(ANTI_SPAM_HOURS))) {
+            throw new IllegalStateException("Уже есть фото за последние 24 часа");
+        }
+
+        PlantProgressPhoto photo = new PlantProgressPhoto();
+        photo.setPlant(plant);
+        photo.setUser(plant.getUser());
+        photo.setTelegramFileId(telegramFileId);
+        photo.setTakenAt(now);
+
+        PlantProgressPhoto saved = photoRepository.save(photo);
+
+        PhotoProgressFrequency frequency = plant.getPhotoProgressFrequency();
+        if (frequency != null && frequency.isEnabled()) {
+            Period period = frequency.getPeriod();
+            plant.setNextPhotoDueAt(now.plus(period));
+        }
+        // Сброс анти-спам поля — новый цикл, prompt можно слать снова, когда подойдёт срок.
+        plant.setLastPhotoPromptSentAt(null);
+        plantRepository.save(plant);
+
+        log.info("Progress photo added: plant={} user={} photoId={} nextDueAt={}",
+                plantId, userId, saved.getId(), plant.getNextPhotoDueAt());
+        return saved;
+    }
+
+    /**
+     * «Пропустить» текущий prompt — сдвинуть {@code nextPhotoDueAt} на полный период,
+     * чтобы юзер не получал повторных пушей до следующего цикла.
+     */
+    public Plant skipPrompt(Long userId, Long plantId) {
+        Plant plant = requirePlant(userId, plantId);
+
+        PhotoProgressFrequency frequency = plant.getPhotoProgressFrequency();
+        if (frequency == null || !frequency.isEnabled()) {
+            // Режим выключен — нечего скипать; возвращаем без изменений.
+            return plant;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        plant.setNextPhotoDueAt(now.plus(frequency.getPeriod()));
+        plant.setLastPhotoPromptSentAt(now);
+
+        Plant saved = plantRepository.save(plant);
+        log.info("Photo-progress prompt skipped: plant={} user={} nextDueAt={}",
+                plantId, userId, saved.getNextPhotoDueAt());
+        return saved;
+    }
+
+    /**
+     * Зафиксировать факт отправки prompt'а — используется шедулером.
+     *
+     * <p>Помимо записи {@code lastPhotoPromptSentAt}, сдвигает
+     * {@code nextPhotoDueAt} на полный период вперёд: иначе при игноре
+     * пользователем дедуп через 24 часа снова разрешит отправку и
+     * растение начнёт получать пуш каждые сутки. Если пользователь хочет
+     * добавить фото — он сделает это вручную из карточки; следующий
+     * автоматический пуш — только через полный период.
+     */
+    public void markPromptSent(Long plantId, LocalDateTime sentAt) {
+        Plant plant = plantRepository.findById(plantId).orElse(null);
+        if (plant == null) {
+            log.warn("markPromptSent: plant {} not found", plantId);
+            return;
+        }
+
+        plant.setLastPhotoPromptSentAt(sentAt);
+
+        PhotoProgressFrequency frequency = plant.getPhotoProgressFrequency();
+        if (frequency != null && frequency.isEnabled()) {
+            plant.setNextPhotoDueAt(sentAt.plus(frequency.getPeriod()));
+        }
+
+        plantRepository.save(plant);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PlantProgressPhoto> getHistory(Long userId, Long plantId, int page) {
+        requirePlant(userId, plantId);
+        int safePage = Math.max(0, page);
+        Pageable pageable = PageRequest.of(safePage, HISTORY_PAGE_SIZE);
+        return photoRepository.findAllByPlantIdOrderByTakenAtDesc(plantId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public long countHistory(Long userId, Long plantId) {
+        requirePlant(userId, plantId);
+        return photoRepository.countByPlantId(plantId);
+    }
+
+    /**
+     * Последние N фото для UI «Выбрать две даты».
+     */
+    @Transactional(readOnly = true)
+    public List<PlantProgressPhoto> getRecent(Long userId, Long plantId, int limit) {
+        requirePlant(userId, plantId);
+        return photoRepository.findRecent(plantId, PageRequest.of(0, Math.max(1, limit)));
+    }
+
+    /**
+     * Сравнение «первое vs последнее». Пусто, если фото < 2.
+     */
+    @Transactional(readOnly = true)
+    public Optional<PhotoPair> compareFirstVsLast(Long userId, Long plantId) {
+        requirePlant(userId, plantId);
+
+        if (photoRepository.countByPlantId(plantId) < 2) {
+            return Optional.empty();
+        }
+
+        Optional<PlantProgressPhoto> first = photoRepository
+                .findFirstByPlantIdOrderByTakenAtAsc(plantId);
+        Optional<PlantProgressPhoto> last = photoRepository
+                .findFirstByPlantIdOrderByTakenAtDesc(plantId);
+
+        if (first.isEmpty() || last.isEmpty()
+                || first.get().getId().equals(last.get().getId())) {
+            return Optional.empty();
+        }
+        return Optional.of(new PhotoPair(first.get(), last.get()));
+    }
+
+    /**
+     * Сравнение «месяц назад vs сейчас». Берёт «до» — ближайшее фото снизу
+     * к {@code now - 1 month}; «после» — последнее.
+     */
+    @Transactional(readOnly = true)
+    public Optional<PhotoPair> compareMonthVsNow(Long userId, Long plantId) {
+        requirePlant(userId, plantId);
+
+        Optional<PlantProgressPhoto> latest = photoRepository
+                .findFirstByPlantIdOrderByTakenAtDesc(plantId);
+        if (latest.isEmpty()) {
+            return Optional.empty();
+        }
+
+        LocalDateTime monthAgo = LocalDateTime.now().minusMonths(1);
+        List<PlantProgressPhoto> before = photoRepository.findClosestBefore(
+                plantId, monthAgo, PageRequest.of(0, 1));
+
+        if (before.isEmpty() || before.get(0).getId().equals(latest.get().getId())) {
+            return Optional.empty();
+        }
+        return Optional.of(new PhotoPair(before.get(0), latest.get()));
+    }
+
+    /**
+     * Сравнение по двум id фото — обе записи должны принадлежать этому растению юзера.
+     */
+    @Transactional(readOnly = true)
+    public Optional<PhotoPair> compareByIds(Long userId, Long plantId, Long leftId, Long rightId) {
+        requirePlant(userId, plantId);
+
+        if (leftId == null || rightId == null || leftId.equals(rightId)) {
+            return Optional.empty();
+        }
+
+        Optional<PlantProgressPhoto> left = photoRepository.findById(leftId);
+        Optional<PlantProgressPhoto> right = photoRepository.findById(rightId);
+
+        if (left.isEmpty() || right.isEmpty()) {
+            return Optional.empty();
+        }
+        // Защита от подмены: оба фото должны быть из выбранного растения.
+        if (!plantId.equals(left.get().getPlant().getId())
+                || !plantId.equals(right.get().getPlant().getId())) {
+            return Optional.empty();
+        }
+
+        PlantProgressPhoto leftPhoto = left.get();
+        PlantProgressPhoto rightPhoto = right.get();
+        PlantProgressPhoto before;
+        PlantProgressPhoto after;
+        if (leftPhoto.getTakenAt().isAfter(rightPhoto.getTakenAt())) {
+            before = rightPhoto;
+            after = leftPhoto;
+        } else if (leftPhoto.getTakenAt().isBefore(rightPhoto.getTakenAt())) {
+            before = leftPhoto;
+            after = rightPhoto;
+        } else {
+            // Tie-breaker по id: меньший id считаем «до», больший — «после»,
+            // чтобы порядок был детерминированным при равных takenAt.
+            if (leftPhoto.getId() < rightPhoto.getId()) {
+                before = leftPhoto;
+                after = rightPhoto;
+            } else {
+                before = rightPhoto;
+                after = leftPhoto;
+            }
+        }
+        return Optional.of(new PhotoPair(before, after));
+    }
+
+    /**
+     * Найти фото по id с проверкой принадлежности юзеру.
+     */
+    @Transactional(readOnly = true)
+    public Optional<PlantProgressPhoto> getPhotoForUser(Long userId, Long photoId) {
+        return photoRepository.findById(photoId)
+                .filter(p -> p.getUser() != null && userId.equals(p.getUser().getId()));
+    }
+
+    private Plant requirePlant(Long userId, Long plantId) {
+        return plantRepository
+                .findByUserIdAndIdAndArchivedAtIsNull(userId, plantId)
+                .orElseThrow(() -> new IllegalArgumentException("Plant not found"));
+    }
+
+    /** Пара «до / после» для UI сравнения. */
+    public record PhotoPair(PlantProgressPhoto before, PlantProgressPhoto after) {
+    }
+}

--- a/src/main/java/com/plantcare/bot/service/PlantCardService.java
+++ b/src/main/java/com/plantcare/bot/service/PlantCardService.java
@@ -1262,6 +1262,16 @@ public class PlantCardService {
                 .build());
         rows.add(eventsRow);
 
+        // 2b') Фото-прогресс (issue #72). Отдельный ряд между Events и Acclimation —
+        // экран фото-прогресса не сохраняет back-контекст «комнаты», его всегда
+        // ведём на PLANT:VIEW.
+        InlineKeyboardRow photoProgressRow = new InlineKeyboardRow();
+        photoProgressRow.add(InlineKeyboardButton.builder()
+                .text("📸 Фото-прогресс")
+                .callbackData("PHOTO_PROGRESS:VIEW:" + plant.getId())
+                .build());
+        rows.add(photoProgressRow);
+
         // 2c) Кнопка выключения акклиматизации (issue #75) — показываем только если режим активен.
         if (plant.isInAcclimation(LocalDateTime.now())) {
             rows.add(new InlineKeyboardRow(List.of(

--- a/src/main/java/com/plantcare/bot/state/impl/AwaitingProgressPhotoStateHandler.java
+++ b/src/main/java/com/plantcare/bot/state/impl/AwaitingProgressPhotoStateHandler.java
@@ -1,0 +1,215 @@
+package com.plantcare.bot.state.impl;
+
+import com.plantcare.bot.domain.PlantProgressPhoto;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.ConversationState;
+import com.plantcare.bot.service.PhotoProgressCardService;
+import com.plantcare.bot.service.PhotoProgressService;
+import com.plantcare.bot.service.UserService;
+import com.plantcare.bot.state.interfaces.StateHandler;
+import com.plantcare.bot.util.TimezoneSupport;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.meta.api.methods.AnswerCallbackQuery;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.photo.PhotoSize;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardRow;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Обработчик состояния {@link ConversationState#AWAITING_PROGRESS_PHOTO} (issue #72):
+ * ожидание фото для таймлайна фото-прогресса.
+ *
+ * <p>Сценарии:
+ * <ul>
+ *     <li>Пользователь шлёт фото → сохраняем самое крупное превью в БД,
+ *         возвращаем в IDLE, показываем подтверждение со следующей датой.</li>
+ *     <li>Callback {@code PHOTO_PROGRESS:CANCEL} → сбрасываем state, открываем
+ *         экран фото-прогресса.</li>
+ *     <li>Любой другой ввод → подсказываем, что нужно фото (или Cancel).</li>
+ * </ul>
+ *
+ * <p>plantId хранится в {@code user.stateData} под ключом
+ * {@link #STATE_KEY_PLANT_ID} — кладётся при переходе в это состояние из
+ * экрана фото-прогресса (callback {@code PHOTO_PROGRESS:ADD:{plantId}}).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AwaitingProgressPhotoStateHandler implements StateHandler {
+
+    public static final String STATE_KEY_PLANT_ID = "photo_progress_plant_id";
+    private static final String CANCEL_CALLBACK = "PHOTO_PROGRESS:CANCEL";
+    private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+
+    private final UserService userService;
+    private final PhotoProgressService photoProgressService;
+    private final PhotoProgressCardService photoProgressCardService;
+
+    @Override
+    public ConversationState getSupportedState() {
+        return ConversationState.AWAITING_PROGRESS_PHOTO;
+    }
+
+    @Override
+    public void handle(User user, Update update, TelegramClient client) {
+        if (update.hasCallbackQuery()) {
+            handleCallback(user, update, client);
+            return;
+        }
+
+        if (update.hasMessage() && update.getMessage().hasPhoto()) {
+            handlePhoto(user, update, client);
+            return;
+        }
+
+        sendHint(user.getTelegramChatId(), client);
+    }
+
+    private void handleCallback(User user, Update update, TelegramClient client) {
+        String data = update.getCallbackQuery().getData();
+        answerCallback(update, client);
+
+        if (!CANCEL_CALLBACK.equals(data)) {
+            log.debug("Ignoring callback in AWAITING_PROGRESS_PHOTO: {}", data);
+            return;
+        }
+
+        Long plantId = readPlantId(user);
+        userService.resetToIdle(user);
+        if (plantId != null) {
+            photoProgressCardService.showPhotoProgressScreen(user, plantId, null, client);
+        }
+    }
+
+    private void handlePhoto(User user, Update update, TelegramClient client) {
+        Long plantId = readPlantId(user);
+        if (plantId == null) {
+            log.warn("Photo received but plantId missing in stateData (user {})",
+                    user.getTelegramChatId());
+            sendText(client, user.getTelegramChatId(),
+                    "❌ Не нашёл контекст растения. Открой экран фото-прогресса заново.");
+            userService.resetToIdle(user);
+            return;
+        }
+
+        List<PhotoSize> photos = update.getMessage().getPhoto();
+        if (photos == null || photos.isEmpty()) {
+            sendHint(user.getTelegramChatId(), client);
+            return;
+        }
+
+        // Telegram возвращает несколько размеров; сохраняем самый крупный.
+        String fileId = photos.stream()
+                .max(Comparator.comparingInt(p -> safeSize(p.getFileSize())))
+                .map(PhotoSize::getFileId)
+                .orElse(null);
+        if (fileId == null || fileId.isBlank()) {
+            sendHint(user.getTelegramChatId(), client);
+            return;
+        }
+
+        PlantProgressPhoto saved;
+        try {
+            saved = photoProgressService.addPhoto(user.getId(), plantId, fileId);
+        } catch (IllegalStateException e) {
+            // Антиспам: уже было фото за последние 24ч.
+            sendText(client, user.getTelegramChatId(), "⚠️ " + e.getMessage());
+            userService.resetToIdle(user);
+            photoProgressCardService.showPhotoProgressScreen(user, plantId, null, client);
+            return;
+        } catch (IllegalArgumentException e) {
+            sendText(client, user.getTelegramChatId(), "❌ Растение не найдено.");
+            userService.resetToIdle(user);
+            return;
+        }
+
+        userService.resetToIdle(user);
+
+        // Подтверждение: «Фото добавлено. Следующее напоминание — {date}».
+        StringBuilder confirm = new StringBuilder("✅ Фото добавлено.");
+        if (saved.getPlant().getPhotoProgressFrequency() != null
+                && saved.getPlant().getPhotoProgressFrequency().isEnabled()
+                && saved.getPlant().getNextPhotoDueAt() != null) {
+            LocalDate next = TimezoneSupport.dateInUserZone(
+                    saved.getPlant().getNextPhotoDueAt(), user);
+            confirm.append(" Следующее напоминание — ").append(next.format(DATE_FMT)).append(".");
+        }
+        sendText(client, user.getTelegramChatId(), confirm.toString());
+
+        photoProgressCardService.showPhotoProgressScreen(user, plantId, null, client);
+    }
+
+    private Long readPlantId(User user) {
+        if (user.getStateData() == null) {
+            return null;
+        }
+        Object raw = user.getStateData().get(STATE_KEY_PLANT_ID);
+        if (raw == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(String.valueOf(raw));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private void sendHint(Long chatId, TelegramClient client) {
+        InlineKeyboardMarkup keyboard = InlineKeyboardMarkup.builder()
+                .keyboardRow(new InlineKeyboardRow(List.of(
+                        InlineKeyboardButton.builder()
+                                .text("⬅️ Отмена")
+                                .callbackData(CANCEL_CALLBACK)
+                                .build()
+                )))
+                .build();
+
+        SendMessage message = SendMessage.builder()
+                .chatId(chatId.toString())
+                .text("📸 Пришли фото как картинку — оно попадёт в таймлайн.")
+                .replyMarkup(keyboard)
+                .build();
+        try {
+            client.execute(message);
+        } catch (TelegramApiException e) {
+            log.error("Failed to send photo-progress hint ({}): {}", chatId, e.getMessage());
+        }
+    }
+
+    private int safeSize(Integer size) {
+        return size == null ? 0 : size;
+    }
+
+    private void sendText(TelegramClient client, Long chatId, String text) {
+        SendMessage message = SendMessage.builder()
+                .chatId(chatId.toString())
+                .text(text)
+                .build();
+        try {
+            client.execute(message);
+        } catch (TelegramApiException e) {
+            log.error("Failed to send text ({}): {}", chatId, e.getMessage());
+        }
+    }
+
+    private void answerCallback(Update update, TelegramClient client) {
+        try {
+            client.execute(AnswerCallbackQuery.builder()
+                    .callbackQueryId(update.getCallbackQuery().getId())
+                    .build());
+        } catch (Exception e) {
+            log.warn("Failed to answer callback: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/db/migration/V16__add_photo_progress.sql
+++ b/src/main/resources/db/migration/V16__add_photo_progress.sql
@@ -1,0 +1,84 @@
+-- =====================================================
+-- V16: Фото-прогресс растения (issue #72)
+--
+-- Юзер может включить периодические пуши «сделай фото» (раз в 2 недели
+-- или раз в месяц), бот сохраняет фото в историю и собирает таймлайн
+-- роста растения.
+--
+-- Состоит из двух частей:
+--   1. Расширение plants — настройки частоты и анти-спам поля для шедулера.
+--   2. Новая таблица plant_progress_photos — собственно история фото.
+--
+-- Backward-compat:
+--   - photo_progress_frequency добавляется с DEFAULT 'OFF' и NOT NULL —
+--     старый код, не знающий о колонке, продолжит работать, новые растения
+--     заводятся с выключенным фото-прогрессом.
+--   - next_photo_due_at / last_photo_prompt_sent_at — nullable, не мешают.
+--   - plant_progress_photos — новая таблица, для существующего кода невидима.
+-- =====================================================
+
+-- 1) Настройки фото-прогресса на уровне растения.
+ALTER TABLE plants
+    ADD COLUMN IF NOT EXISTS photo_progress_frequency VARCHAR(8) NOT NULL DEFAULT 'OFF';
+
+ALTER TABLE plants
+    ADD COLUMN IF NOT EXISTS next_photo_due_at TIMESTAMP;
+
+ALTER TABLE plants
+    ADD COLUMN IF NOT EXISTS last_photo_prompt_sent_at TIMESTAMP;
+
+ALTER TABLE plants
+    ADD CONSTRAINT chk_plants_photo_progress_frequency
+        CHECK (photo_progress_frequency IN ('OFF', 'P2W', 'P1M'));
+
+COMMENT ON COLUMN plants.photo_progress_frequency IS
+    'Частота пушей «обнови фото» (issue #72): OFF — выключено (default), '
+        'P2W — раз в 2 недели, P1M — раз в месяц.';
+
+COMMENT ON COLUMN plants.next_photo_due_at IS
+    'Когда шедулер должен прислать следующий prompt «сделай фото». '
+        'NULL если фото-прогресс выключен или ещё не запланирован.';
+
+COMMENT ON COLUMN plants.last_photo_prompt_sent_at IS
+    'Когда последний раз слали prompt — анти-спам, чтобы при сбоях шедулера '
+        'не задолбать юзера повторами в течение короткого окна.';
+
+-- Partial index под шедулер: «найди растения, которым пора слать фото-prompt».
+-- Большинство растений с OFF → next_photo_due_at IS NULL, в индекс не лезут.
+CREATE INDEX IF NOT EXISTS idx_plants_next_photo_due
+    ON plants(next_photo_due_at)
+    WHERE next_photo_due_at IS NOT NULL;
+
+
+-- 2) История фото-прогресса.
+CREATE TABLE IF NOT EXISTS plant_progress_photos (
+    id                  BIGSERIAL PRIMARY KEY,
+    plant_id            BIGINT       NOT NULL REFERENCES plants(id) ON DELETE CASCADE,
+    user_id             BIGINT       NOT NULL REFERENCES users(id)  ON DELETE CASCADE,
+    telegram_file_id    VARCHAR(255) NOT NULL,
+    taken_at            TIMESTAMP    NOT NULL,
+    caption             VARCHAR(500),
+    created_at          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Индекс для главного экрана истории «фото растения в обратном порядке».
+CREATE INDEX IF NOT EXISTS idx_progress_photo_plant_taken
+    ON plant_progress_photos(plant_id, taken_at DESC);
+
+COMMENT ON TABLE plant_progress_photos IS
+    'История фото-прогресса растения (issue #72). Не пересекается с '
+        'plants.photo_file_id — там одна «обложка», тут таймлайн.';
+
+COMMENT ON COLUMN plant_progress_photos.user_id IS
+    'Денормализация: дублируется из plants.user_id для быстрых выборок '
+        '«все фото юзера» без join (галерея, экспорт).';
+
+COMMENT ON COLUMN plant_progress_photos.telegram_file_id IS
+    'Telegram file_id, не URL. Получаем при загрузке фото юзером.';
+
+COMMENT ON COLUMN plant_progress_photos.taken_at IS
+    'Момент, когда фото попало в систему. Для v1 = время загрузки в бот; '
+        'в будущем юзер сможет указать «фото из прошлого».';
+
+COMMENT ON COLUMN plant_progress_photos.caption IS
+    'Опциональная подпись юзера к фото (до 500 символов).';

--- a/src/test/java/com/plantcare/bot/service/PhotoProgressSchedulerServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/PhotoProgressSchedulerServiceTest.java
@@ -1,0 +1,144 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.client.TelegramClientProvider;
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.PhotoProgressFrequency;
+import com.plantcare.bot.repository.PlantRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit-тесты {@link PhotoProgressSchedulerService} (issue #72) — проверяют
+ * базовое поведение: счастливый путь, фильтр paused/blocked, корректная
+ * обработка падения Telegram-API для одного из растений.
+ */
+@DisplayName("Unit-тесты PhotoProgressSchedulerService (issue #72)")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PhotoProgressSchedulerServiceTest {
+
+    @Mock
+    private PlantRepository plantRepository;
+
+    @Mock
+    private PhotoProgressService photoProgressService;
+
+    @Mock
+    private TelegramClientProvider telegramClientProvider;
+
+    @Mock
+    private TelegramClient telegramClient;
+
+    @InjectMocks
+    private PhotoProgressSchedulerService service;
+
+    @BeforeEach
+    void setUp() {
+        when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
+    }
+
+    @Test
+    void should_send_prompt_and_mark_when_plant_due_and_user_active() throws TelegramApiException {
+        User user = activeUser(100L);
+        Plant plant = duePlant(10L, "Монстера", user);
+        when(plantRepository.findPhotoProgressDue(any(), any())).thenReturn(List.of(plant));
+
+        service.checkPhotoPrompts();
+
+        verify(telegramClient, times(1)).execute(any(SendMessage.class));
+        verify(photoProgressService).markPromptSent(eq(plant.getId()), any(LocalDateTime.class));
+    }
+
+    @Test
+    void should_skip_when_user_is_paused() throws TelegramApiException {
+        User user = activeUser(100L);
+        user.setPausedUntil(LocalDateTime.now().plusHours(2));
+        Plant plant = duePlant(10L, "Монстера", user);
+        when(plantRepository.findPhotoProgressDue(any(), any())).thenReturn(List.of(plant));
+
+        service.checkPhotoPrompts();
+
+        verify(telegramClient, never()).execute(any(SendMessage.class));
+        verify(photoProgressService, never()).markPromptSent(anyLong(), any(LocalDateTime.class));
+    }
+
+    @Test
+    void should_skip_when_user_is_blocked() throws TelegramApiException {
+        User user = activeUser(100L);
+        user.setBlocked(true);
+        Plant plant = duePlant(10L, "Монстера", user);
+        when(plantRepository.findPhotoProgressDue(any(), any())).thenReturn(List.of(plant));
+
+        service.checkPhotoPrompts();
+
+        verify(telegramClient, never()).execute(any(SendMessage.class));
+        verify(photoProgressService, never()).markPromptSent(anyLong(), any(LocalDateTime.class));
+    }
+
+    @Test
+    void should_continue_processing_when_telegram_fails_for_one_plant() throws TelegramApiException {
+        User user = activeUser(100L);
+        Plant failing = duePlant(10L, "Монстера", user);
+        Plant ok = duePlant(11L, "Фикус", user);
+        when(plantRepository.findPhotoProgressDue(any(), any())).thenReturn(List.of(failing, ok));
+
+        // Первый вызов execute падает, второй проходит. Шедулер должен пометить
+        // отправленным только второе растение, первое — пропустить.
+        when(telegramClient.execute(any(SendMessage.class)))
+                .thenThrow(new TelegramApiException("boom"))
+                .thenReturn(null);
+
+        service.checkPhotoPrompts();
+
+        verify(telegramClient, times(2)).execute(any(SendMessage.class));
+        verify(photoProgressService, never()).markPromptSent(eq(failing.getId()), any(LocalDateTime.class));
+        verify(photoProgressService).markPromptSent(eq(ok.getId()), any(LocalDateTime.class));
+    }
+
+    private static User activeUser(Long chatId) {
+        User user = User.builder()
+                .telegramChatId(chatId)
+                .timezone("Europe/Minsk")
+                .quietHoursStart(LocalTime.of(0, 0))
+                .quietHoursEnd(LocalTime.of(0, 0))
+                .blocked(false)
+                .build();
+        ReflectionTestUtils.setField(user, "id", chatId);
+        return user;
+    }
+
+    private static Plant duePlant(Long id, String name, User user) {
+        Plant plant = Plant.builder()
+                .user(user)
+                .name(name)
+                .photoProgressFrequency(PhotoProgressFrequency.P2W)
+                .build();
+        plant.setNextPhotoDueAt(LocalDateTime.now().minusMinutes(5));
+        ReflectionTestUtils.setField(plant, "id", id);
+        return plant;
+    }
+}

--- a/src/test/java/com/plantcare/bot/service/PhotoProgressServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/PhotoProgressServiceTest.java
@@ -1,0 +1,354 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.PlantProgressPhoto;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.PhotoProgressFrequency;
+import com.plantcare.bot.repository.PlantProgressPhotoRepository;
+import com.plantcare.bot.repository.PlantRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("Unit-тесты PhotoProgressService (issue #72)")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PhotoProgressServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long PLANT_ID = 42L;
+    private static final String FILE_ID = "AgACAgI...";
+
+    @Mock
+    private PlantRepository plantRepository;
+
+    @Mock
+    private PlantProgressPhotoRepository photoRepository;
+
+    @InjectMocks
+    private PhotoProgressService service;
+
+    private User user;
+    private Plant plant;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder().telegramChatId(12345L).build();
+        ReflectionTestUtils.setField(user, "id", USER_ID);
+
+        plant = Plant.builder()
+                .user(user)
+                .name("Монстера")
+                .photoProgressFrequency(PhotoProgressFrequency.OFF)
+                .build();
+        ReflectionTestUtils.setField(plant, "id", PLANT_ID);
+
+        when(plantRepository.findByUserIdAndIdAndArchivedAtIsNull(USER_ID, PLANT_ID))
+                .thenReturn(Optional.of(plant));
+        when(plantRepository.save(any(Plant.class))).thenAnswer(i -> i.getArgument(0));
+    }
+
+    @Test
+    void should_set_frequency_and_next_due_at_when_enabling_p2w() {
+        LocalDateTime before = LocalDateTime.now();
+
+        Plant result = service.setFrequency(USER_ID, PLANT_ID, PhotoProgressFrequency.P2W);
+
+        assertThat(result.getPhotoProgressFrequency()).isEqualTo(PhotoProgressFrequency.P2W);
+        assertThat(result.getNextPhotoDueAt())
+                .isAfterOrEqualTo(before.plusWeeks(2).minusSeconds(5))
+                .isBeforeOrEqualTo(LocalDateTime.now().plusWeeks(2).plusSeconds(5));
+        assertThat(result.getLastPhotoPromptSentAt()).isNull();
+    }
+
+    @Test
+    void should_clear_next_due_at_when_setting_off() {
+        plant.setPhotoProgressFrequency(PhotoProgressFrequency.P1M);
+        plant.setNextPhotoDueAt(LocalDateTime.now().plusMonths(1));
+
+        Plant result = service.setFrequency(USER_ID, PLANT_ID, PhotoProgressFrequency.OFF);
+
+        assertThat(result.getPhotoProgressFrequency()).isEqualTo(PhotoProgressFrequency.OFF);
+        assertThat(result.getNextPhotoDueAt()).isNull();
+    }
+
+    @Test
+    void should_throw_when_plant_not_found_on_set_frequency() {
+        when(plantRepository.findByUserIdAndIdAndArchivedAtIsNull(USER_ID, 999L))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.setFrequency(USER_ID, 999L, PhotoProgressFrequency.P2W))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Plant not found");
+    }
+
+    @Test
+    void should_save_photo_and_reschedule_when_frequency_enabled() {
+        plant.setPhotoProgressFrequency(PhotoProgressFrequency.P2W);
+        when(photoRepository.existsByPlantIdAndTakenAtAfter(eq(PLANT_ID), any(LocalDateTime.class)))
+                .thenReturn(false);
+        when(photoRepository.save(any(PlantProgressPhoto.class)))
+                .thenAnswer(i -> {
+                    PlantProgressPhoto p = i.getArgument(0);
+                    ReflectionTestUtils.setField(p, "id", 100L);
+                    return p;
+                });
+
+        LocalDateTime before = LocalDateTime.now();
+        PlantProgressPhoto saved = service.addPhoto(USER_ID, PLANT_ID, FILE_ID);
+
+        assertThat(saved.getTelegramFileId()).isEqualTo(FILE_ID);
+        assertThat(saved.getPlant()).isEqualTo(plant);
+        assertThat(saved.getUser()).isEqualTo(user);
+        assertThat(saved.getTakenAt()).isAfterOrEqualTo(before);
+        assertThat(plant.getNextPhotoDueAt())
+                .isAfterOrEqualTo(before.plusWeeks(2).minusSeconds(5));
+        assertThat(plant.getLastPhotoPromptSentAt()).isNull();
+        verify(plantRepository).save(plant);
+    }
+
+    @Test
+    void should_save_photo_without_reschedule_when_frequency_off() {
+        plant.setPhotoProgressFrequency(PhotoProgressFrequency.OFF);
+        when(photoRepository.existsByPlantIdAndTakenAtAfter(eq(PLANT_ID), any(LocalDateTime.class)))
+                .thenReturn(false);
+        when(photoRepository.save(any(PlantProgressPhoto.class)))
+                .thenAnswer(i -> i.getArgument(0));
+
+        service.addPhoto(USER_ID, PLANT_ID, FILE_ID);
+
+        assertThat(plant.getNextPhotoDueAt()).isNull();
+    }
+
+    @Test
+    void should_throw_when_anti_spam_24h_violated() {
+        when(photoRepository.existsByPlantIdAndTakenAtAfter(eq(PLANT_ID), any(LocalDateTime.class)))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> service.addPhoto(USER_ID, PLANT_ID, FILE_ID))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("24 часа");
+
+        verify(photoRepository, never()).save(any());
+    }
+
+    @Test
+    void should_throw_when_telegram_file_id_blank() {
+        assertThatThrownBy(() -> service.addPhoto(USER_ID, PLANT_ID, "   "))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> service.addPhoto(USER_ID, PLANT_ID, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_reschedule_next_due_at_on_skip_prompt() {
+        plant.setPhotoProgressFrequency(PhotoProgressFrequency.P1M);
+        LocalDateTime before = LocalDateTime.now();
+
+        Plant result = service.skipPrompt(USER_ID, PLANT_ID);
+
+        assertThat(result.getNextPhotoDueAt())
+                .isAfterOrEqualTo(before.plusMonths(1).minusSeconds(5));
+        assertThat(result.getLastPhotoPromptSentAt())
+                .isAfterOrEqualTo(before.minusSeconds(1));
+    }
+
+    @Test
+    void should_noop_skip_when_frequency_off() {
+        plant.setPhotoProgressFrequency(PhotoProgressFrequency.OFF);
+        plant.setNextPhotoDueAt(null);
+
+        Plant result = service.skipPrompt(USER_ID, PLANT_ID);
+
+        assertThat(result.getNextPhotoDueAt()).isNull();
+        verify(plantRepository, never()).save(any());
+    }
+
+    @Test
+    void should_return_pair_when_compare_first_last_with_two_photos() {
+        PlantProgressPhoto first = photo(1L, LocalDateTime.now().minusDays(30));
+        PlantProgressPhoto last = photo(2L, LocalDateTime.now());
+        when(photoRepository.countByPlantId(PLANT_ID)).thenReturn(2L);
+        when(photoRepository.findFirstByPlantIdOrderByTakenAtAsc(PLANT_ID)).thenReturn(Optional.of(first));
+        when(photoRepository.findFirstByPlantIdOrderByTakenAtDesc(PLANT_ID)).thenReturn(Optional.of(last));
+
+        Optional<PhotoProgressService.PhotoPair> pair = service.compareFirstVsLast(USER_ID, PLANT_ID);
+
+        assertThat(pair).isPresent();
+        assertThat(pair.get().before()).isEqualTo(first);
+        assertThat(pair.get().after()).isEqualTo(last);
+    }
+
+    @Test
+    void should_return_empty_when_compare_first_last_has_less_than_two_photos() {
+        when(photoRepository.countByPlantId(PLANT_ID)).thenReturn(1L);
+
+        Optional<PhotoProgressService.PhotoPair> pair = service.compareFirstVsLast(USER_ID, PLANT_ID);
+
+        assertThat(pair).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_when_compare_first_last_returns_same_photo() {
+        PlantProgressPhoto only = photo(1L, LocalDateTime.now());
+        when(photoRepository.countByPlantId(PLANT_ID)).thenReturn(2L);
+        when(photoRepository.findFirstByPlantIdOrderByTakenAtAsc(PLANT_ID)).thenReturn(Optional.of(only));
+        when(photoRepository.findFirstByPlantIdOrderByTakenAtDesc(PLANT_ID)).thenReturn(Optional.of(only));
+
+        Optional<PhotoProgressService.PhotoPair> pair = service.compareFirstVsLast(USER_ID, PLANT_ID);
+
+        assertThat(pair).isEmpty();
+    }
+
+    @Test
+    void should_compare_month_vs_now_returning_closest_before() {
+        PlantProgressPhoto monthOld = photo(1L, LocalDateTime.now().minusMonths(1).minusDays(2));
+        PlantProgressPhoto latest = photo(2L, LocalDateTime.now());
+        when(photoRepository.findFirstByPlantIdOrderByTakenAtDesc(PLANT_ID)).thenReturn(Optional.of(latest));
+        when(photoRepository.findClosestBefore(eq(PLANT_ID), any(LocalDateTime.class), any(Pageable.class)))
+                .thenReturn(List.of(monthOld));
+
+        Optional<PhotoProgressService.PhotoPair> pair = service.compareMonthVsNow(USER_ID, PLANT_ID);
+
+        assertThat(pair).isPresent();
+        assertThat(pair.get().before()).isEqualTo(monthOld);
+        assertThat(pair.get().after()).isEqualTo(latest);
+    }
+
+    @Test
+    void should_return_empty_when_no_photo_for_month_compare() {
+        when(photoRepository.findFirstByPlantIdOrderByTakenAtDesc(PLANT_ID)).thenReturn(Optional.empty());
+
+        assertThat(service.compareMonthVsNow(USER_ID, PLANT_ID)).isEmpty();
+    }
+
+    @Test
+    void should_compare_by_ids_ordering_by_taken_at() {
+        PlantProgressPhoto older = photo(1L, LocalDateTime.now().minusDays(30));
+        PlantProgressPhoto newer = photo(2L, LocalDateTime.now());
+        older.setPlant(plant);
+        newer.setPlant(plant);
+        when(photoRepository.findById(1L)).thenReturn(Optional.of(older));
+        when(photoRepository.findById(2L)).thenReturn(Optional.of(newer));
+
+        // Передаём в обратном порядке (left=newer, right=older) — сервис должен переставить.
+        Optional<PhotoProgressService.PhotoPair> pair =
+                service.compareByIds(USER_ID, PLANT_ID, 2L, 1L);
+
+        assertThat(pair).isPresent();
+        assertThat(pair.get().before()).isEqualTo(older);
+        assertThat(pair.get().after()).isEqualTo(newer);
+    }
+
+    @Test
+    void should_use_id_tiebreaker_when_compare_by_ids_have_equal_taken_at() {
+        LocalDateTime same = LocalDateTime.now();
+        PlantProgressPhoto smallerId = photo(1L, same);
+        PlantProgressPhoto biggerId = photo(2L, same);
+        smallerId.setPlant(plant);
+        biggerId.setPlant(plant);
+        when(photoRepository.findById(1L)).thenReturn(Optional.of(smallerId));
+        when(photoRepository.findById(2L)).thenReturn(Optional.of(biggerId));
+
+        // Передаём в обратном порядке (left=biggerId, right=smallerId) —
+        // tie-breaker по id должен поставить меньший id в "до".
+        Optional<PhotoProgressService.PhotoPair> pair =
+                service.compareByIds(USER_ID, PLANT_ID, 2L, 1L);
+
+        assertThat(pair).isPresent();
+        assertThat(pair.get().before()).isEqualTo(smallerId);
+        assertThat(pair.get().after()).isEqualTo(biggerId);
+    }
+
+    @Test
+    void should_reject_compare_by_ids_when_photo_belongs_to_another_plant() {
+        Plant otherPlant = Plant.builder().user(user).name("X").build();
+        ReflectionTestUtils.setField(otherPlant, "id", 999L);
+        PlantProgressPhoto foreign = photo(1L, LocalDateTime.now());
+        foreign.setPlant(otherPlant);
+        PlantProgressPhoto mine = photo(2L, LocalDateTime.now());
+        mine.setPlant(plant);
+        when(photoRepository.findById(1L)).thenReturn(Optional.of(foreign));
+        when(photoRepository.findById(2L)).thenReturn(Optional.of(mine));
+
+        Optional<PhotoProgressService.PhotoPair> pair =
+                service.compareByIds(USER_ID, PLANT_ID, 1L, 2L);
+
+        assertThat(pair).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_compare_by_ids_when_same_id() {
+        Optional<PhotoProgressService.PhotoPair> pair =
+                service.compareByIds(USER_ID, PLANT_ID, 5L, 5L);
+
+        assertThat(pair).isEmpty();
+        verify(photoRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    void should_return_history_with_pagination() {
+        PlantProgressPhoto photo = photo(1L, LocalDateTime.now());
+        when(photoRepository.findAllByPlantIdOrderByTakenAtDesc(eq(PLANT_ID), any(Pageable.class)))
+                .thenReturn(List.of(photo));
+
+        List<PlantProgressPhoto> page = service.getHistory(USER_ID, PLANT_ID, 0);
+
+        assertThat(page).containsExactly(photo);
+    }
+
+    @Test
+    void should_normalize_negative_page_number_in_history() {
+        when(photoRepository.findAllByPlantIdOrderByTakenAtDesc(eq(PLANT_ID), any(Pageable.class)))
+                .thenReturn(List.of());
+
+        // Не должен бросать исключение даже на отрицательной странице.
+        List<PlantProgressPhoto> page = service.getHistory(USER_ID, PLANT_ID, -5);
+
+        assertThat(page).isEmpty();
+    }
+
+    @Test
+    void should_filter_foreign_photo_in_get_photo_for_user() {
+        User other = User.builder().build();
+        ReflectionTestUtils.setField(other, "id", 999L);
+        PlantProgressPhoto p = photo(7L, LocalDateTime.now());
+        p.setUser(other);
+        when(photoRepository.findById(7L)).thenReturn(Optional.of(p));
+
+        Optional<PlantProgressPhoto> result = service.getPhotoForUser(USER_ID, 7L);
+
+        assertThat(result).isEmpty();
+    }
+
+    private PlantProgressPhoto photo(Long id, LocalDateTime takenAt) {
+        PlantProgressPhoto p = new PlantProgressPhoto();
+        ReflectionTestUtils.setField(p, "id", id);
+        p.setTakenAt(takenAt);
+        p.setPlant(plant);
+        p.setUser(user);
+        p.setTelegramFileId("file-" + id);
+        return p;
+    }
+}

--- a/src/test/java/com/plantcare/bot/state/impl/AwaitingProgressPhotoStateHandlerTest.java
+++ b/src/test/java/com/plantcare/bot/state/impl/AwaitingProgressPhotoStateHandlerTest.java
@@ -1,0 +1,293 @@
+package com.plantcare.bot.state.impl;
+
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.PlantProgressPhoto;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.ConversationState;
+import com.plantcare.bot.domain.enums.PhotoProgressFrequency;
+import com.plantcare.bot.service.PhotoProgressCardService;
+import com.plantcare.bot.service.PhotoProgressService;
+import com.plantcare.bot.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.telegram.telegrambots.meta.api.methods.AnswerCallbackQuery;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
+import org.telegram.telegrambots.meta.api.objects.photo.PhotoSize;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Unit-тесты AwaitingProgressPhotoStateHandler (issue #72)")
+class AwaitingProgressPhotoStateHandlerTest {
+
+    private static final Long USER_ID = 7L;
+    private static final Long CHAT_ID = 12345L;
+    private static final Long PLANT_ID = 42L;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private PhotoProgressService photoProgressService;
+
+    @Mock
+    private PhotoProgressCardService photoProgressCardService;
+
+    @Mock
+    private TelegramClient client;
+
+    @InjectMocks
+    private AwaitingProgressPhotoStateHandler handler;
+
+    private User user;
+    private Plant plant;
+
+    @BeforeEach
+    void setUp() {
+        Map<String, Object> stateData = new HashMap<>();
+        stateData.put(AwaitingProgressPhotoStateHandler.STATE_KEY_PLANT_ID, PLANT_ID.toString());
+
+        user = User.builder()
+                .telegramChatId(CHAT_ID)
+                .stateData(stateData)
+                .timezone("UTC")
+                .build();
+        ReflectionTestUtils.setField(user, "id", USER_ID);
+
+        plant = Plant.builder()
+                .user(user)
+                .name("Монстера")
+                .photoProgressFrequency(PhotoProgressFrequency.P2W)
+                .nextPhotoDueAt(LocalDateTime.now().plusWeeks(2))
+                .build();
+        ReflectionTestUtils.setField(plant, "id", PLANT_ID);
+    }
+
+    @Test
+    void should_return_supported_state() {
+        assertThat(handler.getSupportedState())
+                .isEqualTo(ConversationState.AWAITING_PROGRESS_PHOTO);
+    }
+
+    @Test
+    void should_save_photo_when_photo_received() throws Exception {
+        Update update = photoUpdate(
+                photoSize("small_id", 1000),
+                photoSize("big_id", 20000)
+        );
+        PlantProgressPhoto saved = new PlantProgressPhoto();
+        saved.setPlant(plant);
+        saved.setUser(user);
+        saved.setTakenAt(LocalDateTime.now());
+        when(photoProgressService.addPhoto(USER_ID, PLANT_ID, "big_id")).thenReturn(saved);
+
+        handler.handle(user, update, client);
+
+        verify(photoProgressService).addPhoto(USER_ID, PLANT_ID, "big_id");
+        verify(userService).resetToIdle(user);
+        verify(photoProgressCardService).showPhotoProgressScreen(eq(user), eq(PLANT_ID), any(), eq(client));
+    }
+
+    @Test
+    void should_send_confirmation_with_next_due_date() throws Exception {
+        Update update = photoUpdate(photoSize("file_id", 5000));
+        PlantProgressPhoto saved = new PlantProgressPhoto();
+        saved.setPlant(plant);
+        saved.setUser(user);
+        saved.setTakenAt(LocalDateTime.now());
+        when(photoProgressService.addPhoto(eq(USER_ID), eq(PLANT_ID), anyString())).thenReturn(saved);
+
+        handler.handle(user, update, client);
+
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(client).execute(captor.capture());
+
+        assertThat(captor.getValue().getText())
+                .contains("Фото добавлено")
+                .contains("Следующее напоминание");
+    }
+
+    @Test
+    void should_send_short_confirmation_when_frequency_off() throws Exception {
+        plant.setPhotoProgressFrequency(PhotoProgressFrequency.OFF);
+        plant.setNextPhotoDueAt(null);
+        PlantProgressPhoto saved = new PlantProgressPhoto();
+        saved.setPlant(plant);
+        saved.setUser(user);
+        saved.setTakenAt(LocalDateTime.now());
+        Update update = photoUpdate(photoSize("file_id", 5000));
+        when(photoProgressService.addPhoto(eq(USER_ID), eq(PLANT_ID), anyString())).thenReturn(saved);
+
+        handler.handle(user, update, client);
+
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(client).execute(captor.capture());
+
+        assertThat(captor.getValue().getText())
+                .contains("Фото добавлено")
+                .doesNotContain("Следующее напоминание");
+    }
+
+    @Test
+    void should_show_hint_when_text_received() throws Exception {
+        Update update = textUpdate("какой-то текст");
+
+        handler.handle(user, update, client);
+
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(client).execute(captor.capture());
+
+        assertThat(captor.getValue().getText())
+                .contains("Пришли фото");
+        verify(photoProgressService, never()).addPhoto(anyLong(), anyLong(), anyString());
+        verify(userService, never()).resetToIdle(any());
+    }
+
+    @Test
+    void should_reset_state_and_open_screen_on_cancel_callback() throws Exception {
+        Update update = callbackUpdate("PHOTO_PROGRESS:CANCEL");
+
+        handler.handle(user, update, client);
+
+        verify(client).execute(any(AnswerCallbackQuery.class));
+        verify(userService).resetToIdle(user);
+        verify(photoProgressCardService).showPhotoProgressScreen(eq(user), eq(PLANT_ID), any(), eq(client));
+        verify(photoProgressService, never()).addPhoto(anyLong(), anyLong(), anyString());
+    }
+
+    @Test
+    void should_ignore_unknown_callback_without_resetting_state() throws Exception {
+        Update update = callbackUpdate("SOMETHING:ELSE");
+
+        handler.handle(user, update, client);
+
+        verify(client).execute(any(AnswerCallbackQuery.class));
+        verify(userService, never()).resetToIdle(any());
+        verifyNoInteractions(photoProgressCardService);
+    }
+
+    @Test
+    void should_send_error_when_anti_spam_violated() throws Exception {
+        Update update = photoUpdate(photoSize("file_id", 5000));
+        when(photoProgressService.addPhoto(eq(USER_ID), eq(PLANT_ID), anyString()))
+                .thenThrow(new IllegalStateException("Уже есть фото за последние 24 часа"));
+
+        handler.handle(user, update, client);
+
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(client, org.mockito.Mockito.atLeastOnce()).execute(captor.capture());
+
+        assertThat(captor.getAllValues())
+                .extracting(SendMessage::getText)
+                .anyMatch(t -> t.contains("24 часа"));
+        verify(userService).resetToIdle(user);
+        verify(photoProgressCardService).showPhotoProgressScreen(eq(user), eq(PLANT_ID), any(), eq(client));
+    }
+
+    @Test
+    void should_send_error_when_plant_not_found() throws Exception {
+        Update update = photoUpdate(photoSize("file_id", 5000));
+        when(photoProgressService.addPhoto(eq(USER_ID), eq(PLANT_ID), anyString()))
+                .thenThrow(new IllegalArgumentException("Plant not found"));
+
+        handler.handle(user, update, client);
+
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(client).execute(captor.capture());
+
+        assertThat(captor.getValue().getText()).contains("Растение не найдено");
+        verify(userService).resetToIdle(user);
+        verifyNoInteractions(photoProgressCardService);
+    }
+
+    @Test
+    void should_reset_to_idle_when_plant_id_missing_in_state_data() throws Exception {
+        user.getStateData().clear();
+        Update update = photoUpdate(photoSize("file_id", 5000));
+
+        handler.handle(user, update, client);
+
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(client).execute(captor.capture());
+
+        assertThat(captor.getValue().getText()).contains("контекст");
+        verify(userService).resetToIdle(user);
+        verify(photoProgressService, never()).addPhoto(anyLong(), anyLong(), anyString());
+    }
+
+    @Test
+    void should_show_hint_when_photo_message_has_no_photo_size() throws Exception {
+        Update update = new Update();
+        Message message = new Message();
+        // Photo with empty list — hasPhoto() returns false, so handler falls through to hint.
+        message.setPhoto(List.of());
+        update.setMessage(message);
+
+        handler.handle(user, update, client);
+
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(client).execute(captor.capture());
+        assertThat(captor.getValue().getText()).contains("Пришли фото");
+    }
+
+    // ---- helpers ----
+
+    private Update textUpdate(String text) {
+        Update update = new Update();
+        Message message = new Message();
+        message.setText(text);
+        update.setMessage(message);
+        return update;
+    }
+
+    private Update callbackUpdate(String data) {
+        Update update = new Update();
+        CallbackQuery callbackQuery = new CallbackQuery();
+        callbackQuery.setId("cb-id");
+        callbackQuery.setData(data);
+        update.setCallbackQuery(callbackQuery);
+        return update;
+    }
+
+    private Update photoUpdate(PhotoSize... sizes) {
+        Update update = new Update();
+        Message message = new Message();
+        message.setPhoto(List.of(sizes));
+        update.setMessage(message);
+        return update;
+    }
+
+    private PhotoSize photoSize(String fileId, Integer fileSize) {
+        PhotoSize p = new PhotoSize();
+        p.setFileId(fileId);
+        p.setFileSize(fileSize);
+        return p;
+    }
+}


### PR DESCRIPTION
Closes #72

## Что сделано

- Per-plant настройка «Фото-прогресс» (Выкл / Раз в 2 недели / Раз в месяц), дефолт OFF
- Кнопка «📸 Фото-прогресс» в карточке растения + новый экран с настройками, историей и сравнением
- Hourly scheduler `PhotoProgressSchedulerService` шлёт пуш «обнови фото» когда `next_photo_due_at` пришёл, респектит `users.paused_until` / `users.blocked`
- Антиспам: не более 1 фото за 24ч (`existsByPlantIdAndTakenAtAfter`)
- После отправки пуша `next_photo_due_at` сдвигается на полный период — без спама если юзер игнорит
- Сравнение фото: «Первое vs Последнее», «Месяц назад vs Сейчас», «Выбрать две даты» (с id как tie-breaker)
- История фото с пагинацией (10/страница)
- `AwaitingProgressPhotoStateHandler` принимает фото, обрабатывает cancel, валидирует контекст

## Миграции

`V16__add_photo_progress.sql`:
- 3 колонки на `plants`: `photo_progress_frequency` (CHECK), `next_photo_due_at`, `last_photo_prompt_sent_at`
- Новая таблица `plant_progress_photos` (id, plant_id, user_id, telegram_file_id, taken_at, caption, created_at)
- Partial index `idx_plants_next_photo_due` для шедулера, индекс на `(plant_id, taken_at DESC)` для истории

> **Примечание о нумерации:** V14 зарезервирована feature_flags в develop (issue #78), V15 — за PR #107 (issue #86). V16 здесь выбран сознательно для bezопасного merge order.

## Backward-compat риски

Safe. `photo_progress_frequency` NOT NULL с DEFAULT 'OFF' — Postgres заполнит дефолт. Остальные колонки nullable, таблица новая.

## Тесты

35 новых тестов:
- `PhotoProgressServiceTest` (21): setFrequency / addPhoto / skipPrompt / compareFirstVsLast / compareMonthVsNow / compareByIds (включая tie-breaker по id при равных takenAt), антиспам 24ч, ownership-проверки
- `AwaitingProgressPhotoStateHandlerTest` (11): photo / text / cancel callback / антиспам / отсутствие plantId
- `PhotoProgressSchedulerServiceTest` (4): happy path, isPaused, isBlocked, TelegramApiException на одном растении не ломает остальные

`mvn verify` зелёный — 585 тестов, 0 failures, 0 errors.

## Чек

- [x] `mvn verify` зелёное
- [x] reviewer прошёл (4 блокирующих исправлено: @Transactional вокруг Telegram API убран, scheduler retry-spam пофикшен, шедулер покрыт тестами, JOIN FETCH user добавлен)
- [x] SHOULD-FIX приняты: N+1 (JOIN FETCH), id tie-breaker в compareByIds
- [ ] Принятые SHOULD-FIX в backlog: переход TIMESTAMP → TIMESTAMPTZ (проектный долг), Telegram-блокировка → user.setBlocked(true), уникальный составной индекс для гонки в addPhoto

### Запуск тестов

В worktree нет `./mvnw`. Использовался системный `mvn`:
```bash
TESTCONTAINERS_REUSE_ENABLE=false JAVA_HOME=.../Corretto-21 mvn verify
```
Reuse=false требуется из-за stale-контейнера на dev-машине с V14 от develop (никак не связано с этим PR; в CI на свежем контейнере reuse не помешает).