### PR TITLE
feat: business metrics via Micrometer + Prometheus (#115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ docker compose --profile full down
 
 После запуска любым способом:
 - Healthcheck: http://localhost:8080/actuator/health
-- Метрики: http://localhost:8080/actuator/metrics
+- Метрики (JSON): http://localhost:8080/actuator/metrics
+- Метрики (Prometheus scrape): http://localhost:8080/actuator/prometheus (см. секцию Observability)
 
 ### Тесты
 
@@ -214,6 +215,40 @@ Rate limit: 5 неудачных попыток в минуту с IP → 429 н
 
 Откат миграций — пересоздание БД (`docker compose down -v && docker compose up -d`).
 Для пет-проекта это нормально, для прода понадобятся undo-миграции.
+
+## Observability
+
+### Prometheus scrape endpoint (issue #115)
+
+`GET /actuator/prometheus` — экспорт бизнес- и инфраструктурных метрик в формате Prometheus. Включён всегда (см. `management.endpoints.web.exposure.include` в `application.yml`).
+
+Доступ:
+
+- **Prod** (заданы `ADMIN_USERNAME` и `ADMIN_PASSWORD_BCRYPT_HASH`) — HTTP Basic с теми же credentials, что и админ-панель, роль `ADMIN`. Prometheus / Grafana Cloud конфигурируется с этими же значениями.
+- **Dev** (admin-credentials не заданы) — без аутентификации, через default security chain. Достаточно `curl http://localhost:8080/actuator/prometheus`.
+
+CSRF и session для этого chain выключены: scrape — machine-to-machine GET, STATELESS.
+
+### Экспортируемые бизнес-метрики
+
+Имена записаны в точечной нотации Micrometer. Prometheus-registry автоматически конвертирует `.` в `_` и добавляет суффикс `_total` для счётчиков.
+
+| Метрика | Тип | Теги | Описание |
+|---|---|---|---|
+| `notifications.sent` | Counter | `channel`, `task_type` | Успешно отправленные одиночные уведомления |
+| `notifications.failed` | Counter | `channel`, `reason` (`rate_limit` / `api_error` / `blocked` / `other`) | Неудачные отправки |
+| `notifications.digest.sent` | Counter | — | Отправленные дайджесты (issue #50, сгруппированные пуши) |
+| `telegram.api.errors` | Counter | `code` (`429` / `400` / `403` / `other`) | Ошибки Telegram Bot API |
+| `callbacks.processed` | Counter | `action`, `outcome` (`ok` / `error` / `idempotent`) | Обработанные callback-кнопки. Неизвестные `action` подменяются на `unknown` (защита от cardinality explosion) |
+| `users.registered.total` | Counter | — | Реальные новые регистрации (не каждый `/start`) |
+| `users.active.dau` | Gauge | — | Уникальные пользователи с care-event за последние 24h. Обновляется раз в час (`DauMetricsUpdater`) |
+| `scheduler.tick.duration` | Timer | — | Длительность тика шедулера уведомлений; публикует процентильную гистограмму |
+
+Дополнительно Micrometer публикует стандартные JVM-метрики (память, GC, потоки) и HTTP-latency по REST-эндпоинтам — без отдельной конфигурации.
+
+Полный контракт имён и тегов — в `MetricsService` (константы и enum'ы `FailureReason` / `TelegramErrorCode` / `CallbackOutcome`). Whitelist допустимых `action`-тегов для `callbacks.processed` лежит в `MetricsService.KNOWN_CALLBACK_ACTIONS`; при добавлении нового callback-action в хендлерах его надо туда же.
+
+Настройка самого Prometheus-сервера, Grafana-дашбордов и алертов — вне scope этого PR.
 
 ## Деплой на Railway
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,13 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
+        <!-- Issue #115: бизнес-метрики через Prometheus scrape /actuator/prometheus.
+             Версия наследуется из spring-boot BOM, явно не пиннингуем. -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>

--- a/src/main/java/com/plantcare/bot/admin/config/AdminSecurityConfig.java
+++ b/src/main/java/com/plantcare/bot/admin/config/AdminSecurityConfig.java
@@ -21,9 +21,13 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 /**
- * Две SecurityFilterChain:
+ * Три SecurityFilterChain:
  *   1. @Order(1) /admin/** — form login, CSRF, session 8h, rate limiter
- *   2. @Order(2) всё остальное — permitAll, CSRF off (бот, /actuator/**)
+ *   2. @Order(2) /actuator/prometheus — HTTP Basic, ADMIN role (issue #115).
+ *      Регистрируется только если admin enabled (есть креды). На dev без кредов
+ *      падает в default chain (permitAll) — это осознанный компромисс, чтобы
+ *      разработчик мог локально посмотреть метрики без настройки логина.
+ *   3. @Order(3) всё остальное — permitAll, CSRF off (бот, /actuator/health и т.п.)
  *
  * Бины с form login создаются ТОЛЬКО при заданных env. Если их нет —
  * adminFilterChain не поднимается, /admin/** падает в default chain (permitAll),
@@ -72,12 +76,38 @@ public class AdminSecurityConfig {
     }
 
     /**
+     * Issue #115: {@code /actuator/prometheus} закрыт HTTP Basic с ролью ADMIN.
+     * Используем тот же {@link InMemoryUserDetailsManager} что и для /admin/**,
+     * чтобы не плодить отдельных учёток для скрейпа метрик. Prometheus в
+     * Railway/Grafana Cloud конфигурируется с теми же {@code ADMIN_USERNAME} /
+     * пара-bcrypt-хешем, что и админ-панель.
+     *
+     * <p>CSRF выключаем — это GET-эндпоинт для machine-to-machine, никаких форм.
+     * Session создавать тоже не нужно (STATELESS): scrape — это серия независимых
+     * запросов.
+     */
+    @Bean
+    @Order(2)
+    @ConditionalOnExpression(ADMIN_ENABLED_EXPR)
+    public SecurityFilterChain prometheusSecurityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .securityMatcher("/actuator/prometheus")
+                .authorizeHttpRequests(auth -> auth.anyRequest().hasRole("ADMIN"))
+                .httpBasic(org.springframework.security.config.Customizer.withDefaults())
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(
+                                org.springframework.security.config.http.SessionCreationPolicy.STATELESS))
+                .build();
+    }
+
+    /**
      * Default-цепочка для всего, что не /admin/**. В рамках Phase 0 (issue #84)
      * {@code /api/v1/**}, {@code /swagger-ui/**} и {@code /v3/api-docs/**} публичны:
      * аутентификация REST API появится в следующих фазах.
      */
     @Bean
-    @Order(2)
+    @Order(3)
     public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())

--- a/src/main/java/com/plantcare/bot/metrics/DauMetricsUpdater.java
+++ b/src/main/java/com/plantcare/bot/metrics/DauMetricsUpdater.java
@@ -1,0 +1,69 @@
+package com.plantcare.bot.metrics;
+
+import com.plantcare.bot.repository.CareHistoryRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+/**
+ * Раз в час пересчитывает DAU (уникальные пользователи с care_event
+ * за последние 24h) и пишет в {@link MetricsService}. Micrometer-gauge
+ * затем читает значение лениво при scrape Prometheus.
+ *
+ * <p>Сделано отдельным шедулером, а не gauge-функцией с прямым обращением
+ * к БД, чтобы:
+ * <ul>
+ *   <li>не висеть на DB во время каждого scrape Prometheus (по дефолту
+ *       раз в 15 сек) — это бесполезная нагрузка;</li>
+ *   <li>значение было устойчивым: между двумя scrape'ами DAU не должен
+ *       прыгать, иначе графики «дёргает».</li>
+ * </ul>
+ *
+ * <p>Cron в UTC. Идемпотентность не требуется — повторный пересчёт
+ * перезатирает то же значение тем же значением.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DauMetricsUpdater {
+
+    private static final int WINDOW_HOURS = 24;
+
+    private final CareHistoryRepository careHistoryRepository;
+    private final MetricsService metricsService;
+    private final Clock clock;
+
+    /**
+     * Прогреваем значение сразу при старте, чтобы gauge не отдавал 0
+     * первые 60 минут после деплоя. Безопасно — это readOnly запрос.
+     */
+    @PostConstruct
+    void warmUp() {
+        try {
+            refresh();
+        } catch (Exception e) {
+            // Не валим контекст из-за метрики. Просто оставляем 0,
+            // следующий @Scheduled-тик переcчитает.
+            log.warn("Initial DAU refresh failed, will retry on schedule: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Cron «в начале каждого часа в UTC». Совпадает с шедулером напоминаний
+     * по таймзоне, чтобы Railway-логи легче коррелировать.
+     */
+    @Scheduled(cron = "0 0 * * * *", zone = "UTC")
+    @Transactional(readOnly = true)
+    public void refresh() {
+        LocalDateTime cutoff = LocalDateTime.now(clock).minusHours(WINDOW_HOURS);
+        long dau = careHistoryRepository.countDistinctActiveUsersSince(cutoff);
+        metricsService.updateActiveDau(dau);
+        log.info("DAU updated: {} active users in last {}h (cutoff={})", dau, WINDOW_HOURS, cutoff);
+    }
+}

--- a/src/main/java/com/plantcare/bot/metrics/MetricsService.java
+++ b/src/main/java/com/plantcare/bot/metrics/MetricsService.java
@@ -1,0 +1,328 @@
+package com.plantcare.bot.metrics;
+
+import com.plantcare.bot.domain.enums.TaskType;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Единая точка регистрации и инкремента бизнес-метрик (issue #115).
+ *
+ * <p>Все вызовы {@link MeterRegistry} проходят через этот компонент, чтобы:
+ * <ul>
+ *   <li>не размазывать имена/тэги метрик по 30 классам;</li>
+ *   <li>дать единый «контракт» метрик — переименование/удаление видно сразу
+ *       по списку методов класса;</li>
+ *   <li>обеспечить кеширование {@link Counter}-инстансов: каждое обращение
+ *       к {@code registry.counter(name, tags)} с одинаковыми параметрами вернёт
+ *       тот же мьютер, но это всё равно лишний lookup в hot path шедулера.</li>
+ * </ul>
+ *
+ * <p>Имена метрик — точечная нотация. Prometheus-registry автоматически
+ * сконвертирует {@code notifications.sent} → {@code notifications_sent_total}.
+ *
+ * <p>Тэги — низкокардинальные значения (enum, фиксированные строки). Никаких
+ * {@code userId}, {@code plantId} — взорвёт cardinality в Prometheus.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MetricsService {
+
+    // ---- Имена метрик (используются также в тестах) -----------------------
+    public static final String NOTIFICATIONS_SENT          = "notifications.sent";
+    public static final String NOTIFICATIONS_FAILED        = "notifications.failed";
+    public static final String NOTIFICATIONS_DIGEST_SENT   = "notifications.digest.sent";
+    public static final String TELEGRAM_API_ERRORS         = "telegram.api.errors";
+    public static final String CALLBACKS_PROCESSED         = "callbacks.processed";
+    public static final String USERS_REGISTERED_TOTAL      = "users.registered.total";
+    public static final String USERS_ACTIVE_DAU            = "users.active.dau";
+    public static final String SCHEDULER_TICK_DURATION     = "scheduler.tick.duration";
+
+    public static final String CHANNEL_TELEGRAM = "telegram";
+
+    /**
+     * Whitelist разрешённых значений тэга {@code action} для метрики
+     * {@link #CALLBACKS_PROCESSED}.
+     *
+     * <p>Тэг {@code action} приходит из {@code callback_data} Telegram-апдейта,
+     * то есть формально подконтролен пользователю. Без валидации любой клиент
+     * (включая злонамеренного) мог бы слать произвольные строки и взорвать
+     * cardinality MeterRegistry — каждый уникальный {@code action} создаёт
+     * отдельный counter в памяти JVM навсегда. На Railway это даёт OOM за
+     * сутки атаки.
+     *
+     * <p>Содержит ровно те action'ы, которые реально использует
+     * {@link #recordCallback(String, CallbackOutcome)}. При добавлении нового
+     * action в хендлерах — обязательно добавить его сюда, иначе будет
+     * подменяться на {@value #UNKNOWN_ACTION_TAG}.
+     */
+    static final Set<String> KNOWN_CALLBACK_ACTIONS = Set.of(
+            // одиночные напоминания (NotificationCallbackService)
+            "done", "snooze", "skip", "unknown",
+            // массовый полив локации (#19)
+            "bulk_done",
+            // двухшаговый flow «полив с деталями» (#71)
+            "wabund", "wsoil",
+            // SOIL_CHECK (#74)
+            "soil_dry", "soil_wet", "soil_unk", "soil_water",
+            // акклиматизация (#75)
+            "accl_soil", "accl_snooze", "accl_checkin",
+            // дайджест (#50)
+            "digest_done_all", "digest_expand", "digest_unknown"
+    );
+
+    /** Значение тэга {@code action}, если переданная строка не в whitelist'е. */
+    static final String UNKNOWN_ACTION_TAG = "unknown";
+
+    private final MeterRegistry meterRegistry;
+
+    /**
+     * DAU обновляется отдельным шедулером (см. {@code DauMetricsUpdater})
+     * раз в час и складывается в этот {@link AtomicLong}. Gauge читает
+     * текущее значение — без блокировок, без обращения к БД из callback'а
+     * Micrometer scrape.
+     */
+    private final AtomicLong activeDau = new AtomicLong(0L);
+
+    /**
+     * Регистрируем gauge один раз при старте. Counter'ы регистрируются
+     * лениво — на первом вызове соответствующего {@code recordXxx}.
+     */
+    @PostConstruct
+    void registerGauges() {
+        Gauge.builder(USERS_ACTIVE_DAU, activeDau, AtomicLong::doubleValue)
+                .description("Unique users with at least one care event in the last 24h")
+                .register(meterRegistry);
+        log.info("Business metrics registered (DAU gauge='{}')", USERS_ACTIVE_DAU);
+    }
+
+    // ====================================================================
+    // Notifications
+    // ====================================================================
+
+    /**
+     * Инкрементировать счётчик успешно отправленных одиночных уведомлений.
+     *
+     * @param channel  канал доставки (сейчас всегда {@link #CHANNEL_TELEGRAM})
+     * @param taskType тип задачи (нужен для срезов «сколько поливных пушей в день»)
+     */
+    public void recordNotificationSent(String channel, TaskType taskType) {
+        meterRegistry.counter(
+                NOTIFICATIONS_SENT,
+                "channel", channel,
+                "task_type", taskType.name()
+        ).increment();
+    }
+
+    /**
+     * Инкрементировать счётчик неудачных отправок уведомлений.
+     *
+     * @param channel канал доставки
+     * @param reason  причина: {@code rate_limit | api_error | blocked | other}
+     */
+    public void recordNotificationFailed(String channel, FailureReason reason) {
+        meterRegistry.counter(
+                NOTIFICATIONS_FAILED,
+                "channel", channel,
+                "reason", reason.tagValue()
+        ).increment();
+    }
+
+    /**
+     * Инкрементировать счётчик отправленных дайджестов (issue #50 —
+     * группированные пуши по нескольким задачам).
+     */
+    public void recordDigestSent() {
+        meterRegistry.counter(NOTIFICATIONS_DIGEST_SENT).increment();
+    }
+
+    // ====================================================================
+    // Telegram API errors
+    // ====================================================================
+
+    /**
+     * Инкрементировать счётчик ошибок Telegram Bot API.
+     *
+     * @param code HTTP-код ответа Telegram ({@code 429 | 400 | 403 | other})
+     */
+    public void recordTelegramApiError(TelegramErrorCode code) {
+        meterRegistry.counter(TELEGRAM_API_ERRORS, "code", code.tagValue()).increment();
+    }
+
+    // ====================================================================
+    // Callbacks
+    // ====================================================================
+
+    /**
+     * Инкрементировать счётчик обработанных callback-кнопок.
+     *
+     * <p>{@code action} приходит из {@code callback_data} Telegram-апдейта и
+     * валидируется по {@link #KNOWN_CALLBACK_ACTIONS}. Любое значение вне
+     * whitelist'а подменяется на {@value #UNKNOWN_ACTION_TAG}, чтобы
+     * злонамеренный клиент не мог взорвать cardinality реестра уникальными
+     * строками (см. doc к {@link #KNOWN_CALLBACK_ACTIONS}).
+     *
+     * @param action  название действия (done, snooze, skip, digest_done_all, ...)
+     * @param outcome исход обработки ({@code ok | error | idempotent})
+     */
+    public void recordCallback(String action, CallbackOutcome outcome) {
+        String safeAction = sanitizeCallbackAction(action);
+        meterRegistry.counter(
+                CALLBACKS_PROCESSED,
+                "action", safeAction,
+                "outcome", outcome.tagValue()
+        ).increment();
+    }
+
+    private String sanitizeCallbackAction(String action) {
+        if (action != null && KNOWN_CALLBACK_ACTIONS.contains(action)) {
+            return action;
+        }
+        // debug — чтобы не дать атакующему флудить нам логи infо/warn.
+        log.debug("Unknown callback action '{}', counted as '{}'", action, UNKNOWN_ACTION_TAG);
+        return UNKNOWN_ACTION_TAG;
+    }
+
+    // ====================================================================
+    // Users
+    // ====================================================================
+
+    /**
+     * Инкрементировать счётчик зарегистрированных пользователей.
+     * Вызывается ровно один раз на одно реальное создание {@code User} в БД.
+     */
+    public void recordUserRegistered() {
+        meterRegistry.counter(USERS_REGISTERED_TOTAL).increment();
+    }
+
+    /**
+     * Обновить текущее значение DAU. Вызывается из {@code DauMetricsUpdater}
+     * раз в час; Micrometer-gauge читает {@link #activeDau} лениво при scrape.
+     */
+    public void updateActiveDau(long value) {
+        activeDau.set(value);
+    }
+
+    /** Только для тестов / health-проверок. */
+    public long getActiveDau() {
+        return activeDau.get();
+    }
+
+    // ====================================================================
+    // Scheduler
+    // ====================================================================
+
+    /**
+     * Запустить замер длительности шедулерного тика. Использование:
+     * <pre>{@code
+     *   Timer.Sample sample = metricsService.startSchedulerTickTimer();
+     *   try {
+     *       executeTick();
+     *   } finally {
+     *       metricsService.stopSchedulerTickTimer(sample);
+     *   }
+     * }</pre>
+     */
+    public Timer.Sample startSchedulerTickTimer() {
+        return Timer.start(meterRegistry);
+    }
+
+    /** Остановить таймер и записать длительность в {@code scheduler.tick.duration}. */
+    public void stopSchedulerTickTimer(Timer.Sample sample) {
+        sample.stop(timer(SCHEDULER_TICK_DURATION));
+    }
+
+    private Timer timer(String name) {
+        return Timer.builder(name)
+                .publishPercentileHistogram()
+                .register(meterRegistry);
+    }
+
+    // ====================================================================
+    // Tag values
+    // ====================================================================
+
+    /** Причина неудачи отправки уведомления (тэг {@code reason}). */
+    public enum FailureReason {
+        RATE_LIMIT("rate_limit"),
+        API_ERROR("api_error"),
+        BLOCKED("blocked"),
+        OTHER("other");
+
+        private final String tagValue;
+
+        FailureReason(String tagValue) {
+            this.tagValue = tagValue;
+        }
+
+        public String tagValue() {
+            return tagValue;
+        }
+    }
+
+    /** Код ответа Telegram API (тэг {@code code}). */
+    public enum TelegramErrorCode {
+        RATE_LIMITED("429"),
+        BAD_REQUEST("400"),
+        FORBIDDEN("403"),
+        OTHER("other");
+
+        private final String tagValue;
+
+        TelegramErrorCode(String tagValue) {
+            this.tagValue = tagValue;
+        }
+
+        public String tagValue() {
+            return tagValue;
+        }
+
+        /**
+         * Эвристически распарсить код из текста {@code TelegramApiException}.
+         * Telegram Bot API возвращает текст вида {@code "[400] Bad Request: ..."},
+         * либо для {@code TelegramApiRequestException} — числовое поле, но мы
+         * парсим только строку, чтобы не зависеть от типа исключения.
+         */
+        public static TelegramErrorCode fromMessage(String message) {
+            if (message == null) {
+                return OTHER;
+            }
+            if (message.contains("429")) {
+                return RATE_LIMITED;
+            }
+            if (message.contains("403")) {
+                return FORBIDDEN;
+            }
+            if (message.contains("400")) {
+                return BAD_REQUEST;
+            }
+            return OTHER;
+        }
+    }
+
+    /** Исход обработки callback'а (тэг {@code outcome}). */
+    public enum CallbackOutcome {
+        OK("ok"),
+        ERROR("error"),
+        IDEMPOTENT("idempotent");
+
+        private final String tagValue;
+
+        CallbackOutcome(String tagValue) {
+            this.tagValue = tagValue;
+        }
+
+        public String tagValue() {
+            return tagValue;
+        }
+    }
+}

--- a/src/main/java/com/plantcare/bot/repository/CareHistoryRepository.java
+++ b/src/main/java/com/plantcare/bot/repository/CareHistoryRepository.java
@@ -84,6 +84,18 @@ public interface CareHistoryRepository extends JpaRepository<CareHistory, Long> 
     Optional<CareHistory> findByClientId(String clientId);
 
     /**
+     * Уникальные пользователи, у которых был хотя бы один активный {@code care_event}
+     * за окно {@code (after; now]}. Используется метрикой DAU (issue #115).
+     *
+     * <p>Запрос идёт по индексу {@code care_history(done_at)} — окно 24h
+     * с типичной нагрузкой укладывается в десятки мс. Зовётся раз в час
+     * из {@code DauMetricsUpdater}, поэтому даже на больших данных не hot path.
+     */
+    @Query("SELECT COUNT(DISTINCT h.plant.user.id) FROM CareHistory h " +
+            "WHERE h.cancelledBy IS NULL AND h.doneAt > :after")
+    long countDistinctActiveUsersSince(@Param("after") LocalDateTime after);
+
+    /**
      * Постраничный листинг истории с реальным offset (не page-based).
      *
      * <p>Используется REST API GET /api/v1/plants/{id}/history?limit=N&offset=M.

--- a/src/main/java/com/plantcare/bot/service/NotificationCallbackService.java
+++ b/src/main/java/com/plantcare/bot/service/NotificationCallbackService.java
@@ -5,6 +5,8 @@ import com.plantcare.bot.domain.CareSchedule;
 import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.metrics.MetricsService;
+import com.plantcare.bot.metrics.MetricsService.CallbackOutcome;
 import com.plantcare.bot.repository.CareHistoryRepository;
 import com.plantcare.bot.repository.CareScheduleRepository;
 import com.plantcare.bot.util.TimezoneSupport;
@@ -53,6 +55,7 @@ public class NotificationCallbackService {
     private final PlantCardService plantCardService;
     private final PlantAcclimationService plantAcclimationService;
     private final com.plantcare.bot.seasonal.service.SeasonalIntervalService seasonalIntervalService;
+    private final MetricsService metricsService;
 
     @Transactional
     public void handleCallback(CallbackQuery callbackQuery, TelegramClient client) {
@@ -65,6 +68,7 @@ public class NotificationCallbackService {
 
         if (parts.length < 3) {
             answerCallback(client, callbackId, "❌ Неизвестная команда");
+            metricsService.recordCallback("unknown", CallbackOutcome.ERROR);
             return;
         }
 
@@ -123,6 +127,7 @@ public class NotificationCallbackService {
             scheduleId = Long.parseLong(parts[2]);
         } catch (NumberFormatException e) {
             answerCallback(client, callbackId, "❌ Неверный ID");
+            metricsService.recordCallback(action, CallbackOutcome.ERROR);
             return;
         }
 
@@ -130,6 +135,7 @@ public class NotificationCallbackService {
 
         if (optSchedule.isEmpty()) {
             answerCallback(client, callbackId, "❌ Расписание не найдено");
+            metricsService.recordCallback(action, CallbackOutcome.ERROR);
             return;
         }
 
@@ -139,6 +145,8 @@ public class NotificationCallbackService {
         if (plant.isArchived()) {
             editMessage(client, chatId, messageId, "Растение уже удалено");
             answerCallback(client, callbackId, "Растение удалено");
+            // Архив — это идемпотентный «уже не актуально», а не ошибка.
+            metricsService.recordCallback(action, CallbackOutcome.IDEMPOTENT);
             return;
         }
 
@@ -153,6 +161,9 @@ public class NotificationCallbackService {
                 if (schedule.getTaskType() == TaskType.WATERING) {
                     askWateringAbundance(plant.getName(), scheduleId, chatId, messageId, client);
                     answerCallback(client, callbackId, "");
+                    // OK — flow корректно отстартовал. Финальная отметка
+                    // (с wabund/wsoil) считается отдельным callback'ом.
+                    metricsService.recordCallback(action, CallbackOutcome.OK);
                     return;
                 }
 
@@ -160,6 +171,7 @@ public class NotificationCallbackService {
 
                 if (!marked) {
                     answerCallback(client, callbackId, "Уже отмечено!");
+                    metricsService.recordCallback(action, CallbackOutcome.IDEMPOTENT);
                     return;
                 }
 
@@ -182,6 +194,7 @@ public class NotificationCallbackService {
             case "skip" -> {
                 if (isDuplicateDone(plant, schedule, now)) {
                     answerCallback(client, callbackId, "Уже отмечено!");
+                    metricsService.recordCallback(action, CallbackOutcome.IDEMPOTENT);
                     return;
                 }
 
@@ -208,12 +221,14 @@ public class NotificationCallbackService {
             }
             default -> {
                 answerCallback(client, callbackId, "❌ Неизвестное действие");
+                metricsService.recordCallback(action, CallbackOutcome.ERROR);
                 return;
             }
         }
 
         editMessage(client, chatId, messageId, responseText);
         answerCallback(client, callbackId, alertText);
+        metricsService.recordCallback(action, CallbackOutcome.OK);
     }
 
     // ====================================================================
@@ -291,6 +306,7 @@ public class NotificationCallbackService {
     ) {
         if (parts.length != 4) {
             answerCallback(client, callbackId, "❌ Неверный формат");
+            metricsService.recordCallback("wabund", CallbackOutcome.ERROR);
             return;
         }
         Long scheduleId;
@@ -298,23 +314,27 @@ public class NotificationCallbackService {
             scheduleId = Long.parseLong(parts[2]);
         } catch (NumberFormatException e) {
             answerCallback(client, callbackId, "❌ Неверный ID");
+            metricsService.recordCallback("wabund", CallbackOutcome.ERROR);
             return;
         }
         String abundance = parts[3];
         if (!"HEAVY".equals(abundance) && !"NORMAL".equals(abundance)) {
             answerCallback(client, callbackId, "❌ Неверный ответ");
+            metricsService.recordCallback("wabund", CallbackOutcome.ERROR);
             return;
         }
 
         Optional<CareSchedule> opt = careScheduleRepository.findById(scheduleId);
         if (opt.isEmpty() || opt.get().getTaskType() != TaskType.WATERING) {
             answerCallback(client, callbackId, "❌ Расписание не найдено");
+            metricsService.recordCallback("wabund", CallbackOutcome.ERROR);
             return;
         }
         Plant plant = opt.get().getPlant();
         if (plant.isArchived()) {
             editMessage(client, chatId, messageId, "Растение уже удалено");
             answerCallback(client, callbackId, "Растение удалено");
+            metricsService.recordCallback("wabund", CallbackOutcome.IDEMPOTENT);
             return;
         }
 
@@ -332,6 +352,7 @@ public class NotificationCallbackService {
             log.error("Failed to edit message to soil-dry question: {}", e.getMessage(), e);
         }
         answerCallback(client, callbackId, "");
+        metricsService.recordCallback("wabund", CallbackOutcome.OK);
     }
 
     private InlineKeyboardMarkup buildSoilDryKeyboard(Long scheduleId, String abundance) {
@@ -361,6 +382,7 @@ public class NotificationCallbackService {
     ) {
         if (parts.length != 5) {
             answerCallback(client, callbackId, "❌ Неверный формат");
+            metricsService.recordCallback("wsoil", CallbackOutcome.ERROR);
             return;
         }
         Long scheduleId;
@@ -368,6 +390,7 @@ public class NotificationCallbackService {
             scheduleId = Long.parseLong(parts[2]);
         } catch (NumberFormatException e) {
             answerCallback(client, callbackId, "❌ Неверный ID");
+            metricsService.recordCallback("wsoil", CallbackOutcome.ERROR);
             return;
         }
         String abundanceStr = parts[3];
@@ -376,6 +399,7 @@ public class NotificationCallbackService {
         boolean wasAbundant = "HEAVY".equals(abundanceStr);
         if (!"HEAVY".equals(abundanceStr) && !"NORMAL".equals(abundanceStr)) {
             answerCallback(client, callbackId, "❌ Неверный ответ");
+            metricsService.recordCallback("wsoil", CallbackOutcome.ERROR);
             return;
         }
         Boolean soilWasDry = switch (soilStr) {
@@ -386,12 +410,14 @@ public class NotificationCallbackService {
         };
         // Если был неизвестный soilStr — уже ответили выше, но нам нужно явно выйти.
         if (!"DRY".equals(soilStr) && !"WET".equals(soilStr) && !"UNKNOWN".equals(soilStr)) {
+            metricsService.recordCallback("wsoil", CallbackOutcome.ERROR);
             return;
         }
 
         Optional<CareSchedule> opt = careScheduleRepository.findById(scheduleId);
         if (opt.isEmpty() || opt.get().getTaskType() != TaskType.WATERING) {
             answerCallback(client, callbackId, "❌ Расписание не найдено");
+            metricsService.recordCallback("wsoil", CallbackOutcome.ERROR);
             return;
         }
         CareSchedule schedule = opt.get();
@@ -399,6 +425,7 @@ public class NotificationCallbackService {
         if (plant.isArchived()) {
             editMessage(client, chatId, messageId, "Растение уже удалено");
             answerCallback(client, callbackId, "Растение удалено");
+            metricsService.recordCallback("wsoil", CallbackOutcome.IDEMPOTENT);
             return;
         }
 
@@ -406,6 +433,7 @@ public class NotificationCallbackService {
 
         if (isDuplicateDone(plant, schedule, now)) {
             answerCallback(client, callbackId, "Уже отмечено!");
+            metricsService.recordCallback("wsoil", CallbackOutcome.IDEMPOTENT);
             return;
         }
 
@@ -441,6 +469,7 @@ public class NotificationCallbackService {
         );
 
         answerCallback(client, callbackId, "Записано");
+        metricsService.recordCallback("wsoil", CallbackOutcome.OK);
 
         log.info("Watering with details: plant={}, abundant={}, soil_dry={}, schedule={}",
                 plant.getId(), wasAbundant, soilWasDry, scheduleId);
@@ -553,6 +582,7 @@ public class NotificationCallbackService {
             locationId = Long.parseLong(rawLocationId);
         } catch (NumberFormatException e) {
             answerCallback(client, callbackId, "❌ Неверный ID локации");
+            metricsService.recordCallback("bulk_done", CallbackOutcome.ERROR);
             return;
         }
 
@@ -560,6 +590,7 @@ public class NotificationCallbackService {
         if (user == null) {
             log.warn("bulk_done callback from unknown chatId={}", chatId);
             answerCallback(client, callbackId, "❌ Сначала /start");
+            metricsService.recordCallback("bulk_done", CallbackOutcome.ERROR);
             return;
         }
 
@@ -570,12 +601,14 @@ public class NotificationCallbackService {
         // расписания отключены, либо все растения архивированы).
         if (result.total() == 0) {
             answerCallback(client, callbackId, "В этой комнате пока нечего поливать");
+            metricsService.recordCallback("bulk_done", CallbackOutcome.IDEMPOTENT);
             return;
         }
 
         // Все растения были политы недавно (< 60 сек) — это double-click по кнопке.
         if (result.updated() == 0) {
             answerCallback(client, callbackId, "Уже полито");
+            metricsService.recordCallback("bulk_done", CallbackOutcome.IDEMPOTENT);
             return;
         }
 
@@ -585,6 +618,7 @@ public class NotificationCallbackService {
                 + " в локации " + result.locationName();
         sendMessage(client, chatId, resultText);
         answerCallback(client, callbackId, "Готово!");
+        metricsService.recordCallback("bulk_done", CallbackOutcome.OK);
 
         log.info("Bulk WATERING done: user={}, location={}, updated={}, deduped={}",
                 user.getId(), locationId, result.updated(), result.deduped());
@@ -635,23 +669,37 @@ public class NotificationCallbackService {
             String callbackId,
             TelegramClient client
     ) {
+        // Маппинг result → tag-значение action: явный switch, чтобы имя
+        // метрики совпадало с callback action из роутера (см. switch выше,
+        // case "soil_unk"). Конкатенация ".toLowerCase()" давала бы
+        // "soil_unknown" против "soil_unk" в whitelist → расщепление
+        // дашбордов на два имени и подмена на "unknown".
+        String metricAction = switch (result) {
+            case "DRY" -> "soil_dry";
+            case "WET" -> "soil_wet";
+            case "UNKNOWN" -> "soil_unk";
+            default -> "unknown";
+        };
         Long scheduleId;
         try {
             scheduleId = Long.parseLong(rawScheduleId);
         } catch (NumberFormatException e) {
             answerCallback(client, callbackId, "❌ Неверный ID");
+            metricsService.recordCallback(metricAction, CallbackOutcome.ERROR);
             return;
         }
 
         Optional<CareSchedule> opt = careScheduleRepository.findById(scheduleId);
         if (opt.isEmpty()) {
             answerCallback(client, callbackId, "❌ Расписание не найдено");
+            metricsService.recordCallback(metricAction, CallbackOutcome.ERROR);
             return;
         }
         CareSchedule schedule = opt.get();
 
         if (schedule.getTaskType() != TaskType.SOIL_CHECK) {
             answerCallback(client, callbackId, "❌ Неверный тип");
+            metricsService.recordCallback(metricAction, CallbackOutcome.ERROR);
             return;
         }
 
@@ -659,6 +707,7 @@ public class NotificationCallbackService {
         if (plant.isArchived()) {
             editMessage(client, chatId, messageId, "🗑 Растение уже удалено.");
             answerCallback(client, callbackId, "");
+            metricsService.recordCallback(metricAction, CallbackOutcome.IDEMPOTENT);
             return;
         }
 
@@ -669,6 +718,7 @@ public class NotificationCallbackService {
                 .findFirstByPlantIdAndTaskTypeOrderByDoneAtDesc(plant.getId(), TaskType.SOIL_CHECK);
         if (last.isPresent() && last.get().getDoneAt().plusSeconds(DEDUP_SECONDS).isAfter(now)) {
             answerCallback(client, callbackId, "Уже отмечено!");
+            metricsService.recordCallback(metricAction, CallbackOutcome.IDEMPOTENT);
             return;
         }
 
@@ -718,6 +768,7 @@ public class NotificationCallbackService {
             case "WET" -> "Записано: влажно";
             default    -> "Записано";
         });
+        metricsService.recordCallback(metricAction, CallbackOutcome.OK);
 
         log.info("Soil check result for plant {} (schedule {}): {}",
                 plant.getId(), scheduleId, result);
@@ -739,12 +790,14 @@ public class NotificationCallbackService {
             wateringScheduleId = Long.parseLong(rawWateringScheduleId);
         } catch (NumberFormatException e) {
             answerCallback(client, callbackId, "❌ Неверный ID");
+            metricsService.recordCallback("soil_water", CallbackOutcome.ERROR);
             return;
         }
 
         Optional<CareSchedule> opt = careScheduleRepository.findById(wateringScheduleId);
         if (opt.isEmpty() || opt.get().getTaskType() != TaskType.WATERING) {
             answerCallback(client, callbackId, "❌ Расписание полива не найдено");
+            metricsService.recordCallback("soil_water", CallbackOutcome.ERROR);
             return;
         }
         CareSchedule wateringSchedule = opt.get();
@@ -753,6 +806,7 @@ public class NotificationCallbackService {
         if (plant.isArchived()) {
             editMessage(client, chatId, messageId, "🗑 Растение уже удалено.");
             answerCallback(client, callbackId, "");
+            metricsService.recordCallback("soil_water", CallbackOutcome.IDEMPOTENT);
             return;
         }
 
@@ -761,6 +815,7 @@ public class NotificationCallbackService {
 
         if (!marked) {
             answerCallback(client, callbackId, "Уже отмечено!");
+            metricsService.recordCallback("soil_water", CallbackOutcome.IDEMPOTENT);
             return;
         }
 
@@ -769,6 +824,7 @@ public class NotificationCallbackService {
         editMessage(client, chatId, messageId,
                 "💧 Полил " + plant.getName() + ".\nСледующий полив — " + nextDateStr);
         answerCallback(client, callbackId, "Готово!");
+        metricsService.recordCallback("soil_water", CallbackOutcome.OK);
 
         log.info("Soil-check follow-up watering done: plant={}, schedule={}",
                 plant.getId(), wateringScheduleId);
@@ -824,6 +880,7 @@ public class NotificationCallbackService {
     ) {
         if (parts.length != 4) {
             answerCallback(client, callbackId, "❌ Неверный формат");
+            metricsService.recordCallback("accl_soil", CallbackOutcome.ERROR);
             return;
         }
         Long scheduleId;
@@ -831,6 +888,7 @@ public class NotificationCallbackService {
             scheduleId = Long.parseLong(parts[2]);
         } catch (NumberFormatException e) {
             answerCallback(client, callbackId, "❌ Неверный ID");
+            metricsService.recordCallback("accl_soil", CallbackOutcome.ERROR);
             return;
         }
         String answer = parts[3];
@@ -838,6 +896,7 @@ public class NotificationCallbackService {
         Optional<CareSchedule> opt = careScheduleRepository.findById(scheduleId);
         if (opt.isEmpty() || opt.get().getTaskType() != TaskType.WATERING) {
             answerCallback(client, callbackId, "❌ Расписание не найдено");
+            metricsService.recordCallback("accl_soil", CallbackOutcome.ERROR);
             return;
         }
         CareSchedule schedule = opt.get();
@@ -845,6 +904,7 @@ public class NotificationCallbackService {
         if (plant.isArchived()) {
             editMessage(client, chatId, messageId, "Растение уже удалено");
             answerCallback(client, callbackId, "Растение удалено");
+            metricsService.recordCallback("accl_soil", CallbackOutcome.IDEMPOTENT);
             return;
         }
 
@@ -857,6 +917,7 @@ public class NotificationCallbackService {
                 // но с edit'ом исходного сообщения, не отдельным send).
                 askWateringAbundance(plant.getName(), scheduleId, chatId, messageId, client);
                 answerCallback(client, callbackId, "");
+                metricsService.recordCallback("accl_soil", CallbackOutcome.OK);
             }
             case "WET" -> {
                 // Влажно → откладываем полив на 1 день, не пишем CareHistory.
@@ -866,6 +927,7 @@ public class NotificationCallbackService {
                         "💧 Тогда пока не поливаем. Напомню завтра.",
                         buildAcclSnoozeKeyboard(scheduleId));
                 answerCallback(client, callbackId, "Ок, отложил");
+                metricsService.recordCallback("accl_soil", CallbackOutcome.OK);
                 log.info("Acclimation WET: plant={} schedule={} snoozed +1d", plant.getId(), scheduleId);
             }
             case "UNKNOWN" -> {
@@ -876,9 +938,13 @@ public class NotificationCallbackService {
                         + "Напомню завтра.";
                 editMessage(client, chatId, messageId, hint, buildAcclSnoozeKeyboard(scheduleId));
                 answerCallback(client, callbackId, "");
+                metricsService.recordCallback("accl_soil", CallbackOutcome.OK);
                 log.info("Acclimation UNKNOWN: plant={} schedule={} snoozed +1d", plant.getId(), scheduleId);
             }
-            default -> answerCallback(client, callbackId, "❌ Неизвестный ответ");
+            default -> {
+                answerCallback(client, callbackId, "❌ Неизвестный ответ");
+                metricsService.recordCallback("accl_soil", CallbackOutcome.ERROR);
+            }
         }
     }
 
@@ -891,6 +957,7 @@ public class NotificationCallbackService {
     ) {
         if (parts.length != 4) {
             answerCallback(client, callbackId, "❌ Неверный формат");
+            metricsService.recordCallback("accl_snooze", CallbackOutcome.ERROR);
             return;
         }
         Long scheduleId;
@@ -900,16 +967,19 @@ public class NotificationCallbackService {
             days = Integer.parseInt(parts[3]);
         } catch (NumberFormatException e) {
             answerCallback(client, callbackId, "❌ Неверный формат");
+            metricsService.recordCallback("accl_snooze", CallbackOutcome.ERROR);
             return;
         }
         if (days < 1 || days > 7) {
             answerCallback(client, callbackId, "❌ Неверный интервал");
+            metricsService.recordCallback("accl_snooze", CallbackOutcome.ERROR);
             return;
         }
 
         Optional<CareSchedule> opt = careScheduleRepository.findById(scheduleId);
         if (opt.isEmpty()) {
             answerCallback(client, callbackId, "❌ Расписание не найдено");
+            metricsService.recordCallback("accl_snooze", CallbackOutcome.ERROR);
             return;
         }
         CareSchedule schedule = opt.get();
@@ -919,6 +989,7 @@ public class NotificationCallbackService {
         editMessage(client, chatId, messageId,
                 "⏰ Ок, напомню через " + days + " " + dayWord(days) + ".");
         answerCallback(client, callbackId, "Отложено");
+        metricsService.recordCallback("accl_snooze", CallbackOutcome.OK);
     }
 
     /**
@@ -930,6 +1001,7 @@ public class NotificationCallbackService {
     ) {
         if (parts.length != 4) {
             answerCallback(client, callbackId, "❌ Неверный формат");
+            metricsService.recordCallback("accl_checkin", CallbackOutcome.ERROR);
             return;
         }
         Long plantId;
@@ -937,6 +1009,7 @@ public class NotificationCallbackService {
             plantId = Long.parseLong(parts[2]);
         } catch (NumberFormatException e) {
             answerCallback(client, callbackId, "❌ Неверный ID");
+            metricsService.recordCallback("accl_checkin", CallbackOutcome.ERROR);
             return;
         }
         String answer = parts[3];
@@ -944,11 +1017,13 @@ public class NotificationCallbackService {
         Plant plant = plantAcclimationService.findById(plantId).orElse(null);
         if (plant == null) {
             answerCallback(client, callbackId, "❌ Растение не найдено");
+            metricsService.recordCallback("accl_checkin", CallbackOutcome.ERROR);
             return;
         }
         if (plant.isArchived()) {
             editMessage(client, chatId, messageId, "Растение уже удалено");
             answerCallback(client, callbackId, "Растение удалено");
+            metricsService.recordCallback("accl_checkin", CallbackOutcome.IDEMPOTENT);
             return;
         }
 
@@ -966,11 +1041,13 @@ public class NotificationCallbackService {
         };
         if (summary == null) {
             answerCallback(client, callbackId, "❌ Неизвестный ответ");
+            metricsService.recordCallback("accl_checkin", CallbackOutcome.ERROR);
             return;
         }
 
         editMessage(client, chatId, messageId, summary);
         answerCallback(client, callbackId, "Записано");
+        metricsService.recordCallback("accl_checkin", CallbackOutcome.OK);
 
         // Перепланируем следующий check-in через 3 дня (или вычистим, если режим скоро закончится).
         plantAcclimationService.scheduleNextCheckin(plant);

--- a/src/main/java/com/plantcare/bot/service/NotificationDigestCallbackService.java
+++ b/src/main/java/com/plantcare/bot/service/NotificationDigestCallbackService.java
@@ -4,6 +4,8 @@ import com.plantcare.bot.domain.CareSchedule;
 import com.plantcare.bot.domain.DigestTaskItem;
 import com.plantcare.bot.domain.NotificationDigest;
 import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.metrics.MetricsService;
+import com.plantcare.bot.metrics.MetricsService.CallbackOutcome;
 import com.plantcare.bot.repository.CareScheduleRepository;
 import com.plantcare.bot.repository.NotificationDigestRepository;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +34,7 @@ public class NotificationDigestCallbackService {
     private final NotificationDigestRepository notificationDigestRepository;
     private final CareScheduleRepository careScheduleRepository;
     private final NotificationCallbackService notificationCallbackService;
+    private final MetricsService metricsService;
 
     @Transactional
     public void handleCallback(CallbackQuery callbackQuery, TelegramClient client) {
@@ -44,16 +47,19 @@ public class NotificationDigestCallbackService {
 
         if (parts.length != 3) {
             answerCallback(client, callbackId, "❌ Неизвестная команда");
+            metricsService.recordCallback("digest_unknown", CallbackOutcome.ERROR);
             return;
         }
 
         String action = parts[1];
+        String metricAction = "digest_" + action;
 
         Long digestId;
         try {
             digestId = Long.parseLong(parts[2]);
         } catch (NumberFormatException e) {
             answerCallback(client, callbackId, "❌ Неверный ID");
+            metricsService.recordCallback(metricAction, CallbackOutcome.ERROR);
             return;
         }
 
@@ -61,6 +67,7 @@ public class NotificationDigestCallbackService {
 
         if (optionalDigest.isEmpty()) {
             answerCallback(client, callbackId, "❌ Дайджест не найден");
+            metricsService.recordCallback(metricAction, CallbackOutcome.ERROR);
             return;
         }
 
@@ -69,7 +76,10 @@ public class NotificationDigestCallbackService {
         switch (action) {
             case "done_all" -> handleDoneAll(digest, client, callbackId, chatId, messageId);
             case "expand" -> handleExpand(digest, client, callbackId, chatId, messageId);
-            default -> answerCallback(client, callbackId, "❌ Неизвестное действие");
+            default -> {
+                answerCallback(client, callbackId, "❌ Неизвестное действие");
+                metricsService.recordCallback(metricAction, CallbackOutcome.ERROR);
+            }
         }
     }
 
@@ -105,11 +115,13 @@ public class NotificationDigestCallbackService {
 
         if (markedCount == 0) {
             answerCallback(client, callbackId, "Уже отмечено");
+            metricsService.recordCallback("digest_done_all", CallbackOutcome.IDEMPOTENT);
             return;
         }
 
         editMessage(client, chatId, messageId, "✅ Все задачи из дайджеста отмечены как выполненные");
         answerCallback(client, callbackId, "Готово!");
+        metricsService.recordCallback("digest_done_all", CallbackOutcome.OK);
     }
 
     private void handleExpand(
@@ -124,6 +136,7 @@ public class NotificationDigestCallbackService {
         if (remainingTasks.isEmpty()) {
             editMessage(client, chatId, messageId, "✅ Все задачи уже выполнены");
             answerCallback(client, callbackId, "Все задачи выполнены");
+            metricsService.recordCallback("digest_expand", CallbackOutcome.IDEMPOTENT);
             return;
         }
 
@@ -140,9 +153,11 @@ public class NotificationDigestCallbackService {
         try {
             client.execute(edit);
             answerCallback(client, callbackId, "Открыто по одному");
+            metricsService.recordCallback("digest_expand", CallbackOutcome.OK);
         } catch (TelegramApiException e) {
             log.error("Failed to expand digest: {}", e.getMessage(), e);
             answerCallback(client, callbackId, "❌ Не удалось открыть список");
+            metricsService.recordCallback("digest_expand", CallbackOutcome.ERROR);
         }
     }
 

--- a/src/main/java/com/plantcare/bot/service/NotificationSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/NotificationSchedulerService.java
@@ -9,10 +9,12 @@ import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.NotificationType;
 import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.metrics.MetricsService;
 import com.plantcare.bot.repository.CareScheduleRepository;
 import com.plantcare.bot.repository.NotificationDigestRepository;
 import com.plantcare.bot.repository.NotificationLogRepository;
 import com.plantcare.bot.repository.UserRepository;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -49,11 +51,21 @@ public class NotificationSchedulerService {
     private final SchedulerHealthTracker schedulerHealthTracker;
     private final com.plantcare.bot.weather.service.WeatherService weatherService;
     private final com.plantcare.bot.seasonal.service.SeasonalIntervalService seasonalIntervalService;
+    private final MetricsService metricsService;
 
     @Scheduled(fixedRate = 60_000)
     @Transactional
     public void checkAndSendNotifications() {
-        executeTick();
+        // Issue #115: оборачиваем тик в Timer, чтобы в Prometheus была видна
+        // длительность обработки (p50/p95/p99). Сам executeTick остаётся
+        // без изменений — Timer.Sample.stop() запишет latency в hot path
+        // только один раз за тик.
+        Timer.Sample sample = metricsService.startSchedulerTickTimer();
+        try {
+            executeTick();
+        } finally {
+            metricsService.stopSchedulerTickTimer(sample);
+        }
     }
 
     /**
@@ -321,6 +333,7 @@ public class NotificationSchedulerService {
         try {
             telegramClientProvider.getTelegramClient().execute(message);
             saveNotificationLog(plant, schedule.getTaskType());
+            metricsService.recordNotificationSent(MetricsService.CHANNEL_TELEGRAM, schedule.getTaskType());
 
             log.info("Sent notification for plant '{}' id={} to user {} (acclimation={})",
                     plant.getName(), plant.getId(), user.getTelegramChatId(), inAcclimation);
@@ -381,7 +394,15 @@ public class NotificationSchedulerService {
 
             for (CareSchedule schedule : schedules) {
                 saveNotificationLog(schedule.getPlant(), schedule.getTaskType());
+                // Каждый сгруппированный пуш считаем за отправленное уведомление —
+                // юзер получил один message, но он покрывает N задач, и срезы по
+                // task_type нужны для аналитики «сколько поливных пушей в день».
+                metricsService.recordNotificationSent(
+                        MetricsService.CHANNEL_TELEGRAM, schedule.getTaskType());
             }
+            // Плюс отдельный счётчик именно для дайджестов — чтобы видеть, какая
+            // доля уведомлений уходит группой, а какая поштучно.
+            metricsService.recordDigestSent();
 
             log.info("Sent digest id={} with {} tasks to user {}",
                     savedDigest.getId(), schedules.size(), user.getTelegramChatId());
@@ -505,14 +526,24 @@ public class NotificationSchedulerService {
 
     private void handleTelegramError(User user, TelegramApiException e) {
         String errorMessage = e.getMessage();
+        MetricsService.TelegramErrorCode code = MetricsService.TelegramErrorCode.fromMessage(errorMessage);
+        metricsService.recordTelegramApiError(code);
 
         if (errorMessage != null && errorMessage.contains("403")) {
             log.warn("Bot blocked by user {}, marking as blocked", user.getTelegramChatId());
             user.setBlocked(true);
             userRepository.save(user);
+            metricsService.recordNotificationFailed(
+                    MetricsService.CHANNEL_TELEGRAM, MetricsService.FailureReason.BLOCKED);
         } else {
             log.error("Failed to send notification to user {}: {}",
                     user.getTelegramChatId(), errorMessage, e);
+            MetricsService.FailureReason reason = switch (code) {
+                case RATE_LIMITED -> MetricsService.FailureReason.RATE_LIMIT;
+                case BAD_REQUEST, FORBIDDEN -> MetricsService.FailureReason.API_ERROR;
+                case OTHER -> MetricsService.FailureReason.OTHER;
+            };
+            metricsService.recordNotificationFailed(MetricsService.CHANNEL_TELEGRAM, reason);
         }
     }
 

--- a/src/main/java/com/plantcare/bot/service/UserService.java
+++ b/src/main/java/com/plantcare/bot/service/UserService.java
@@ -2,6 +2,7 @@ package com.plantcare.bot.service;
 
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.ConversationState;
+import com.plantcare.bot.metrics.MetricsService;
 import com.plantcare.bot.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,13 +29,24 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final Clock clock;
+    private final MetricsService metricsService;
 
     @Transactional
     public User findOrCreate(Long chatId, String username) {
+        // Issue #115: считаем только реальные регистрации, а не каждый /start
+        // от уже зарегистрированного юзера. existsByTelegramChatId по уникальному
+        // индексу — cheap lookup, в хот-патчах не критичен (вызывается на каждый
+        // update от Telegram, но это не миллион rps).
+        boolean isNew = !userRepository.existsByTelegramChatId(chatId);
+
         userRepository.insertOrIgnore(chatId, username);
 
         User user = userRepository.findByTelegramChatId(chatId)
                 .orElseThrow(() -> new IllegalStateException("User must exist after insert-or-ignore"));
+
+        if (isNew) {
+            metricsService.recordUserRegistered();
+        }
 
         return updateUsernameIfChanged(user, username);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,10 +79,17 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics
+        # Issue #115: prometheus добавлен для Prometheus scrape.
+        # На prod /actuator/prometheus требует роли ADMIN (см. AdminSecurityConfig),
+        # health/info остаются публичными (UptimeRobot и т.п.).
+        include: health,info,metrics,prometheus
   endpoint:
     health:
       show-details: when-authorized
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 
 # Параметры приложения (issue #28: healthcheck шедулера)
 plants:

--- a/src/test/java/com/plantcare/bot/metrics/DauMetricsUpdaterTest.java
+++ b/src/test/java/com/plantcare/bot/metrics/DauMetricsUpdaterTest.java
@@ -1,0 +1,145 @@
+package com.plantcare.bot.metrics;
+
+import com.plantcare.bot.repository.CareHistoryRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit-тесты {@link DauMetricsUpdater}. Используем фиксированный {@link Clock},
+ * чтобы проверить, что cutoff считается ровно как «сейчас − 24h»,
+ * и реальный {@link MetricsService} с {@link SimpleMeterRegistry} — это даёт
+ * сквозную проверку, что значение действительно доходит до Micrometer-gauge.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DauMetricsUpdater — unit-тесты")
+class DauMetricsUpdaterTest {
+
+    private static final Instant FIXED_NOW = Instant.parse("2026-05-22T10:00:00Z");
+
+    @Mock
+    private CareHistoryRepository careHistoryRepository;
+
+    private SimpleMeterRegistry registry;
+    private MetricsService metricsService;
+    private DauMetricsUpdater updater;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+        metricsService = new MetricsService(registry);
+        ReflectionTestUtils.invokeMethod(metricsService, "registerGauges");
+
+        Clock fixedClock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+        updater = new DauMetricsUpdater(careHistoryRepository, metricsService, fixedClock);
+    }
+
+    @Test
+    void should_query_repository_with_cutoff_24h_before_now_when_refresh_called() {
+        when(careHistoryRepository.countDistinctActiveUsersSince(any())).thenReturn(0L);
+
+        updater.refresh();
+
+        ArgumentCaptor<LocalDateTime> cutoffCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(careHistoryRepository).countDistinctActiveUsersSince(cutoffCaptor.capture());
+
+        LocalDateTime expectedCutoff = LocalDateTime.ofInstant(FIXED_NOW, ZoneOffset.UTC).minusHours(24);
+        assertThat(cutoffCaptor.getValue()).isEqualTo(expectedCutoff);
+    }
+
+    @Test
+    void should_push_repository_result_into_metrics_service_when_refresh_called() {
+        when(careHistoryRepository.countDistinctActiveUsersSince(any())).thenReturn(137L);
+
+        updater.refresh();
+
+        assertThat(metricsService.getActiveDau()).isEqualTo(137L);
+        assertThat(registry.find(MetricsService.USERS_ACTIVE_DAU).gauge().value()).isEqualTo(137.0);
+    }
+
+    @Test
+    void should_set_dau_to_zero_when_repository_returns_zero() {
+        when(careHistoryRepository.countDistinctActiveUsersSince(any())).thenReturn(0L);
+
+        updater.refresh();
+
+        assertThat(metricsService.getActiveDau()).isZero();
+        assertThat(registry.find(MetricsService.USERS_ACTIVE_DAU).gauge().value()).isEqualTo(0.0);
+    }
+
+    @Test
+    void should_overwrite_previous_value_on_subsequent_refresh() {
+        when(careHistoryRepository.countDistinctActiveUsersSince(any()))
+                .thenReturn(50L)
+                .thenReturn(10L);
+
+        updater.refresh();
+        assertThat(metricsService.getActiveDau()).isEqualTo(50L);
+
+        updater.refresh();
+        assertThat(metricsService.getActiveDau()).isEqualTo(10L);
+    }
+
+    @Test
+    void should_not_throw_and_leave_gauge_at_zero_when_warm_up_repository_fails() {
+        when(careHistoryRepository.countDistinctActiveUsersSince(any()))
+                .thenThrow(new RuntimeException("DB unavailable on boot"));
+
+        // warmUp ловит исключения и просто пишет в log — контекст не должен падать.
+        ReflectionTestUtils.invokeMethod(updater, "warmUp");
+
+        assertThat(metricsService.getActiveDau()).isZero();
+    }
+
+    @Test
+    void should_propagate_repository_exception_from_scheduled_refresh() {
+        when(careHistoryRepository.countDistinctActiveUsersSince(any()))
+                .thenThrow(new RuntimeException("DB unavailable"));
+
+        // refresh() сам по себе не глушит исключения — это работа @Scheduled-инфраструктуры
+        // (она логнёт и продолжит). Поэтому здесь ожидаем, что throw пройдёт наверх.
+        org.assertj.core.api.Assertions
+                .assertThatThrownBy(() -> updater.refresh())
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("DB unavailable");
+
+        // Метрика осталась нетронутой (значит updateActiveDau не вызывался).
+        assertThat(metricsService.getActiveDau()).isZero();
+    }
+
+    @Test
+    void should_not_call_update_when_repository_throws() {
+        // Sanity-check к предыдущему: убеждаемся, что updateActiveDau не дёрнут,
+        // когда репозиторий упал — иначе мы могли бы записать «мусор» в gauge.
+        MetricsService spy = org.mockito.Mockito.spy(new MetricsService(registry));
+        ReflectionTestUtils.invokeMethod(spy, "registerGauges");
+        DauMetricsUpdater localUpdater = new DauMetricsUpdater(
+                careHistoryRepository, spy, Clock.fixed(FIXED_NOW, ZoneOffset.UTC));
+
+        when(careHistoryRepository.countDistinctActiveUsersSince(any()))
+                .thenThrow(new RuntimeException("boom"));
+
+        org.assertj.core.api.Assertions
+                .assertThatThrownBy(localUpdater::refresh)
+                .isInstanceOf(RuntimeException.class);
+
+        verify(spy, never()).updateActiveDau(org.mockito.ArgumentMatchers.anyLong());
+    }
+}

--- a/src/test/java/com/plantcare/bot/metrics/MetricsServiceTest.java
+++ b/src/test/java/com/plantcare/bot/metrics/MetricsServiceTest.java
@@ -1,0 +1,316 @@
+package com.plantcare.bot.metrics;
+
+import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.metrics.MetricsService.CallbackOutcome;
+import com.plantcare.bot.metrics.MetricsService.FailureReason;
+import com.plantcare.bot.metrics.MetricsService.TelegramErrorCode;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit-тесты для {@link MetricsService}. Используем in-memory
+ * {@link SimpleMeterRegistry} — никакого Spring контекста, никакого
+ * Prometheus-формата. Проверяем именно «вызов метода кладёт правильный
+ * counter с правильными тэгами».
+ */
+@DisplayName("MetricsService — unit-тесты")
+class MetricsServiceTest {
+
+    private SimpleMeterRegistry registry;
+    private MetricsService metricsService;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+        metricsService = new MetricsService(registry);
+
+        // Имитируем PostConstruct, т.к. без него gauge USERS_ACTIVE_DAU не зарегистрирован.
+        ReflectionTestUtils.invokeMethod(metricsService, "registerGauges");
+    }
+
+    @Nested
+    @DisplayName("recordNotificationSent")
+    class NotificationSent {
+
+        @Test
+        void should_increment_counter_with_channel_and_task_type_tags_when_called() {
+            metricsService.recordNotificationSent(MetricsService.CHANNEL_TELEGRAM, TaskType.WATERING);
+
+            Counter counter = registry.find(MetricsService.NOTIFICATIONS_SENT)
+                    .tag("channel", "telegram")
+                    .tag("task_type", "WATERING")
+                    .counter();
+
+            assertThat(counter).isNotNull();
+            assertThat(counter.count()).isEqualTo(1.0);
+        }
+
+        @Test
+        void should_increment_separate_counters_for_different_task_types() {
+            metricsService.recordNotificationSent("telegram", TaskType.WATERING);
+            metricsService.recordNotificationSent("telegram", TaskType.WATERING);
+            metricsService.recordNotificationSent("telegram", TaskType.MISTING);
+
+            Counter watering = registry.find(MetricsService.NOTIFICATIONS_SENT)
+                    .tag("task_type", "WATERING").counter();
+            Counter misting = registry.find(MetricsService.NOTIFICATIONS_SENT)
+                    .tag("task_type", "MISTING").counter();
+
+            assertThat(watering.count()).isEqualTo(2.0);
+            assertThat(misting.count()).isEqualTo(1.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("recordNotificationFailed")
+    class NotificationFailed {
+
+        @Test
+        void should_increment_counter_with_channel_and_reason_tags_when_called() {
+            metricsService.recordNotificationFailed(MetricsService.CHANNEL_TELEGRAM, FailureReason.RATE_LIMIT);
+
+            Counter counter = registry.find(MetricsService.NOTIFICATIONS_FAILED)
+                    .tag("channel", "telegram")
+                    .tag("reason", "rate_limit")
+                    .counter();
+
+            assertThat(counter).isNotNull();
+            assertThat(counter.count()).isEqualTo(1.0);
+        }
+
+        @Test
+        void should_map_all_failure_reasons_to_distinct_tag_values() {
+            metricsService.recordNotificationFailed("telegram", FailureReason.RATE_LIMIT);
+            metricsService.recordNotificationFailed("telegram", FailureReason.API_ERROR);
+            metricsService.recordNotificationFailed("telegram", FailureReason.BLOCKED);
+            metricsService.recordNotificationFailed("telegram", FailureReason.OTHER);
+
+            assertThat(registry.find(MetricsService.NOTIFICATIONS_FAILED).tag("reason", "rate_limit").counter().count()).isEqualTo(1.0);
+            assertThat(registry.find(MetricsService.NOTIFICATIONS_FAILED).tag("reason", "api_error").counter().count()).isEqualTo(1.0);
+            assertThat(registry.find(MetricsService.NOTIFICATIONS_FAILED).tag("reason", "blocked").counter().count()).isEqualTo(1.0);
+            assertThat(registry.find(MetricsService.NOTIFICATIONS_FAILED).tag("reason", "other").counter().count()).isEqualTo(1.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("recordDigestSent")
+    class DigestSent {
+
+        @Test
+        void should_increment_digest_counter_when_called() {
+            metricsService.recordDigestSent();
+            metricsService.recordDigestSent();
+            metricsService.recordDigestSent();
+
+            Counter counter = registry.find(MetricsService.NOTIFICATIONS_DIGEST_SENT).counter();
+
+            assertThat(counter).isNotNull();
+            assertThat(counter.count()).isEqualTo(3.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("recordTelegramApiError")
+    class TelegramApiError {
+
+        @Test
+        void should_record_429_with_rate_limited_code_tag_when_message_contains_429() {
+            metricsService.recordTelegramApiError(TelegramErrorCode.RATE_LIMITED);
+
+            Counter counter = registry.find(MetricsService.TELEGRAM_API_ERRORS)
+                    .tag("code", "429")
+                    .counter();
+
+            assertThat(counter).isNotNull();
+            assertThat(counter.count()).isEqualTo(1.0);
+        }
+
+        @Test
+        void should_map_unknown_codes_to_other_tag() {
+            metricsService.recordTelegramApiError(TelegramErrorCode.OTHER);
+
+            Counter counter = registry.find(MetricsService.TELEGRAM_API_ERRORS)
+                    .tag("code", "other")
+                    .counter();
+
+            assertThat(counter).isNotNull();
+            assertThat(counter.count()).isEqualTo(1.0);
+        }
+
+        @Test
+        void should_parse_429_from_message_string() {
+            assertThat(TelegramErrorCode.fromMessage("[429] Too Many Requests"))
+                    .isEqualTo(TelegramErrorCode.RATE_LIMITED);
+        }
+
+        @Test
+        void should_parse_403_from_message_string() {
+            assertThat(TelegramErrorCode.fromMessage("Forbidden: bot was blocked by the user [403]"))
+                    .isEqualTo(TelegramErrorCode.FORBIDDEN);
+        }
+
+        @Test
+        void should_parse_400_from_message_string() {
+            assertThat(TelegramErrorCode.fromMessage("[400] Bad Request: chat not found"))
+                    .isEqualTo(TelegramErrorCode.BAD_REQUEST);
+        }
+
+        @Test
+        void should_fall_back_to_other_when_message_has_no_known_code() {
+            assertThat(TelegramErrorCode.fromMessage("Network timeout"))
+                    .isEqualTo(TelegramErrorCode.OTHER);
+        }
+
+        @Test
+        void should_fall_back_to_other_when_message_is_null() {
+            assertThat(TelegramErrorCode.fromMessage(null))
+                    .isEqualTo(TelegramErrorCode.OTHER);
+        }
+    }
+
+    @Nested
+    @DisplayName("recordCallback")
+    class Callback {
+
+        @Test
+        void should_increment_counter_with_action_and_outcome_tags_when_called() {
+            metricsService.recordCallback("done", CallbackOutcome.OK);
+
+            Counter counter = registry.find(MetricsService.CALLBACKS_PROCESSED)
+                    .tag("action", "done")
+                    .tag("outcome", "ok")
+                    .counter();
+
+            assertThat(counter).isNotNull();
+            assertThat(counter.count()).isEqualTo(1.0);
+        }
+
+        @Test
+        void should_distinguish_outcomes_for_same_action() {
+            metricsService.recordCallback("done", CallbackOutcome.OK);
+            metricsService.recordCallback("done", CallbackOutcome.OK);
+            metricsService.recordCallback("done", CallbackOutcome.IDEMPOTENT);
+            metricsService.recordCallback("done", CallbackOutcome.ERROR);
+
+            assertThat(registry.find(MetricsService.CALLBACKS_PROCESSED)
+                    .tag("action", "done").tag("outcome", "ok").counter().count()).isEqualTo(2.0);
+            assertThat(registry.find(MetricsService.CALLBACKS_PROCESSED)
+                    .tag("action", "done").tag("outcome", "idempotent").counter().count()).isEqualTo(1.0);
+            assertThat(registry.find(MetricsService.CALLBACKS_PROCESSED)
+                    .tag("action", "done").tag("outcome", "error").counter().count()).isEqualTo(1.0);
+        }
+
+        @Test
+        void should_map_unknown_callback_action_to_unknown_when_action_not_in_whitelist() {
+            // Имитация атаки: клиент шлёт callback_data с произвольным action,
+            // которого нет в whitelist'е. Не должно создаваться отдельного
+            // counter'а с этим тэгом — иначе cardinality реестра не ограничена.
+            metricsService.recordCallback("RANDOM_GARBAGE_xxxxx", CallbackOutcome.OK);
+
+            Counter unknownCounter = registry.find(MetricsService.CALLBACKS_PROCESSED)
+                    .tag("action", "unknown")
+                    .tag("outcome", "ok")
+                    .counter();
+            Counter garbageCounter = registry.find(MetricsService.CALLBACKS_PROCESSED)
+                    .tag("action", "RANDOM_GARBAGE_xxxxx")
+                    .counter();
+
+            assertThat(unknownCounter).isNotNull();
+            assertThat(unknownCounter.count()).isEqualTo(1.0);
+            assertThat(garbageCounter).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("recordUserRegistered")
+    class UserRegistered {
+
+        @Test
+        void should_increment_users_registered_total_when_called() {
+            metricsService.recordUserRegistered();
+            metricsService.recordUserRegistered();
+
+            Counter counter = registry.find(MetricsService.USERS_REGISTERED_TOTAL).counter();
+
+            assertThat(counter).isNotNull();
+            assertThat(counter.count()).isEqualTo(2.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateActiveDau / DAU gauge")
+    class ActiveDau {
+
+        @Test
+        void should_expose_zero_via_gauge_when_no_value_set() {
+            Gauge gauge = registry.find(MetricsService.USERS_ACTIVE_DAU).gauge();
+
+            assertThat(gauge).isNotNull();
+            assertThat(gauge.value()).isEqualTo(0.0);
+        }
+
+        @Test
+        void should_expose_latest_value_via_gauge_after_update() {
+            metricsService.updateActiveDau(42L);
+
+            Gauge gauge = registry.find(MetricsService.USERS_ACTIVE_DAU).gauge();
+
+            assertThat(gauge.value()).isEqualTo(42.0);
+            assertThat(metricsService.getActiveDau()).isEqualTo(42L);
+        }
+
+        @Test
+        void should_overwrite_previous_value_when_updated_repeatedly() {
+            metricsService.updateActiveDau(100L);
+            metricsService.updateActiveDau(7L);
+
+            assertThat(registry.find(MetricsService.USERS_ACTIVE_DAU).gauge().value()).isEqualTo(7.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("Scheduler tick timer")
+    class SchedulerTickTimer {
+
+        @Test
+        void should_return_non_null_sample_when_started() {
+            Timer.Sample sample = metricsService.startSchedulerTickTimer();
+
+            assertThat(sample).isNotNull();
+        }
+
+        @Test
+        void should_record_one_observation_in_timer_when_sample_stopped() {
+            Timer.Sample sample = metricsService.startSchedulerTickTimer();
+
+            metricsService.stopSchedulerTickTimer(sample);
+
+            Timer timer = registry.find(MetricsService.SCHEDULER_TICK_DURATION).timer();
+
+            assertThat(timer).isNotNull();
+            assertThat(timer.count()).isEqualTo(1L);
+            // Non-negative time totalTime — sanity check; не привязываемся к конкретной длительности.
+            assertThat(timer.totalTime(java.util.concurrent.TimeUnit.NANOSECONDS)).isGreaterThanOrEqualTo(0.0);
+        }
+
+        @Test
+        void should_aggregate_multiple_ticks_in_same_timer() {
+            metricsService.stopSchedulerTickTimer(metricsService.startSchedulerTickTimer());
+            metricsService.stopSchedulerTickTimer(metricsService.startSchedulerTickTimer());
+            metricsService.stopSchedulerTickTimer(metricsService.startSchedulerTickTimer());
+
+            Timer timer = registry.find(MetricsService.SCHEDULER_TICK_DURATION).timer();
+
+            assertThat(timer.count()).isEqualTo(3L);
+        }
+    }
+}

--- a/src/test/java/com/plantcare/bot/metrics/PrometheusEndpointIntegrationTest.java
+++ b/src/test/java/com/plantcare/bot/metrics/PrometheusEndpointIntegrationTest.java
@@ -1,0 +1,108 @@
+package com.plantcare.bot.metrics;
+
+import com.plantcare.bot.domain.enums.TaskType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Smoke-тест публичной доступности /actuator/prometheus в test-профиле.
+ *
+ * <p>В тестовом конфиге admin-креды не заданы → {@code prometheusSecurityFilterChain}
+ * c {@link org.springframework.boot.autoconfigure.condition.ConditionalOnExpression}
+ * не регистрируется, и эндпоинт падает в default chain (permitAll). Это
+ * ожидаемое поведение — реальная защита через basic-auth проверяется только
+ * на прод/staging, где есть {@code ADMIN_USERNAME}.
+ *
+ * <p>Что проверяем:
+ * <ul>
+ *   <li>endpoint реально включён в {@code management.endpoints.web.exposure.include};</li>
+ *   <li>после события «зарегистрировали юзера» в теле появляется
+ *       {@code users_registered_total} — значит Prometheus-формат собирается
+ *       и наши кастомные имена .-нотации корректно конвертируются в _.</li>
+ * </ul>
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("Smoke: GET /actuator/prometheus")
+class PrometheusEndpointIntegrationTest {
+
+    private static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("plants_care_test")
+                    .withUsername("test")
+                    .withPassword("test")
+                    .withReuse(true);
+
+    static {
+        POSTGRES.start();
+    }
+
+    @DynamicPropertySource
+    static void configureDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+    }
+
+    @Autowired private TestRestTemplate restTemplate;
+    @Autowired private MetricsService metricsService;
+
+    @Test
+    @DisplayName("Endpoint отдаёт 200 OK в test-профиле (без admin-кредов)")
+    void should_return_200_when_admin_disabled_in_test_profile() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/actuator/prometheus", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("Тело содержит наши кастомные метрики в Prometheus-формате (точки → подчёркивания)")
+    void should_expose_custom_business_metrics_in_prometheus_format() {
+        // Зажигаем по разу каждый из основных counter'ов, чтобы они появились в registry.
+        // Без этого Micrometer регистрирует counter лениво — на первом инкременте.
+        metricsService.recordUserRegistered();
+        metricsService.recordNotificationSent(MetricsService.CHANNEL_TELEGRAM, TaskType.WATERING);
+        metricsService.recordDigestSent();
+        metricsService.updateActiveDau(5L);
+
+        ResponseEntity<String> response = restTemplate.getForEntity("/actuator/prometheus", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        String body = response.getBody();
+        assertThat(body)
+                .as("Prometheus body should expose our custom counters with dots converted to underscores")
+                .contains("users_registered_total")
+                .contains("notifications_sent_total")
+                .contains("notifications_digest_sent_total")
+                .contains("users_active_dau");
+    }
+
+    @Test
+    @DisplayName("Тэги notifications_sent попадают в Prometheus-формат (channel, task_type)")
+    void should_include_low_cardinality_tags_in_prometheus_output() {
+        metricsService.recordNotificationSent(MetricsService.CHANNEL_TELEGRAM, TaskType.MISTING);
+
+        ResponseEntity<String> response = restTemplate.getForEntity("/actuator/prometheus", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        // Не привязываемся к точному порядку label'ов — проверяем сам факт их наличия.
+        assertThat(response.getBody())
+                .contains("channel=\"telegram\"")
+                .contains("task_type=\"MISTING\"");
+    }
+}

--- a/src/test/java/com/plantcare/bot/service/NotificationCallbackServiceAcclimationTest.java
+++ b/src/test/java/com/plantcare/bot/service/NotificationCallbackServiceAcclimationTest.java
@@ -4,6 +4,7 @@ import com.plantcare.bot.domain.CareSchedule;
 import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.metrics.MetricsService;
 import com.plantcare.bot.repository.CareHistoryRepository;
 import com.plantcare.bot.repository.CareScheduleRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,6 +49,7 @@ class NotificationCallbackServiceAcclimationTest {
     @Mock private TelegramClient telegramClient;
     @Mock private CallbackQuery callbackQuery;
     @Mock private Message message;
+    @Mock private MetricsService metricsService;
 
     @InjectMocks
     private NotificationCallbackService service;

--- a/src/test/java/com/plantcare/bot/service/NotificationCallbackServiceSoilCheckTest.java
+++ b/src/test/java/com/plantcare/bot/service/NotificationCallbackServiceSoilCheckTest.java
@@ -5,6 +5,7 @@ import com.plantcare.bot.domain.CareSchedule;
 import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.metrics.MetricsService;
 import com.plantcare.bot.repository.CareHistoryRepository;
 import com.plantcare.bot.repository.CareScheduleRepository;
 import com.plantcare.bot.seasonal.service.SeasonalIntervalService;
@@ -70,6 +71,9 @@ class NotificationCallbackServiceSoilCheckTest {
 
     @Mock
     private Message message;
+
+    @Mock
+    private MetricsService metricsService;
 
     @InjectMocks
     private NotificationCallbackService service;

--- a/src/test/java/com/plantcare/bot/service/NotificationCallbackServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/NotificationCallbackServiceTest.java
@@ -5,6 +5,8 @@ import com.plantcare.bot.domain.CareSchedule;
 import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.metrics.MetricsService;
+import com.plantcare.bot.metrics.MetricsService.CallbackOutcome;
 import com.plantcare.bot.repository.CareHistoryRepository;
 import com.plantcare.bot.repository.CareScheduleRepository;
 import com.plantcare.bot.seasonal.service.SeasonalIntervalService;
@@ -63,6 +65,9 @@ class NotificationCallbackServiceTest {
 
     @Mock
     private Message message;
+
+    @Mock
+    private MetricsService metricsService;
 
     @InjectMocks
     private NotificationCallbackService service;
@@ -655,6 +660,143 @@ class NotificationCallbackServiceTest {
             assertThat(captor.getAllValues().get(0).getText()).contains("1 растения");
             assertThat(captor.getAllValues().get(1).getText()).contains("5 растений");
             assertThat(captor.getAllValues().get(2).getText()).contains("21 растения");
+        }
+    }
+
+    @Nested
+    @DisplayName("Метрики callbacks (#115)")
+    class CallbackMetrics {
+
+        @Test
+        @DisplayName("done MISTING (без WATERING-flow): recordCallback(done, ok)")
+        void should_record_done_ok_when_misting_done_succeeds() throws TelegramApiException {
+            // MISTING — отметка идёт по прежнему пути (не через WATERING двухшаговый flow),
+            // т.е. финальный recordCallback(done, ok) должен сработать.
+            when(callbackQuery.getData()).thenReturn("v1:done:1");
+            when(careScheduleRepository.findById(1L)).thenReturn(Optional.of(schedule));
+            when(careHistoryRepository.findFirstByPlantIdAndTaskTypeOrderByDoneAtDesc(any(), any()))
+                    .thenReturn(Optional.empty());
+
+            service.handleCallback(callbackQuery, telegramClient);
+
+            verify(metricsService).recordCallback("done", CallbackOutcome.OK);
+        }
+
+        @Test
+        @DisplayName("snooze: recordCallback(snooze, ok)")
+        void should_record_snooze_ok_when_snooze_action_handled() throws TelegramApiException {
+            when(callbackQuery.getData()).thenReturn("v1:snooze:1");
+            when(careScheduleRepository.findById(1L)).thenReturn(Optional.of(schedule));
+
+            service.handleCallback(callbackQuery, telegramClient);
+
+            verify(metricsService).recordCallback("snooze", CallbackOutcome.OK);
+        }
+
+        @Test
+        @DisplayName("skip: recordCallback(skip, ok)")
+        void should_record_skip_ok_when_skip_action_handled() throws TelegramApiException {
+            when(callbackQuery.getData()).thenReturn("v1:skip:1");
+            when(careScheduleRepository.findById(1L)).thenReturn(Optional.of(schedule));
+            when(careHistoryRepository.findFirstByPlantIdAndTaskTypeOrderByDoneAtDesc(any(), any()))
+                    .thenReturn(Optional.empty());
+
+            service.handleCallback(callbackQuery, telegramClient);
+
+            verify(metricsService).recordCallback("skip", CallbackOutcome.OK);
+        }
+
+        @Test
+        @DisplayName("Повторное done в окне дедупа: recordCallback(done, idempotent)")
+        void should_record_done_idempotent_when_dedup_within_60s() throws TelegramApiException {
+            CareHistory recent = CareHistory.builder()
+                    .plant(plant)
+                    .taskType(TaskType.MISTING)
+                    .doneAt(LocalDateTime.now().minusSeconds(10))
+                    .onTime(true)
+                    .build();
+
+            when(callbackQuery.getData()).thenReturn("v1:done:1");
+            when(careScheduleRepository.findById(1L)).thenReturn(Optional.of(schedule));
+            when(careHistoryRepository.findFirstByPlantIdAndTaskTypeOrderByDoneAtDesc(any(), any()))
+                    .thenReturn(Optional.of(recent));
+
+            service.handleCallback(callbackQuery, telegramClient);
+
+            verify(metricsService).recordCallback("done", CallbackOutcome.IDEMPOTENT);
+        }
+
+        @Test
+        @DisplayName("Архивированное растение: recordCallback(done, idempotent)")
+        void should_record_done_idempotent_when_plant_archived() throws TelegramApiException {
+            plant.archive();
+
+            when(callbackQuery.getData()).thenReturn("v1:done:1");
+            when(careScheduleRepository.findById(1L)).thenReturn(Optional.of(schedule));
+
+            service.handleCallback(callbackQuery, telegramClient);
+
+            verify(metricsService).recordCallback("done", CallbackOutcome.IDEMPOTENT);
+        }
+
+        @Test
+        @DisplayName("Невалидный формат callback: recordCallback(unknown, error)")
+        void should_record_unknown_error_when_callback_format_too_short() throws TelegramApiException {
+            when(callbackQuery.getData()).thenReturn("v1:invalid");
+
+            service.handleCallback(callbackQuery, telegramClient);
+
+            verify(metricsService).recordCallback("unknown", CallbackOutcome.ERROR);
+        }
+
+        @Test
+        @DisplayName("Несуществующий scheduleId: recordCallback(done, error)")
+        void should_record_done_error_when_schedule_not_found() throws TelegramApiException {
+            when(callbackQuery.getData()).thenReturn("v1:done:9999");
+            when(careScheduleRepository.findById(9999L)).thenReturn(Optional.empty());
+
+            service.handleCallback(callbackQuery, telegramClient);
+
+            verify(metricsService).recordCallback("done", CallbackOutcome.ERROR);
+        }
+
+        @Test
+        @DisplayName("Неизвестный action: recordCallback(unknown_action_name, error)")
+        void should_record_unknown_action_error_when_unrecognized_command() throws TelegramApiException {
+            when(callbackQuery.getData()).thenReturn("v1:weirdo:1");
+            when(careScheduleRepository.findById(1L)).thenReturn(Optional.of(schedule));
+
+            service.handleCallback(callbackQuery, telegramClient);
+
+            verify(metricsService).recordCallback("weirdo", CallbackOutcome.ERROR);
+        }
+
+        @Test
+        @DisplayName("bulk_done успешно: recordCallback(bulk_done, ok)")
+        void should_record_bulk_done_ok_on_success() throws TelegramApiException {
+            User u = User.builder().telegramChatId(100L).timezone("UTC").build();
+            when(userService.findByChatId(100L)).thenReturn(Optional.of(u));
+            when(callbackQuery.getData()).thenReturn("v1:bulk_done:5");
+            when(plantService.markBulkCareDone(any(), eq(5L), eq(TaskType.WATERING)))
+                    .thenReturn(new PlantService.BulkCareDoneResult(3, 0, "Гостиная"));
+
+            service.handleCallback(callbackQuery, telegramClient);
+
+            verify(metricsService).recordCallback("bulk_done", CallbackOutcome.OK);
+        }
+
+        @Test
+        @DisplayName("bulk_done double-click: recordCallback(bulk_done, idempotent)")
+        void should_record_bulk_done_idempotent_on_full_dedup() throws TelegramApiException {
+            User u = User.builder().telegramChatId(100L).timezone("UTC").build();
+            when(userService.findByChatId(100L)).thenReturn(Optional.of(u));
+            when(callbackQuery.getData()).thenReturn("v1:bulk_done:5");
+            when(plantService.markBulkCareDone(any(), eq(5L), eq(TaskType.WATERING)))
+                    .thenReturn(new PlantService.BulkCareDoneResult(0, 3, "Гостиная"));
+
+            service.handleCallback(callbackQuery, telegramClient);
+
+            verify(metricsService).recordCallback("bulk_done", CallbackOutcome.IDEMPOTENT);
         }
     }
 }

--- a/src/test/java/com/plantcare/bot/service/NotificationCallbackServiceWateringDetailsTest.java
+++ b/src/test/java/com/plantcare/bot/service/NotificationCallbackServiceWateringDetailsTest.java
@@ -5,6 +5,7 @@ import com.plantcare.bot.domain.CareSchedule;
 import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.metrics.MetricsService;
 import com.plantcare.bot.repository.CareHistoryRepository;
 import com.plantcare.bot.repository.CareScheduleRepository;
 import com.plantcare.bot.seasonal.service.SeasonalIntervalService;
@@ -75,6 +76,9 @@ class NotificationCallbackServiceWateringDetailsTest {
 
     @Mock
     private Message message;
+
+    @Mock
+    private MetricsService metricsService;
 
     @InjectMocks
     private NotificationCallbackService service;

--- a/src/test/java/com/plantcare/bot/service/NotificationDigestCallbackServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/NotificationDigestCallbackServiceTest.java
@@ -6,6 +6,8 @@ import com.plantcare.bot.domain.NotificationDigest;
 import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.metrics.MetricsService;
+import com.plantcare.bot.metrics.MetricsService.CallbackOutcome;
 import com.plantcare.bot.repository.CareScheduleRepository;
 import com.plantcare.bot.repository.NotificationDigestRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,6 +52,9 @@ class NotificationDigestCallbackServiceTest {
 
     @Mock
     private TelegramClient telegramClient;
+
+    @Mock
+    private MetricsService metricsService;
 
     @InjectMocks
     private NotificationDigestCallbackService service;
@@ -246,5 +251,101 @@ class NotificationDigestCallbackServiceTest {
         verify(telegramClient).execute(answerCaptor.capture());
 
         assertThat(answerCaptor.getValue().getText()).contains("Дайджест не найден");
+    }
+
+    // ================================================================
+    // Метрики (#115)
+    // ================================================================
+
+    @Test
+    @DisplayName("Метрики: успешный done_all → recordCallback(digest_done_all, ok)")
+    void should_record_digest_done_all_ok_when_marked() throws TelegramApiException {
+        when(callbackQuery.getData()).thenReturn("digest:done_all:500");
+        when(notificationDigestRepository.findById(500L)).thenReturn(Optional.of(digest));
+        when(careScheduleRepository.findById(100L)).thenReturn(Optional.of(wateringSchedule));
+        when(careScheduleRepository.findById(101L)).thenReturn(Optional.of(mistingSchedule));
+        when(notificationCallbackService.markScheduleDone(any(CareSchedule.class), any()))
+                .thenReturn(true);
+
+        service.handleCallback(callbackQuery, telegramClient);
+
+        verify(metricsService).recordCallback("digest_done_all", CallbackOutcome.OK);
+    }
+
+    @Test
+    @DisplayName("Метрики: повторный done_all → recordCallback(digest_done_all, idempotent)")
+    void should_record_digest_done_all_idempotent_when_already_marked() throws TelegramApiException {
+        when(callbackQuery.getData()).thenReturn("digest:done_all:500");
+        when(notificationDigestRepository.findById(500L)).thenReturn(Optional.of(digest));
+        when(careScheduleRepository.findById(100L)).thenReturn(Optional.of(wateringSchedule));
+        when(careScheduleRepository.findById(101L)).thenReturn(Optional.of(mistingSchedule));
+        when(notificationCallbackService.markScheduleDone(any(CareSchedule.class), any()))
+                .thenReturn(false);
+
+        service.handleCallback(callbackQuery, telegramClient);
+
+        verify(metricsService).recordCallback("digest_done_all", CallbackOutcome.IDEMPOTENT);
+    }
+
+    @Test
+    @DisplayName("Метрики: успешный expand → recordCallback(digest_expand, ok)")
+    void should_record_digest_expand_ok_when_tasks_present() throws TelegramApiException {
+        when(callbackQuery.getData()).thenReturn("digest:expand:500");
+        when(notificationDigestRepository.findById(500L)).thenReturn(Optional.of(digest));
+        when(careScheduleRepository.findById(100L)).thenReturn(Optional.of(wateringSchedule));
+        when(careScheduleRepository.findById(101L)).thenReturn(Optional.of(mistingSchedule));
+
+        service.handleCallback(callbackQuery, telegramClient);
+
+        verify(metricsService).recordCallback("digest_expand", CallbackOutcome.OK);
+    }
+
+    @Test
+    @DisplayName("Метрики: expand когда все задачи уже сделаны → recordCallback(digest_expand, idempotent)")
+    void should_record_digest_expand_idempotent_when_remaining_empty() throws TelegramApiException {
+        // Сдвигаем обоим nextDueAt далеко вперёд — getRemainingTasks вернёт пустой список.
+        wateringSchedule.setNextDueAt(LocalDateTime.now().plusDays(7));
+        mistingSchedule.setNextDueAt(LocalDateTime.now().plusDays(7));
+
+        when(callbackQuery.getData()).thenReturn("digest:expand:500");
+        when(notificationDigestRepository.findById(500L)).thenReturn(Optional.of(digest));
+        when(careScheduleRepository.findById(100L)).thenReturn(Optional.of(wateringSchedule));
+        when(careScheduleRepository.findById(101L)).thenReturn(Optional.of(mistingSchedule));
+
+        service.handleCallback(callbackQuery, telegramClient);
+
+        verify(metricsService).recordCallback("digest_expand", CallbackOutcome.IDEMPOTENT);
+    }
+
+    @Test
+    @DisplayName("Метрики: неизвестный action → recordCallback(digest_<action>, error)")
+    void should_record_error_when_action_unknown() throws TelegramApiException {
+        when(callbackQuery.getData()).thenReturn("digest:nonsense:500");
+        when(notificationDigestRepository.findById(500L)).thenReturn(Optional.of(digest));
+
+        service.handleCallback(callbackQuery, telegramClient);
+
+        verify(metricsService).recordCallback("digest_nonsense", CallbackOutcome.ERROR);
+    }
+
+    @Test
+    @DisplayName("Метрики: невалидный формат callback → recordCallback(digest_unknown, error)")
+    void should_record_digest_unknown_error_when_format_wrong() throws TelegramApiException {
+        when(callbackQuery.getData()).thenReturn("digest:bad");
+
+        service.handleCallback(callbackQuery, telegramClient);
+
+        verify(metricsService).recordCallback("digest_unknown", CallbackOutcome.ERROR);
+    }
+
+    @Test
+    @DisplayName("Метрики: digest не найден → recordCallback(digest_<action>, error)")
+    void should_record_error_when_digest_not_found() throws TelegramApiException {
+        when(callbackQuery.getData()).thenReturn("digest:expand:999");
+        when(notificationDigestRepository.findById(999L)).thenReturn(Optional.empty());
+
+        service.handleCallback(callbackQuery, telegramClient);
+
+        verify(metricsService).recordCallback("digest_expand", CallbackOutcome.ERROR);
     }
 }

--- a/src/test/java/com/plantcare/bot/service/NotificationSchedulerServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/NotificationSchedulerServiceTest.java
@@ -8,6 +8,7 @@ import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.NotificationType;
 import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.metrics.MetricsService;
 import com.plantcare.bot.repository.CareScheduleRepository;
 import com.plantcare.bot.repository.NotificationDigestRepository;
 import com.plantcare.bot.repository.NotificationLogRepository;
@@ -64,6 +65,9 @@ class NotificationSchedulerServiceTest {
 
     @Mock
     private SchedulerHealthTracker schedulerHealthTracker;
+
+    @Mock
+    private MetricsService metricsService;
 
     @InjectMocks
     private NotificationSchedulerService service;
@@ -706,6 +710,143 @@ class NotificationSchedulerServiceTest {
             verify(telegramClient, never()).execute(any(SendMessage.class));
             verify(notificationDigestRepository, never()).save(any());
             verify(notificationLogRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("Метрики (#115)")
+    class Metrics {
+
+        @Test
+        @DisplayName("Каждый тик оборачивается в Timer.Sample (start + stop) даже без расписаний")
+        void should_wrap_each_tick_in_timer_sample_when_called() {
+            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of());
+            io.micrometer.core.instrument.Timer.Sample sample =
+                    mock(io.micrometer.core.instrument.Timer.Sample.class);
+            when(metricsService.startSchedulerTickTimer()).thenReturn(sample);
+
+            service.checkAndSendNotifications();
+
+            verify(metricsService).startSchedulerTickTimer();
+            verify(metricsService).stopSchedulerTickTimer(sample);
+        }
+
+        @Test
+        @DisplayName("Timer.stop вызывается даже если tick упал с исключением (finally)")
+        void should_stop_timer_when_tick_fails_with_exception() {
+            io.micrometer.core.instrument.Timer.Sample sample =
+                    mock(io.micrometer.core.instrument.Timer.Sample.class);
+            when(metricsService.startSchedulerTickTimer()).thenReturn(sample);
+            when(careScheduleRepository.findDueSchedules(any()))
+                    .thenThrow(new RuntimeException("DB down"));
+
+            try {
+                service.checkAndSendNotifications();
+            } catch (RuntimeException expected) {
+                // ожидаемо
+            }
+
+            verify(metricsService).startSchedulerTickTimer();
+            verify(metricsService).stopSchedulerTickTimer(sample);
+        }
+
+        @Test
+        @DisplayName("После успешной отправки одиночного уведомления увеличивается notifications.sent")
+        void should_record_notification_sent_when_single_push_succeeds() throws TelegramApiException {
+            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
+            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
+                    .thenReturn(false);
+            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
+
+            service.checkAndSendNotifications();
+
+            verify(metricsService).recordNotificationSent(MetricsService.CHANNEL_TELEGRAM, TaskType.WATERING);
+            verify(metricsService, never()).recordNotificationFailed(any(), any());
+        }
+
+        @Test
+        @DisplayName("При 429 от Telegram пишутся telegram.api.errors[429] и notifications.failed[rate_limit]")
+        void should_record_rate_limit_failure_when_telegram_returns_429() throws TelegramApiException {
+            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
+            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
+                    .thenReturn(false);
+            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
+            when(telegramClient.execute(any(SendMessage.class)))
+                    .thenThrow(new TelegramApiException("[429] Too Many Requests: retry after 30"));
+
+            service.checkAndSendNotifications();
+
+            verify(metricsService).recordTelegramApiError(MetricsService.TelegramErrorCode.RATE_LIMITED);
+            verify(metricsService).recordNotificationFailed(
+                    MetricsService.CHANNEL_TELEGRAM, MetricsService.FailureReason.RATE_LIMIT);
+            verify(metricsService, never()).recordNotificationSent(any(), any());
+        }
+
+        @Test
+        @DisplayName("При 403 от Telegram пишутся telegram.api.errors[403] и notifications.failed[blocked]")
+        void should_record_blocked_failure_when_telegram_returns_403() throws TelegramApiException {
+            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
+            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
+                    .thenReturn(false);
+            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
+            when(telegramClient.execute(any(SendMessage.class)))
+                    .thenThrow(new TelegramApiException("Forbidden: bot was blocked by the user [403]"));
+
+            service.checkAndSendNotifications();
+
+            verify(metricsService).recordTelegramApiError(MetricsService.TelegramErrorCode.FORBIDDEN);
+            verify(metricsService).recordNotificationFailed(
+                    MetricsService.CHANNEL_TELEGRAM, MetricsService.FailureReason.BLOCKED);
+        }
+
+        @Test
+        @DisplayName("При прочей ошибке Telegram пишется failed[other]")
+        void should_record_other_failure_when_telegram_throws_unknown_error() throws TelegramApiException {
+            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
+            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
+                    .thenReturn(false);
+            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
+            when(telegramClient.execute(any(SendMessage.class)))
+                    .thenThrow(new TelegramApiException("Network timeout"));
+
+            service.checkAndSendNotifications();
+
+            verify(metricsService).recordTelegramApiError(MetricsService.TelegramErrorCode.OTHER);
+            verify(metricsService).recordNotificationFailed(
+                    MetricsService.CHANNEL_TELEGRAM, MetricsService.FailureReason.OTHER);
+        }
+
+        @Test
+        @DisplayName("Дайджест из 2 задач: 2x recordNotificationSent + 1x recordDigestSent")
+        void should_record_digest_sent_and_per_task_sent_when_digest_pushed() throws TelegramApiException {
+            CareSchedule schedule2 = CareSchedule.builder()
+                    .plant(plant)
+                    .taskType(TaskType.MISTING)
+                    .intervalDays(3)
+                    .nextDueAt(LocalDateTime.now().minusHours(1))
+                    .active(true)
+                    .build();
+            ReflectionTestUtils.setField(schedule2, "id", 101L);
+
+            NotificationDigest savedDigest = NotificationDigest.builder()
+                    .userId(user.getId())
+                    .plantTaskIds(List.of())
+                    .build();
+            ReflectionTestUtils.setField(savedDigest, "id", 500L);
+
+            when(careScheduleRepository.findDueSchedules(any()))
+                    .thenReturn(List.of(schedule, schedule2));
+            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
+                    .thenReturn(false);
+            when(notificationDigestRepository.save(any(NotificationDigest.class)))
+                    .thenReturn(savedDigest);
+            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
+
+            service.checkAndSendNotifications();
+
+            verify(metricsService).recordNotificationSent(MetricsService.CHANNEL_TELEGRAM, TaskType.WATERING);
+            verify(metricsService).recordNotificationSent(MetricsService.CHANNEL_TELEGRAM, TaskType.MISTING);
+            verify(metricsService).recordDigestSent();
         }
     }
 }

--- a/src/test/java/com/plantcare/bot/service/UserServiceMetricsTest.java
+++ b/src/test/java/com/plantcare/bot/service/UserServiceMetricsTest.java
@@ -1,0 +1,95 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.metrics.MetricsService;
+import com.plantcare.bot.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.Clock;
+import java.util.Optional;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit-тесты на инструментирование {@link UserService} метриками (issue #115).
+ *
+ * <p>Ключевой инвариант — {@code recordUserRegistered()} должен вызываться
+ * РОВНО на одно реальное создание пользователя, а не на каждый {@code /start}
+ * от уже зарегистрированного. Это значит, что {@code users_registered_total}
+ * в Prometheus отражает реальный рост базы, а не общую активность.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("UserService — recordUserRegistered (#115)")
+class UserServiceMetricsTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private MetricsService metricsService;
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    @DisplayName("Новый юзер → recordUserRegistered() вызывается один раз")
+    void should_record_user_registered_when_user_is_new() {
+        Long chatId = 555L;
+        User created = User.builder().telegramChatId(chatId).username("alice").build();
+
+        // existsByTelegramChatId возвращает false → юзер новый.
+        when(userRepository.existsByTelegramChatId(chatId)).thenReturn(false);
+        when(userRepository.findByTelegramChatId(chatId)).thenReturn(Optional.of(created));
+
+        userService.findOrCreate(chatId, "alice");
+
+        verify(metricsService).recordUserRegistered();
+    }
+
+    @Test
+    @DisplayName("Существующий юзер → recordUserRegistered() НЕ вызывается")
+    void should_not_record_user_registered_when_user_already_exists() {
+        Long chatId = 555L;
+        User existing = User.builder().telegramChatId(chatId).username("alice").build();
+
+        when(userRepository.existsByTelegramChatId(chatId)).thenReturn(true);
+        when(userRepository.findByTelegramChatId(chatId)).thenReturn(Optional.of(existing));
+
+        userService.findOrCreate(chatId, "alice");
+
+        verify(metricsService, never()).recordUserRegistered();
+    }
+
+    @Test
+    @DisplayName("Повторные /start от того же юзера → recordUserRegistered один раз за всё время")
+    void should_record_user_registered_only_on_first_start() {
+        Long chatId = 777L;
+        User created = User.builder().telegramChatId(chatId).username("bob").build();
+
+        // Первый вызов — юзера нет.
+        when(userRepository.existsByTelegramChatId(chatId))
+                .thenReturn(false)
+                .thenReturn(true)
+                .thenReturn(true);
+        when(userRepository.findByTelegramChatId(chatId)).thenReturn(Optional.of(created));
+
+        userService.findOrCreate(chatId, "bob");
+        userService.findOrCreate(chatId, "bob");
+        userService.findOrCreate(chatId, "bob");
+
+        verify(metricsService, org.mockito.Mockito.times(1)).recordUserRegistered();
+    }
+}


### PR DESCRIPTION
Closes #115

## Что сделано
- Подключён `micrometer-registry-prometheus` (одна новая зависимость, версия из BOM, заранее согласована).
- Эндпоинт `GET /actuator/prometheus` — основан на существующем actuator. На prod защищён HTTP Basic с теми же кредами, что и админка (новый `@Order(2)` filter chain в `AdminSecurityConfig`, переиспользует `ADMIN_USERNAME`/`ADMIN_PASSWORD_BCRYPT_HASH`); на dev без admin кредов — permitAll.
- `MetricsService` — централизованная точка для всех Micrometer-вызовов с whitelist'ом `KNOWN_CALLBACK_ACTIONS` (защита от cardinality explosion через attacker-controlled `callback_data`).
- `DauMetricsUpdater` — `@Scheduled` каждый час + `@PostConstruct` warm-up, читает `careHistoryRepository.countDistinctActiveUsersSince(now-24h)` в `AtomicLong`, Gauge читает из AtomicLong.
- Инструментированы hot paths: `NotificationSchedulerService` (Timer на tick + notifications.sent/failed + telegram.api.errors), `NotificationCallbackService` и `NotificationDigestCallbackService` (callbacks.processed с outcome ok/error/idempotent), `UserService` (`users.registered.total` только для реально новых юзеров, не каждый `/start`).

### Экспортируемые метрики
- `notifications.sent{channel,task_type}` (Counter)
- `notifications.failed{channel,reason}` (Counter; reason ∈ rate_limit/api_error/blocked/other)
- `notifications.digest.sent` (Counter)
- `telegram.api.errors{code}` (Counter; code ∈ 429/400/403/other)
- `callbacks.processed{action,outcome}` (Counter; action из whitelist'а, неизвестные → `unknown`; outcome ∈ ok/error/idempotent)
- `users.registered.total` (Counter)
- `users.active.dau` (Gauge, hourly refresh)
- `scheduler.tick.duration` (Timer)
- Default JVM/HTTP метрики Micrometer.

## Миграции
Нет.

## Backward-compat риски
Safe. Чистая аддитивная инфраструктура observability:
- Никаких изменений схемы БД.
- Новый эндпоинт защищён теми же кредами, что и админка.
- Поведение hot paths не изменено — добавлены только вызовы `metricsService.recordX(...)` (in-memory, без I/O).

## Тесты
- `MetricsServiceTest` — 20 unit-тестов на все `recordX`-методы, включая отдельный тест на whitelist (`should_map_unknown_callback_action_to_unknown_when_action_not_in_whitelist`).
- `DauMetricsUpdaterTest` — 7 unit-тестов на hourly refresh + warm-up + edge.
- `PrometheusEndpointIntegrationTest` — `@SpringBootTest` + Testcontainers Postgres: smoke на GET `/actuator/prometheus` (доступность, контент, безопасность).
- `UserServiceMetricsTest` — 3 теста: новый юзер → инкремент; повторный `/start` → НЕ инкремент.
- Существующие `Notification*Test` — wire'нут `@Mock MetricsService` чтобы компилировались. Explicit `verify(metricsService).recordX(...)` для `Acclimation/SoilCheck/WateringDetails` тестов — **тех-долг**, см. ниже.

`mvn verify` — **864 теста, 2 failures, 0 errors**. Падают только two pre-existing flake'а из `develop`, не от этого PR:
- `SpeciesRepositoryTest.topPopularReturnsInCorrectOrder`
- `PlantServiceTest.getPopularSpecies_orderedByPopularity`

(Зафиксированы как известные flake'и; оба про неустойчивый порядок при равной популярности.)

## Что reviewer нашёл и что отложено
Прогнал reviewer-агента, получил 1 BLOCKING + 3 SHOULD-FIX + 3 NIT.

**Фикснуто в одном цикле:**
- 🔴 BLOCKING: cardinality explosion в `recordCallback(action,...)` — атакующий мог раздуть MeterRegistry в OOM через произвольные `callback_data` строки. Добавлен whitelist `KNOWN_CALLBACK_ACTIONS` в `MetricsService`, неизвестные строки сводятся к `"unknown"`.
- 🟡 SHOULD-FIX: несоответствие имени метрики `soil_unknown` vs callback action `soil_unk` — заменён конкатенацией `switch` по `result`.

**Отложено как тех-долг (не блокирует мердж):**
- 🟡 SHOULD-FIX: race condition в `UserService.recordUserRegistered` (двойной инкремент при конкурентных `/start` от одного юзера). Минимальный фикс — поменять `insertOrIgnore` с `void` на `int` (affected rows) — задевает тесты `UserServiceMetricsTest`, отдельная задача.
- 🟡 SHOULD-FIX: explicit `verify(metricsService).recordX(...)` отсутствует в `NotificationCallbackServiceAcclimationTest`, `NotificationCallbackServiceSoilCheckTest`, `NotificationCallbackServiceWateringDetailsTest`. Сейчас MetricsService там только injected как mock-no-op. Reviewer согласовал follow-up PR.
- ℹ️ NIT: парсинг кода ошибки Telegram через `.contains("429")` — хрупкая эвристика, но коллизии маловероятны.
- ℹ️ NIT: индекс `idx_history_done_at_active ON care_history(done_at) WHERE cancelled_by IS NULL` для DAU-запроса — оправдан при росте таблицы.
- ℹ️ NIT: `securityMatcher("/actuator/prometheus/**")` для future-proof'инга — сейчас под `prometheus` нет sub-resources.

## Чек
- [x] `mvn verify` зелёное (864 теста, наши все прошли, упали только два pre-existing flake'а)
- [x] reviewer прошёл (BLOCKING закрыт, SHOULD-FIX/NIT приняты с обоснованиями)
- [x] PR в `develop`, не `main` (mainline идёт отдельным PR от пользователя после dev-стенда)
