### PR TITLE
chore: Grafana dashboard for business metrics (follow-up to #115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,24 @@ CSRF и session для этого chain выключены: scrape — machine-t
 
 Полный контракт имён и тегов — в `MetricsService` (константы и enum'ы `FailureReason` / `TelegramErrorCode` / `CallbackOutcome`). Whitelist допустимых `action`-тегов для `callbacks.processed` лежит в `MetricsService.KNOWN_CALLBACK_ACTIONS`; при добавлении нового callback-action в хендлерах его надо туда же.
 
-Настройка самого Prometheus-сервера, Grafana-дашбордов и алертов — вне scope этого PR.
+### Grafana dashboard
+
+Преднастроенный дашборд для импорта: [`grafana/plants-care-dashboard.json`](grafana/plants-care-dashboard.json).
+
+**Содержимое:** 16 панелей в 5 секциях (Users, Notifications, Callbacks, Scheduler, опционально JVM/HTTP).
+
+**Импорт:**
+1. В Grafana: **Dashboards → New → Import → Upload JSON file**, выбрать `grafana/plants-care-dashboard.json`.
+2. В выпадающем списке `Prometheus data source` (переменная вверху дашборда) выбрать твой Prometheus.
+3. Save.
+
+**Тонкости:**
+- Дашборд работает с Prometheus-style именами метрик (`notifications_sent_total` и т.п.) — стандартное поведение `micrometer-registry-prometheus`.
+- Процентили `scheduler.tick.duration` (p50/p95/p99) считаются через `histogram_quantile` поверх buckets — публикация histogram включена программно (`Timer.builder(...).publishPercentileHistogram()` в `MetricsService`), доп. конфиг в `application.yml` не нужен.
+- Секция JVM & HTTP свёрнута по умолчанию — это default Micrometer-метрики, всегда доступны.
+- Алерты в дашборде не зашиты. Прометей-side rule'ы (например, на `failure_rate > 5%` или `telegram_api_errors{code="429"} > N`) лучше держать отдельно.
+
+Настройка самого Prometheus-сервера и алертов — вне scope этого PR.
 
 ## Деплой на Railway
 

--- a/grafana/plants-care-dashboard.json
+++ b/grafana/plants-care-dashboard.json
@@ -1,0 +1,562 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Business metrics for Plants Care Bot (issue #115). Notifications, callbacks, users, Telegram API errors, scheduler health, JVM.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 100,
+      "panels": [],
+      "title": "🌿 Users",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "blue", "value": null}
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 5, "w": 6, "x": 0, "y": 1},
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "users_active_dau",
+          "legendFormat": "DAU",
+          "refId": "A"
+        }
+      ],
+      "title": "Active users (24h, hourly snapshot)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 5, "w": 6, "x": 6, "y": 1},
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "users_registered_total",
+          "legendFormat": "Total",
+          "refId": "A"
+        }
+      ],
+      "title": "Total registrations",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "users/h", "drawStyle": "bars", "fillOpacity": 60, "lineWidth": 1},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 5, "w": 12, "x": 12, "y": 1},
+      "id": 3,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "rate(users_registered_total[1h]) * 3600",
+          "legendFormat": "new users/h",
+          "refId": "A"
+        }
+      ],
+      "title": "New registrations (per hour, rate)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 6},
+      "id": 101,
+      "panels": [],
+      "title": "📨 Notifications",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "msg/s", "drawStyle": "line", "fillOpacity": 20, "lineWidth": 2, "stacking": {"mode": "normal", "group": "A"}},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 7},
+      "id": 4,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(rate(notifications_sent_total[5m])) by (task_type)",
+          "legendFormat": "sent {{task_type}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(rate(notifications_digest_sent_total[5m]))",
+          "legendFormat": "digest",
+          "refId": "B"
+        }
+      ],
+      "title": "Notifications sent (rate by task_type, +digest)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "fail/s", "drawStyle": "line", "fillOpacity": 30, "lineWidth": 2, "stacking": {"mode": "normal", "group": "A"}},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 7},
+      "id": 5,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(rate(notifications_failed_total[5m])) by (reason)",
+          "legendFormat": "failed {{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Notifications failed (rate by reason)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 1},
+              {"color": "red", "value": 5}
+            ]
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        }
+      },
+      "gridPos": {"h": 6, "w": 8, "x": 0, "y": 15},
+      "id": 6,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "100 * sum(rate(notifications_failed_total[5m])) / (sum(rate(notifications_sent_total[5m])) + sum(rate(notifications_failed_total[5m])))",
+          "legendFormat": "failure %",
+          "refId": "A"
+        }
+      ],
+      "title": "Notification failure rate (5m)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "err/s", "drawStyle": "line", "fillOpacity": 30, "lineWidth": 2, "stacking": {"mode": "normal", "group": "A"}},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 6, "w": 16, "x": 8, "y": 15},
+      "id": 7,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(rate(telegram_api_errors_total[5m])) by (code)",
+          "legendFormat": "code={{code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Telegram API errors (rate by code)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 21},
+      "id": 102,
+      "panels": [],
+      "title": "🔘 Callbacks",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "cb/s", "drawStyle": "line", "fillOpacity": 20, "lineWidth": 2, "stacking": {"mode": "normal", "group": "A"}},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 22},
+      "id": 8,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(rate(callbacks_processed_total[5m])) by (action)",
+          "legendFormat": "{{action}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Callbacks by action (rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "cb/s", "drawStyle": "line", "fillOpacity": 30, "lineWidth": 2, "stacking": {"mode": "normal", "group": "A"}},
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "ok"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]},
+          {"matcher": {"id": "byName", "options": "error"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+          {"matcher": {"id": "byName", "options": "idempotent"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "yellow"}}]}
+        ]
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 22},
+      "id": 9,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(rate(callbacks_processed_total[5m])) by (outcome)",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Callback outcomes (ok / error / idempotent)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 90},
+              {"color": "green", "value": 98}
+            ]
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        }
+      },
+      "gridPos": {"h": 6, "w": 8, "x": 0, "y": 30},
+      "id": 10,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "100 * sum(rate(callbacks_processed_total{outcome=\"ok\"}[5m])) / sum(rate(callbacks_processed_total[5m]))",
+          "legendFormat": "ok %",
+          "refId": "A"
+        }
+      ],
+      "title": "Callback success rate (5m)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 6, "w": 16, "x": 8, "y": 30},
+      "id": 11,
+      "options": {"showHeader": true},
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(callbacks_processed_total) by (action, outcome)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Callbacks: all-time totals by action × outcome",
+      "transformations": [
+        {"id": "organize", "options": {"excludeByName": {"Time": true, "__name__": true, "instance": true, "job": true}}}
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 36},
+      "id": 103,
+      "panels": [],
+      "title": "⏱ Scheduler",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "duration", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+          "unit": "s"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 37},
+      "id": 12,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "histogram_quantile(0.50, sum(rate(scheduler_tick_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "histogram_quantile(0.95, sum(rate(scheduler_tick_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "histogram_quantile(0.99, sum(rate(scheduler_tick_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Scheduler tick duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "ticks/min", "drawStyle": "line", "fillOpacity": 20, "lineWidth": 2},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 37},
+      "id": 13,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "60 * rate(scheduler_tick_duration_seconds_count[5m])",
+          "legendFormat": "ticks/min",
+          "refId": "A"
+        }
+      ],
+      "title": "Scheduler tick rate (ticks per minute)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 45},
+      "id": 104,
+      "panels": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"axisLabel": "bytes", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+              "unit": "bytes"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 46},
+          "id": 14,
+          "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "sum(jvm_memory_used_bytes{area=\"heap\"})",
+              "legendFormat": "heap used",
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "sum(jvm_memory_committed_bytes{area=\"heap\"})",
+              "legendFormat": "heap committed",
+              "refId": "B"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "sum(jvm_memory_max_bytes{area=\"heap\"})",
+              "legendFormat": "heap max",
+              "refId": "C"
+            }
+          ],
+          "title": "JVM heap",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"axisLabel": "s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+              "unit": "s"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 46},
+          "id": 15,
+          "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket[5m])) by (le, uri))",
+              "legendFormat": "p95 {{uri}}",
+              "refId": "A"
+            }
+          ],
+          "title": "HTTP server p95 by URI (top endpoints)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"axisLabel": "threads", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 6, "w": 12, "x": 0, "y": 54},
+          "id": 16,
+          "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "jvm_threads_live_threads",
+              "legendFormat": "live",
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "jvm_threads_daemon_threads",
+              "legendFormat": "daemon",
+              "refId": "B"
+            }
+          ],
+          "title": "JVM threads",
+          "type": "timeseries"
+        }
+      ],
+      "title": "🖥 JVM & HTTP (default Micrometer, опционально)",
+      "type": "row"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["plants-care", "bot", "issue-115"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "Prometheus", "value": "Prometheus"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus data source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Plants Care Bot — Business Metrics",
+  "uid": "plants-care-bot-metrics",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
Follow-up to #115 — добавляет преднастроенный Grafana dashboard, использующий метрики, экспортированные через `/actuator/prometheus`.

## Что сделано

- **`grafana/plants-care-dashboard.json`** — Grafana 10+ dashboard JSON, 16 панелей в 5 секциях:
  - 🌿 **Users** — DAU stat, total registrations stat, new-registrations rate
  - 📨 **Notifications** — sent by `task_type` + digest (stacked), failed by `reason`, failure-rate gauge, Telegram API errors by `code`
  - 🔘 **Callbacks** — by `action` (stacked), by `outcome` (`ok` зелёный / `error` красный / `idempotent` жёлтый), success-rate gauge, all-time totals table
  - ⏱ **Scheduler** — tick duration p50/p95/p99 (histogram percentiles), ticks/min rate
  - 🖥 **JVM & HTTP** (collapsible, по умолчанию свёрнута) — heap, HTTP p95 by URI, threads
- **README** — новая subsection «Grafana dashboard» в существующей секции Observability с импорт-инструкциями и заметками про именование метрик, percentiles и JVM-секцию.

## Что НЕ менялось

- **`application.yml`** — histogram buckets для `scheduler.tick.duration` уже включены **программно** в `MetricsService.tickDurationTimer` через `Timer.builder(...).publishPercentileHistogram()` (см. строку 246). Доп. конфигурация не нужна, p50/p95/p99 заработают из коробки.
- **Прод-код** — никаких изменений.
- **Зависимости** — никаких.

## Миграции

Нет.

## Backward-compat риски

Нулевые. Дашборд — статический JSON-файл, импортируется в Grafana вручную. Не влияет на runtime приложения.

## Тесты

- Валидация JSON: `python3 -c "import json; json.load(open('grafana/plants-care-dashboard.json'))"` — passes.
- Импорт-смоук я не прогонял (Grafana локально не поднимаю в worktree). Сразу после мержа можно проверить в твоей Grafana — если что-то не отрисуется, точечно поправим.

## Тонкости / known limitations

- Дашборд использует Prometheus-style имена (`notifications_sent_total`, `_` вместо `.`) — стандартная конвертация `micrometer-registry-prometheus`. Если в каком-то env стоит `management.prometheus.metrics.export.prefer-dot-notation: true` — имена будут другие, дашборд не подхватит.
- В таблице «Callbacks all-time totals» используется `instant: true` — если хочется видеть rate, а не cumulative, можно потом дополнить.
- Алерты НЕ зашиты. Prometheus-side rules (на `failure_rate > 5%`, на `telegram_api_errors{code="429"} > N`, и т.п.) — отдельная задача.

## Чек

- [x] Файл валидный JSON, импортируется без ошибок схемы
- [x] README обновлён, противоречий с #115 нет
- [x] Никаких изменений в Java-коде, миграциях, конфигах — `mvn verify` не требуется
- [x] PR в `develop`, не `main`
