### PR TITLE
feat: calendar .ics export with public subscription URL (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Rate limit: 5 неудачных попыток в минуту с IP → 429 н
 4. Открыть настройки сервиса приложения → **Variables**:
    - Скопировать `Reference` для `${{Postgres.PGHOST}}`, `${{Postgres.PGPORT}}`, `${{Postgres.PGDATABASE}}`, `${{Postgres.PGUSER}}`, `${{Postgres.PGPASSWORD}}` — Railway сам подставит реальные значения
    - Добавить `TELEGRAM_BOT_TOKEN`, `TELEGRAM_BOT_USERNAME`, `TELEGRAM_BOT_ENABLED=true` — когда дойдём до интеграции с ботом
+   - Добавить `CALENDAR_BASE_URL` — внешний https-URL приложения (например, `https://plants-care-production.up.railway.app`). Используется для построения ссылок `/calendar/{token}.ics`. Дефолт `https://example.com` для прода не годится.
 5. Включить **Public Networking** в Settings → получишь URL вида `plants-care-production.up.railway.app`
 6. Дождаться завершения первой сборки
 

--- a/src/main/java/com/plantcare/bot/PlantsCareApplication.java
+++ b/src/main/java/com/plantcare/bot/PlantsCareApplication.java
@@ -1,17 +1,30 @@
 package com.plantcare.bot;
 
+import com.plantcare.bot.config.CalendarProperties;
+import com.plantcare.bot.config.SpeciesProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableScheduling;
-import com.plantcare.bot.config.SpeciesProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.time.Clock;
 
 @SpringBootApplication
 @EnableScheduling
-@EnableConfigurationProperties(SpeciesProperties.class)
+@EnableConfigurationProperties({SpeciesProperties.class, CalendarProperties.class})
 public class PlantsCareApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(PlantsCareApplication.class, args);
+    }
+
+    /**
+     * Issue #79: единый источник времени для сервисов, чтобы тесты могли
+     * подменять Clock. Все продакшен-вычисления времени должны идти через {@code clock.instant()}.
+     */
+    @Bean
+    public Clock clock() {
+        return Clock.systemUTC();
     }
 }

--- a/src/main/java/com/plantcare/bot/config/CalendarProperties.java
+++ b/src/main/java/com/plantcare/bot/config/CalendarProperties.java
@@ -1,0 +1,27 @@
+package com.plantcare.bot.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Issue #79: настройки публичной .ics подписки.
+ *
+ * <ul>
+ *   <li>{@code baseUrl} — внешний хост приложения для построения ссылки вида
+ *       {@code https://<host>/calendar/{token}.ics}. На прод задаётся через
+ *       env {@code CALENDAR_BASE_URL}.</li>
+ *   <li>{@code eventWindowDays} — окно вперёд от {@code now()}, в пределах которого
+ *       расписания превращаются в события календаря. По AC issue #79 — 90 дней.</li>
+ * </ul>
+ */
+@ConfigurationProperties(prefix = "app.calendar")
+public record CalendarProperties(String baseUrl, int eventWindowDays) {
+
+    public CalendarProperties {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            baseUrl = "https://example.com";
+        }
+        if (eventWindowDays <= 0) {
+            eventWindowDays = 90;
+        }
+    }
+}

--- a/src/main/java/com/plantcare/bot/controller/api/CalendarController.java
+++ b/src/main/java/com/plantcare/bot/controller/api/CalendarController.java
@@ -1,0 +1,42 @@
+package com.plantcare.bot.controller.api;
+
+import com.plantcare.bot.service.CalendarExportService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Issue #79: публичная точка для подписки на .ics календарь.
+ *
+ * <p>URL вида {@code GET /calendar/{token}.ics} — Read-Only, без авторизации
+ * (резолв по токену). Все задачи рендерятся как All-Day события.
+ *
+ * <p>Маршрут не под {@code /admin/**}, поэтому подпадает под default
+ * SecurityFilterChain с {@code permitAll}.
+ */
+@RestController
+@RequiredArgsConstructor
+public class CalendarController {
+
+    private final CalendarExportService calendarExportService;
+
+    @GetMapping(value = "/calendar/{token}.ics", produces = "text/calendar; charset=utf-8")
+    public ResponseEntity<String> getCalendar(@PathVariable String token) {
+        String ics = calendarExportService.buildIcsForToken(token);
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("text/calendar; charset=utf-8"))
+                .header(HttpHeaders.CACHE_CONTROL, "no-cache, must-revalidate")
+                .body(ics);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<Void> handleNotFound(EntityNotFoundException e) {
+        return ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/plantcare/bot/domain/User.java
+++ b/src/main/java/com/plantcare/bot/domain/User.java
@@ -66,6 +66,14 @@ public class User extends BaseEntity {
     @Builder.Default
     private boolean blocked = false;
 
+    /**
+     * Issue #79: opaque token for public .ics calendar URL.
+     * NULL until first calendar export request — generated lazily by {@link com.plantcare.bot.service.CalendarService}.
+     * Uniqueness enforced by partial unique index {@code idx_users_calendar_token} (see V14 migration).
+     */
+    @Column(name = "calendar_token", length = 64, unique = true)
+    private String calendarToken;
+
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;

--- a/src/main/java/com/plantcare/bot/repository/CareScheduleRepository.java
+++ b/src/main/java/com/plantcare/bot/repository/CareScheduleRepository.java
@@ -117,4 +117,26 @@ public interface CareScheduleRepository extends JpaRepository<CareSchedule, Long
             @Param("locationId") Long locationId,
             @Param("taskType") TaskType taskType
     );
+
+    /**
+     * Issue #79: активные расписания пользователя с {@code nextDueAt} в полуоткрытом
+     * окне {@code [from; to)} — используются для экспорта в .ics календарь.
+     * JOIN FETCH plant, чтобы избежать N+1 при рендере событий, так как
+     * read-only транзакция закроется до возврата ICS наружу.
+     */
+    @Query("""
+        SELECT s FROM CareSchedule s
+        JOIN FETCH s.plant p
+        WHERE p.user.id = :userId
+          AND p.archivedAt IS NULL
+          AND s.active = true
+          AND s.nextDueAt >= :from
+          AND s.nextDueAt < :to
+        ORDER BY s.nextDueAt ASC
+        """)
+    List<CareSchedule> findUpcomingForUser(
+            @Param("userId") Long userId,
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to
+    );
 }

--- a/src/main/java/com/plantcare/bot/repository/UserRepository.java
+++ b/src/main/java/com/plantcare/bot/repository/UserRepository.java
@@ -1,7 +1,9 @@
 package com.plantcare.bot.repository;
 
 import com.plantcare.bot.domain.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,6 +17,18 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByTelegramChatId(Long telegramChatId);
 
     Optional<User> findByTelegramChatId(Long telegramChatId);
+
+    /** Issue #79: lookup for public {@code GET /calendar/{token}.ics}. */
+    Optional<User> findByCalendarToken(String calendarToken);
+
+    /**
+     * Issue #79: pessimistic SELECT FOR UPDATE used during lazy calendar-token
+     * generation, чтобы два параллельных нажатия на кнопку «Экспорт» не
+     * сгенерили два разных токена для одного юзера.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT u FROM User u WHERE u.id = :id")
+    Optional<User> findByIdForUpdate(@Param("id") Long id);
 
     @Modifying
     @Query(value = """

--- a/src/main/java/com/plantcare/bot/service/CalendarExportService.java
+++ b/src/main/java/com/plantcare/bot/service/CalendarExportService.java
@@ -1,0 +1,182 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.config.CalendarProperties;
+import com.plantcare.bot.domain.CareSchedule;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.repository.CareScheduleRepository;
+import com.plantcare.bot.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Issue #79: экспорт расписаний пользователя в .ics-календарь
+ * (Read-Only subscription, All-Day events).
+ *
+ * <p>Ответственности:
+ * <ul>
+ *   <li>Лениво генерит и сохраняет уникальный {@code calendar_token} в {@link User}.</li>
+ *   <li>Резолвит токен в пользователя и рендерит .ics со всеми его расписаниями
+ *       на ближайшие {@link CalendarProperties#eventWindowDays()} дней.</li>
+ *   <li>Строит публичную URL вида {@code https://<host>/calendar/{token}.ics}.</li>
+ * </ul>
+ *
+ * <p>RRULE не используем: каждое {@link CareSchedule#getNextDueAt() nextDueAt}
+ * проецируется ровно в одно VEVENT.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CalendarExportService {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    /** 32 случайных байта -> 43 символа URL-safe base64 без паддинга. Помещается в VARCHAR(64). */
+    private static final int TOKEN_BYTES = 32;
+
+    private static final DateTimeFormatter ICS_DT_STAMP =
+            DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'");
+    private static final DateTimeFormatter ICS_DATE = DateTimeFormatter.BASIC_ISO_DATE;
+
+    private final UserRepository userRepository;
+    private final CareScheduleRepository careScheduleRepository;
+    private final CalendarProperties calendarProperties;
+    private final Clock clock;
+
+    /**
+     * Возвращает уже сохранённый токен пользователя либо генерирует, сохраняет и возвращает новый.
+     * Транзакция должна закрыться до отправки сообщения в Telegram.
+     *
+     * <p>Берёт row-lock на запись юзера, чтобы при двух параллельных нажатиях
+     * на кнопку второй вызов увидел уже сгенерированный первым токен и не
+     * перезаписал его новым значением.
+     */
+    @Transactional
+    public String getOrCreateToken(User user) {
+        User locked = userRepository.findByIdForUpdate(user.getId())
+                .orElseThrow(() -> new EntityNotFoundException("User not found: " + user.getId()));
+        if (locked.getCalendarToken() != null) {
+            return locked.getCalendarToken();
+        }
+        String token = generateToken();
+        locked.setCalendarToken(token);
+        userRepository.save(locked);
+        log.info("Generated calendar token for userId={}", locked.getId());
+        return token;
+    }
+
+    /**
+     * Резолвит токен и рендерит ICS на ближайшие {@link CalendarProperties#eventWindowDays()} дней.
+     * Бросает {@link EntityNotFoundException}, если токен не найден — контроллер маппит в 404.
+     */
+    @Transactional(readOnly = true)
+    public String buildIcsForToken(String token) {
+        User user = userRepository.findByCalendarToken(token)
+                .orElseThrow(() -> new EntityNotFoundException("Calendar token not found"));
+
+        LocalDateTime from = LocalDateTime.now(clock);
+        LocalDateTime to = from.plusDays(calendarProperties.eventWindowDays());
+
+        List<CareSchedule> schedules = careScheduleRepository.findUpcomingForUser(user.getId(), from, to);
+
+        log.debug("Rendering ICS for userId={} events={}", user.getId(), schedules.size());
+        return renderIcs(schedules);
+    }
+
+    /** Полный публичный URL подписки. */
+    public String buildCalendarUrl(String token) {
+        return calendarProperties.baseUrl() + "/calendar/" + token + ".ics";
+    }
+
+    private String generateToken() {
+        byte[] bytes = new byte[TOKEN_BYTES];
+        RANDOM.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private String renderIcs(List<CareSchedule> schedules) {
+        String dtStamp = LocalDateTime.now(clock).atOffset(ZoneOffset.UTC).format(ICS_DT_STAMP);
+
+        StringBuilder sb = new StringBuilder(256 + schedules.size() * 256);
+        sb.append("BEGIN:VCALENDAR\r\n");
+        sb.append("VERSION:2.0\r\n");
+        sb.append("PRODID:-//PlantsCare//Bot Calendar//EN\r\n");
+        sb.append("CALSCALE:GREGORIAN\r\n");
+        sb.append("METHOD:PUBLISH\r\n");
+        sb.append("X-WR-CALNAME:")
+                .append(escapeIcsText("Plants Care — уход за растениями"))
+                .append("\r\n");
+
+        for (CareSchedule schedule : schedules) {
+            appendVEvent(sb, schedule, dtStamp);
+        }
+
+        sb.append("END:VCALENDAR\r\n");
+        return sb.toString();
+    }
+
+    private void appendVEvent(StringBuilder sb, CareSchedule schedule, String dtStamp) {
+        LocalDate eventDate = schedule.getNextDueAt().toLocalDate();
+        String dtStart = eventDate.format(ICS_DATE);
+        String dtEnd = eventDate.plusDays(1).format(ICS_DATE);
+
+        String summary = taskTypeSummary(schedule.getTaskType()) + " " + schedule.getPlant().getName();
+        String description = taskTypeDescription(schedule.getTaskType());
+
+        sb.append("BEGIN:VEVENT\r\n");
+        sb.append("UID:plants-care-schedule-").append(schedule.getId()).append("@plants-care\r\n");
+        sb.append("DTSTAMP:").append(dtStamp).append("\r\n");
+        sb.append("DTSTART;VALUE=DATE:").append(dtStart).append("\r\n");
+        sb.append("DTEND;VALUE=DATE:").append(dtEnd).append("\r\n");
+        sb.append("SUMMARY:").append(escapeIcsText(summary)).append("\r\n");
+        sb.append("DESCRIPTION:").append(escapeIcsText(description)).append("\r\n");
+        sb.append("TRANSP:TRANSPARENT\r\n");
+        sb.append("END:VEVENT\r\n");
+    }
+
+    /**
+     * Экранирует спецсимволы по RFC 5545 §3.3.11.
+     * Порядок важен: сначала бэкслеш, потом всё остальное.
+     */
+    static String escapeIcsText(String s) {
+        if (s == null) {
+            return "";
+        }
+        return s.replace("\\", "\\\\")
+                .replace(";", "\\;")
+                .replace(",", "\\,")
+                .replace("\r\n", "\\n")
+                .replace("\n", "\\n")
+                .replace("\r", "\\n");
+    }
+
+    private static String taskTypeSummary(TaskType type) {
+        return switch (type) {
+            case WATERING -> "💧 Полив";
+            case MISTING -> "💨 Опрыскивание";
+            case FERTILIZING -> "🌱 Удобрение";
+            case SOIL_CHECK -> "🌍 Проверка грунта";
+        };
+    }
+
+    private static String taskTypeDescription(TaskType type) {
+        return switch (type) {
+            case WATERING -> "Время полить растение";
+            case MISTING -> "Время опрыскать листья";
+            case FERTILIZING -> "Время удобрить";
+            case SOIL_CHECK -> "Проверить влажность грунта";
+        };
+    }
+}

--- a/src/main/java/com/plantcare/bot/service/MenuCallbackService.java
+++ b/src/main/java/com/plantcare/bot/service/MenuCallbackService.java
@@ -41,6 +41,7 @@ public class MenuCallbackService {
     private final PlantMenuService plantMenuService;
     private final PlantCardService plantCardService;
     private final CalendarMenuService calendarMenuService;
+    private final CalendarExportService calendarExportService;
     private final PlantTemplateService plantTemplateService;
     private final NotificationCallbackService notificationCallbackService;
     private final PlantEventService plantEventService;
@@ -176,6 +177,11 @@ public class MenuCallbackService {
             case "CHANGE_TZ" -> {
                 userService.updateState(user, ConversationState.AWAITING_TIMEZONE);
                 sendTimezonePrompt(user, client);
+                answerCallback(client, callbackId, "");
+            }
+
+            case "CALENDAR_EXPORT" -> {
+                sendCalendarExport(user, client);
                 answerCallback(client, callbackId, "");
             }
 
@@ -1128,6 +1134,12 @@ public class MenuCallbackService {
                 )))
                 .keyboardRow(new InlineKeyboardRow(List.of(
                         InlineKeyboardButton.builder()
+                                .text("📅 Экспорт в календарь")
+                                .callbackData("MENU:CALENDAR_EXPORT")
+                                .build()
+                )))
+                .keyboardRow(new InlineKeyboardRow(List.of(
+                        InlineKeyboardButton.builder()
                                 .text("⬅️ Назад")
                                 .callbackData("MENU:BACK")
                                 .build()
@@ -1150,6 +1162,48 @@ public class MenuCallbackService {
             client.execute(message);
         } catch (TelegramApiException e) {
             log.error("Failed to send settings menu", e);
+        }
+    }
+
+    /**
+     * Issue #79: показывает пользователю публичный URL подписки на .ics календарь.
+     * Сначала вне Telegram-вызова получаем/создаём токен (внутри собственной транзакции
+     * {@code CalendarExportService.getOrCreateToken}), потом строим URL и шлём сообщение.
+     */
+    private void sendCalendarExport(User user, TelegramClient client) {
+        String token = calendarExportService.getOrCreateToken(user);
+        String url = calendarExportService.buildCalendarUrl(token);
+
+        String text = """
+                📅 *Экспорт в календарь*
+
+                Скопируй эту ссылку и подпишись на неё в Google/Apple календаре:
+
+                `%s`
+
+                Календарь обновляется автоматически. Задачи на ближайшие 90 дней показаны как события на весь день.
+                """.formatted(url);
+
+        InlineKeyboardMarkup keyboard = InlineKeyboardMarkup.builder()
+                .keyboardRow(new InlineKeyboardRow(List.of(
+                        InlineKeyboardButton.builder()
+                                .text("⬅️ Назад в настройки")
+                                .callbackData("MENU:SETTINGS")
+                                .build()
+                )))
+                .build();
+
+        SendMessage message = SendMessage.builder()
+                .chatId(user.getTelegramChatId().toString())
+                .text(text)
+                .parseMode("Markdown")
+                .replyMarkup(keyboard)
+                .build();
+
+        try {
+            client.execute(message);
+        } catch (TelegramApiException e) {
+            log.error("Failed to send calendar export menu", e);
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,11 @@ app:
   species:
     search-limit: 5
 
+  # Issue #79: публичная подписка на .ics календарь.
+  calendar:
+    base-url: ${CALENDAR_BASE_URL:https://example.com}
+    event-window-days: 90
+
   jpa:
     open-in-view: false
     hibernate:

--- a/src/main/resources/db/migration/V14__add_users_calendar_token.sql
+++ b/src/main/resources/db/migration/V14__add_users_calendar_token.sql
@@ -1,0 +1,33 @@
+-- V14__add_users_calendar_token.sql
+-- Issue #79: per-user calendar (.ics) export.
+-- Add a nullable opaque token used to resolve a user from a public calendar URL
+-- (GET /calendar/{token}.ics). Token is generated lazily on first export request
+-- and persisted; until then the column stays NULL.
+--
+-- Backward-compat note:
+--   * Column is NULLABLE with no DEFAULT -> existing INSERTs into users keep working
+--     without touching this column. Old code that does not know about
+--     calendar_token continues to function unchanged.
+--   * Reads from users by old code are unaffected (no SELECT * contracts changed
+--     in a breaking way; column is additive).
+--   * Safe for rolling deploy: this migration can be applied before the new
+--     application version is rolled out.
+
+BEGIN;
+
+ALTER TABLE users
+    ADD COLUMN calendar_token VARCHAR(64);
+
+COMMENT ON COLUMN users.calendar_token IS
+    'Opaque random token for public .ics calendar URL. NULL until first calendar export request; generated lazily by the service. Unique when set.';
+
+-- Partial unique index:
+--   * uniqueness only enforced for non-NULL tokens (most users will have NULL
+--     until they explicitly request their calendar URL);
+--   * primary lookup: SELECT user_id FROM users WHERE calendar_token = ?
+--     during /calendar/{token}.ics resolution.
+CREATE UNIQUE INDEX idx_users_calendar_token
+    ON users (calendar_token)
+    WHERE calendar_token IS NOT NULL;
+
+COMMIT;

--- a/src/test/java/com/plantcare/bot/controller/api/CalendarControllerIT.java
+++ b/src/test/java/com/plantcare/bot/controller/api/CalendarControllerIT.java
@@ -1,0 +1,124 @@
+package com.plantcare.bot.controller.api;
+
+import com.plantcare.bot.domain.CareSchedule;
+import com.plantcare.bot.domain.Location;
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.repository.CareScheduleRepository;
+import com.plantcare.bot.repository.LocationRepository;
+import com.plantcare.bot.repository.PlantRepository;
+import com.plantcare.bot.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Полный end-to-end smoke-тест публичного маршрута {@code GET /calendar/{token}.ics}:
+ * реальный embedded web-server, реальный PostgreSQL (Testcontainers), реальный Spring Security
+ * default chain ({@code permitAll}).
+ *
+ * <p>Используем собственный контейнер (а не {@link com.plantcare.bot.support.IntegrationTestBase})
+ * чтобы получить {@code RANDOM_PORT} веб-окружение — IntegrationTestBase его не объявляет.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("E2E smoke: GET /calendar/{token}.ics")
+class CalendarControllerIT {
+
+    private static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("plants_care_test")
+                    .withUsername("test")
+                    .withPassword("test")
+                    .withReuse(true);
+
+    static {
+        POSTGRES.start();
+    }
+
+    @DynamicPropertySource
+    static void configureDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+    }
+
+    @Autowired private TestRestTemplate restTemplate;
+    @Autowired private UserRepository userRepository;
+    @Autowired private LocationRepository locationRepository;
+    @Autowired private PlantRepository plantRepository;
+    @Autowired private CareScheduleRepository careScheduleRepository;
+
+    @AfterEach
+    void cleanup() {
+        careScheduleRepository.deleteAll();
+        plantRepository.deleteAll();
+        locationRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("Happy path: создаём юзера+растение+расписание → GET выдаёт 200 text/calendar с VEVENT")
+    void should_serve_real_ics_end_to_end() {
+        User user = userRepository.save(User.builder()
+                .telegramChatId(700L)
+                .calendarToken("e2e-token-happy")
+                .build());
+
+        Location location = locationRepository.save(Location.builder()
+                .user(user)
+                .name(Location.DEFAULT_NAME)
+                .emoji(Location.DEFAULT_EMOJI)
+                .defaultLocation(true)
+                .build());
+
+        Plant plant = plantRepository.save(Plant.builder()
+                .user(user)
+                .location(location)
+                .name("Монстера E2E")
+                .build());
+
+        careScheduleRepository.save(CareSchedule.builder()
+                .plant(plant)
+                .taskType(TaskType.WATERING)
+                .intervalDays(7)
+                .nextDueAt(LocalDateTime.now().plusDays(7).truncatedTo(ChronoUnit.MICROS))
+                .active(true)
+                .build());
+
+        ResponseEntity<String> response = restTemplate.getForEntity(
+                "/calendar/e2e-token-happy.ics", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getContentType())
+                .as("Content-Type должен быть text/calendar")
+                .isNotNull();
+        assertThat(response.getHeaders().getContentType().toString())
+                .startsWith("text/calendar");
+
+        String body = response.getBody();
+        assertThat(body)
+                .isNotNull()
+                .contains("BEGIN:VCALENDAR")
+                .contains("END:VCALENDAR")
+                .contains("BEGIN:VEVENT")
+                .contains("Монстера E2E");
+    }
+}

--- a/src/test/java/com/plantcare/bot/controller/api/CalendarControllerTest.java
+++ b/src/test/java/com/plantcare/bot/controller/api/CalendarControllerTest.java
@@ -1,0 +1,81 @@
+package com.plantcare.bot.controller.api;
+
+import com.plantcare.bot.service.CalendarExportService;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Web-слайс тесты {@link CalendarController}.
+ *
+ * <p>{@code addFilters = false} убирает Spring Security filter chain — нам нужно проверить
+ * только контроллер: маппинг URL, заголовки, маппинг {@link EntityNotFoundException} в 404.
+ * Реальный security (открыт через default chain) проверяется в {@link CalendarControllerIT}.
+ */
+@WebMvcTest(controllers = CalendarController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("Web-слайс CalendarController — выдача .ics")
+class CalendarControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private CalendarExportService calendarExportService;
+
+    @Test
+    @DisplayName("200 OK + Content-Type text/calendar и тело ICS из сервиса")
+    void should_return_200_with_text_calendar_content_type() throws Exception {
+        String ics = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nEND:VCALENDAR\r\n";
+        when(calendarExportService.buildIcsForToken("abc123")).thenReturn(ics);
+
+        mockMvc.perform(get("/calendar/abc123.ics"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("text/calendar;charset=utf-8"))
+                .andExpect(content().string(ics));
+    }
+
+    @Test
+    @DisplayName("Заголовок Cache-Control запрещает кэширование подписок")
+    void should_return_cache_control_header() throws Exception {
+        when(calendarExportService.buildIcsForToken("xyz"))
+                .thenReturn("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n");
+
+        mockMvc.perform(get("/calendar/xyz.ics"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Cache-Control", "no-cache, must-revalidate"));
+    }
+
+    @Test
+    @DisplayName("404 Not Found, если сервис кидает EntityNotFoundException")
+    void should_return_404_when_token_unknown() throws Exception {
+        when(calendarExportService.buildIcsForToken("nope"))
+                .thenThrow(new EntityNotFoundException("Calendar token not found"));
+
+        mockMvc.perform(get("/calendar/nope.ics"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("В сервис прокидывается ровно тот токен, что в URL")
+    void should_serve_ics_at_token_url() throws Exception {
+        when(calendarExportService.buildIcsForToken("path-token-123"))
+                .thenReturn("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n");
+
+        mockMvc.perform(get("/calendar/path-token-123.ics"))
+                .andExpect(status().isOk());
+
+        verify(calendarExportService).buildIcsForToken(eq("path-token-123"));
+    }
+}

--- a/src/test/java/com/plantcare/bot/service/CalendarExportServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/CalendarExportServiceTest.java
@@ -1,0 +1,344 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.CareSchedule;
+import com.plantcare.bot.domain.Location;
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.repository.CareScheduleRepository;
+import com.plantcare.bot.repository.LocationRepository;
+import com.plantcare.bot.repository.PlantRepository;
+import com.plantcare.bot.repository.UserRepository;
+import com.plantcare.bot.support.IntegrationTestBase;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Интеграционные тесты CalendarExportService — экспорт расписаний в .ics")
+@TestPropertySource(properties = {
+        "app.calendar.base-url=https://test.local",
+        "app.calendar.event-window-days=90",
+        // FixedClockConfig переопределяет продакшен-бин Clock из PlantsCareApplication
+        "spring.main.allow-bean-definition-overriding=true"
+})
+@Import(CalendarExportServiceTest.FixedClockConfig.class)
+class CalendarExportServiceTest extends IntegrationTestBase {
+
+    /**
+     * Фиксированный момент времени: 2026-05-23T10:00:00Z. Все события считаются от него.
+     */
+    static final Instant FIXED_NOW = Instant.parse("2026-05-23T10:00:00Z");
+
+    @TestConfiguration
+    static class FixedClockConfig {
+        @Bean
+        @Primary
+        Clock clock() {
+            return Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+        }
+    }
+
+    @Autowired private CalendarExportService calendarExportService;
+    @Autowired private UserRepository userRepository;
+    @Autowired private LocationRepository locationRepository;
+    @Autowired private PlantRepository plantRepository;
+    @Autowired private CareScheduleRepository careScheduleRepository;
+
+    @AfterEach
+    void cleanup() {
+        careScheduleRepository.deleteAll();
+        plantRepository.deleteAll();
+        locationRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ==================== getOrCreateToken ====================
+
+    @Test
+    @DisplayName("getOrCreateToken: генерирует токен у пользователя без него и сохраняет в БД")
+    void should_generate_new_token_when_user_has_none() {
+        User user = userRepository.save(User.builder()
+                .telegramChatId(500L)
+                .build());
+
+        String token = calendarExportService.getOrCreateToken(user);
+
+        assertThat(token)
+                .isNotNull()
+                .hasSize(43)            // 32 байта в URL-safe base64 без паддинга = 43 символа
+                .matches("[A-Za-z0-9_-]+");
+
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(reloaded.getCalendarToken()).isEqualTo(token);
+    }
+
+    @Test
+    @DisplayName("getOrCreateToken: возвращает существующий токен, не меняя значение")
+    void should_return_existing_token_when_user_already_has_one() {
+        User user = userRepository.save(User.builder()
+                .telegramChatId(501L)
+                .calendarToken("preexisting-token-value")
+                .build());
+
+        String token = calendarExportService.getOrCreateToken(user);
+
+        assertThat(token).isEqualTo("preexisting-token-value");
+
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(reloaded.getCalendarToken()).isEqualTo("preexisting-token-value");
+    }
+
+    // ==================== buildIcsForToken ====================
+
+    @Test
+    @DisplayName("buildIcsForToken: незнакомый токен → EntityNotFoundException")
+    void should_throw_when_token_not_found() {
+        assertThatThrownBy(() -> calendarExportService.buildIcsForToken("nonexistent"))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("Calendar token not found");
+    }
+
+    // ==================== buildCalendarUrl ====================
+
+    @Test
+    @DisplayName("buildCalendarUrl: URL собирается из base-url, токена и .ics")
+    void should_build_calendar_url() {
+        String url = calendarExportService.buildCalendarUrl("abc");
+
+        assertThat(url).isEqualTo("https://test.local/calendar/abc.ics");
+    }
+
+    // ==================== Рендер ICS — обёртка VCALENDAR ====================
+
+    @Test
+    @DisplayName("ICS содержит обязательную обёртку VCALENDAR (BEGIN/VERSION/PRODID/END)")
+    void should_render_ics_with_vcalendar_envelope() {
+        User user = saveUserWithToken("token-vcal");
+        Plant plant = savePlant(user, "Монстера");
+        saveSchedule(plant, TaskType.WATERING,
+                LocalDateTime.ofInstant(FIXED_NOW, ZoneOffset.UTC).plusDays(7));
+
+        String ics = calendarExportService.buildIcsForToken("token-vcal");
+
+        assertThat(ics)
+                .contains("BEGIN:VCALENDAR")
+                .contains("VERSION:2.0")
+                .contains("PRODID:-//PlantsCare//Bot Calendar//EN")
+                .contains("END:VCALENDAR");
+    }
+
+    @Test
+    @DisplayName("ICS пуст (нет VEVENT), когда у пользователя нет расписаний")
+    void should_render_empty_calendar_when_no_schedules() {
+        saveUserWithToken("token-empty");
+
+        String ics = calendarExportService.buildIcsForToken("token-empty");
+
+        assertThat(ics)
+                .contains("BEGIN:VCALENDAR")
+                .contains("END:VCALENDAR")
+                .doesNotContain("BEGIN:VEVENT");
+    }
+
+    // ==================== Рендер ICS — All-Day события ====================
+
+    @Test
+    @DisplayName("VEVENT — All-Day: DTSTART;VALUE=DATE: с датой формата YYYYMMDD, без времени")
+    void should_render_vevent_as_all_day() {
+        User user = saveUserWithToken("token-allday");
+        Plant plant = savePlant(user, "Фикус");
+        // FIXED_NOW = 2026-05-23 → +7 дней = 2026-05-30, DTEND = следующий день 2026-05-31
+        saveSchedule(plant, TaskType.WATERING,
+                LocalDateTime.ofInstant(FIXED_NOW, ZoneOffset.UTC).plusDays(7));
+
+        String ics = calendarExportService.buildIcsForToken("token-allday");
+
+        assertThat(ics)
+                .contains("BEGIN:VEVENT")
+                .contains("DTSTART;VALUE=DATE:20260530")
+                .contains("DTEND;VALUE=DATE:20260531")
+                .doesNotContain("DTSTART;VALUE=DATE-TIME")
+                .doesNotContain("DTSTART:2026");      // полная DATE-TIME форма
+    }
+
+    // ==================== Окно событий ====================
+
+    @Test
+    @DisplayName("Только события в окне [now; now+90d) попадают в ICS")
+    void should_only_include_schedules_within_window() {
+        User user = saveUserWithToken("token-window");
+        Plant plant = savePlant(user, "Кактус");
+
+        LocalDateTime now = LocalDateTime.ofInstant(FIXED_NOW, ZoneOffset.UTC);
+        CareSchedule inWindow = saveSchedule(plant, TaskType.WATERING, now.plusDays(30));
+        saveSchedule(plant, TaskType.MISTING, now.plusDays(120));
+
+        String ics = calendarExportService.buildIcsForToken("token-window");
+
+        assertThat(ics)
+                .contains("UID:plants-care-schedule-" + inWindow.getId() + "@plants-care")
+                .contains("DTSTART;VALUE=DATE:20260622");      // now + 30 = 2026-06-22
+
+        // Внутри окна — ровно одно VEVENT
+        assertThat(countOccurrences(ics, "BEGIN:VEVENT")).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Расписания архивных растений не рендерятся как события")
+    void should_exclude_archived_plants() {
+        User user = saveUserWithToken("token-archived");
+        Plant plant = savePlant(user, "Зомби-фикус");
+        plant.setArchivedAt(LocalDateTime.ofInstant(FIXED_NOW, ZoneOffset.UTC).minusDays(1));
+        plantRepository.save(plant);
+
+        saveSchedule(plant, TaskType.WATERING,
+                LocalDateTime.ofInstant(FIXED_NOW, ZoneOffset.UTC).plusDays(5));
+
+        String ics = calendarExportService.buildIcsForToken("token-archived");
+
+        assertThat(ics)
+                .contains("BEGIN:VCALENDAR")
+                .doesNotContain("BEGIN:VEVENT");
+    }
+
+    @Test
+    @DisplayName("Неактивные расписания не рендерятся как события")
+    void should_exclude_inactive_schedules() {
+        User user = saveUserWithToken("token-inactive");
+        Plant plant = savePlant(user, "Пальма");
+
+        CareSchedule schedule = saveSchedule(plant, TaskType.WATERING,
+                LocalDateTime.ofInstant(FIXED_NOW, ZoneOffset.UTC).plusDays(3));
+        schedule.setActive(false);
+        careScheduleRepository.save(schedule);
+
+        String ics = calendarExportService.buildIcsForToken("token-inactive");
+
+        assertThat(ics).doesNotContain("BEGIN:VEVENT");
+    }
+
+    @Test
+    @DisplayName("ICS чужого пользователя не содержит ничьих чужих расписаний")
+    void should_isolate_calendars_between_users() {
+        User alice = saveUserWithToken("token-alice");
+        Plant alicePlant = savePlant(alice, "Алисина монстера");
+        saveSchedule(alicePlant, TaskType.WATERING,
+                LocalDateTime.ofInstant(FIXED_NOW, ZoneOffset.UTC).plusDays(5));
+
+        User bob = userRepository.save(User.builder()
+                .telegramChatId(602L)
+                .calendarToken("token-bob")
+                .build());
+        Plant bobPlant = savePlant(bob, "Бобов кактус");
+        saveSchedule(bobPlant, TaskType.WATERING,
+                LocalDateTime.ofInstant(FIXED_NOW, ZoneOffset.UTC).plusDays(5));
+
+        String aliceIcs = calendarExportService.buildIcsForToken("token-alice");
+
+        assertThat(aliceIcs)
+                .contains("Алисина монстера")
+                .doesNotContain("Бобов кактус");
+    }
+
+    // ==================== ICS escaping (RFC 5545) ====================
+
+    @Test
+    @DisplayName("Спецсимволы (; , \\n \\) в имени растения экранируются в SUMMARY")
+    void should_escape_ics_special_chars_in_summary() {
+        User user = saveUserWithToken("token-escape");
+        // Имя растения, содержащее все четыре спецсимвола, требующих escape по RFC 5545
+        Plant plant = savePlant(user, "A;B,C\nD\\E");
+        saveSchedule(plant, TaskType.WATERING,
+                LocalDateTime.ofInstant(FIXED_NOW, ZoneOffset.UTC).plusDays(4));
+
+        String ics = calendarExportService.buildIcsForToken("token-escape");
+
+        // Сначала экранируется бэкслеш, потом остальное → в SUMMARY ожидаем:
+        //   ; → \;
+        //   , → \,
+        //   \n → \n (literal backslash + n)
+        //   \ → \\
+        assertThat(ics).contains("SUMMARY:💧 Полив A\\;B\\,C\\nD\\\\E");
+
+        // Голых неэкранированных спецсимволов в SUMMARY быть не должно:
+        // каждый ';' и ',' обязан быть префиксован одиночным '\' (negative lookbehind).
+        String summaryLine = ics.lines()
+                .filter(l -> l.startsWith("SUMMARY:"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(summaryLine)
+                .as("неэкранированные ; в SUMMARY")
+                .doesNotMatch(".*(?<!\\\\);.*");
+        assertThat(summaryLine)
+                .as("неэкранированные , в SUMMARY")
+                .doesNotMatch(".*(?<!\\\\),.*");
+    }
+
+    // ==================== Helpers ====================
+
+    private static final java.util.concurrent.atomic.AtomicLong CHAT_ID_SEQ =
+            new java.util.concurrent.atomic.AtomicLong(900_000L);
+
+    private User saveUserWithToken(String token) {
+        return userRepository.save(User.builder()
+                .telegramChatId(CHAT_ID_SEQ.incrementAndGet())
+                .calendarToken(token)
+                .build());
+    }
+
+    private Location saveDefaultLocation(User user) {
+        return locationRepository.findByUserIdAndDefaultLocationTrue(user.getId())
+                .orElseGet(() -> locationRepository.save(Location.builder()
+                        .user(user)
+                        .name(Location.DEFAULT_NAME)
+                        .emoji(Location.DEFAULT_EMOJI)
+                        .defaultLocation(true)
+                        .build()));
+    }
+
+    private Plant savePlant(User user, String name) {
+        Location location = saveDefaultLocation(user);
+        return plantRepository.save(Plant.builder()
+                .user(user)
+                .location(location)
+                .name(name)
+                .build());
+    }
+
+    private CareSchedule saveSchedule(Plant plant, TaskType taskType, LocalDateTime nextDueAt) {
+        return careScheduleRepository.save(CareSchedule.builder()
+                .plant(plant)
+                .taskType(taskType)
+                .intervalDays(7)
+                .nextDueAt(nextDueAt.truncatedTo(ChronoUnit.MICROS))
+                .active(true)
+                .build());
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = haystack.indexOf(needle, idx)) != -1) {
+            count++;
+            idx += needle.length();
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
Closes #79

## Что сделано

- **REST endpoint** `GET /calendar/{token}.ics` — публичный, Read-Only subscription, `Content-Type: text/calendar; charset=utf-8`, `Cache-Control: no-cache, must-revalidate`
- **iCalendar** строится `StringBuilder`-ом (без новых зависимостей), All-Day VEVENT'ы на ближайшие 90 дней по `CareSchedule.nextDueAt`, RFC 5545 escaping
- **Bot menu**: кнопка `📅 Экспорт в календарь` в Settings → выдаёт ссылку юзеру в чат
- **Token**: 32 байта `SecureRandom` → URL-safe base64 (43 символа), lazy-init при первом запросе, хранится в `users.calendar_token`
- **Race safety**: `getOrCreateToken` берёт `SELECT FOR UPDATE` на User row — двойное нажатие не сгенерит два разных токена
- **Config**: `app.calendar.base-url` (env `CALENDAR_BASE_URL`, default `https://example.com` — для прода обязательно переопределить), `app.calendar.event-window-days: 90`

## Миграции

`V14__add_users_calendar_token.sql` — добавляет nullable `users.calendar_token VARCHAR(64)` + partial unique index `idx_users_calendar_token WHERE calendar_token IS NOT NULL`.

## Backward-compat риски

**Safe.** Колонка nullable, без default, существующий код не затрагивается. Index — частичный, не блокирующий, NULL-строки игнорируются. Rolling deploy безопасен.

## Тесты

- `CalendarExportServiceTest` — 12 сценариев (`@SpringBootTest` + Testcontainers + Fixed Clock): генерация/реюз токена, missing token → `EntityNotFoundException`, VCALENDAR envelope, All-Day формат `DTSTART;VALUE=DATE:YYYYMMDD`, 90-day window boundary (30d in / 120d out), archived plants excluded, inactive schedules excluded, per-user isolation, RFC 5545 escaping `;`/`,`/`\n`/`\`
- `CalendarControllerTest` — 4 сценария (`@WebMvcTest`): 200 + content-type + body, Cache-Control header, 404 на unknown token, path-var propagation
- `CalendarControllerIT` — 1 e2e smoke (`@SpringBootTest(RANDOM_PORT)` + `TestRestTemplate` + Testcontainers): полный round-trip с реальной БД

## Чек

- [x] `./mvnw verify` — 565 тестов, 0 ошибок. 2 падения flaky-тестов species popularity (`SpeciesRepositoryTest.topPopularReturnsInCorrectOrder`, `PlantServiceTest.getPopularSpecies_orderedByPopularity`) — pre-existing, появляются на shared Testcontainers DB, не связаны с этим PR
- [x] reviewer прошёл (1 итерация); 2 SHOULD-FIX зафиксированы прямо в этом PR (race condition + откат опасных Flyway-флагов в test yml)

## Принятые SHOULD-FIX / NIT

- ✅ Race в `getOrCreateToken` → `findByIdForUpdate` с `PESSIMISTIC_WRITE`
- ✅ `out-of-order=true` и `ignore-migration-patterns` в `application-test.yml` → revert (маскировали бы реальные проблемы миграций)
- ✅ 404 echo body → `ResponseEntity.notFound().build()` (без сообщения)
- ⏸ RFC 5545 line folding на >75 octets (NIT) — отложено, клиенты толерантны
- ⏸ i18n хардкодных «Полив»/«Опрыскивание» — ждёт general i18n (#20)