### PR TITLE
chore: docker-compose profile for local Prometheus + Grafana stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,22 @@ CSRF и session для этого chain выключены: scrape — machine-t
 
 **Содержимое:** 16 панелей в 5 секциях (Users, Notifications, Callbacks, Scheduler, опционально JVM/HTTP).
 
-**Импорт:**
+**Локальный стек одной командой (рекомендуется для разработки):**
+```bash
+docker compose --profile monitoring up -d
+# затем (если app не в Docker, а через mvn spring-boot:run):
+mvn spring-boot:run -Dspring-boot.run.profiles=dev
+```
+Откроет:
+- Prometheus — http://localhost:9090 (таргеты: Status → Targets)
+- Grafana — http://localhost:3000 (без логина, дашборд сразу в «Plants Care → Plants Care Bot — Business Metrics»)
+
+Если app тоже хочется в Docker — добавь профиль `full`:
+```bash
+docker compose --profile full --profile monitoring up -d
+```
+
+**Ручной импорт (если Grafana уже где-то развёрнута):**
 1. В Grafana: **Dashboards → New → Import → Upload JSON file**, выбрать `grafana/plants-care-dashboard.json`.
 2. В выпадающем списке `Prometheus data source` (переменная вверху дашборда) выбрать твой Prometheus.
 3. Save.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,5 +43,57 @@ services:
     ports:
       - "${APP_PORT:-8080}:8080"
 
+  prometheus:
+    # Локальный Prometheus, скрейпит /actuator/prometheus приложения.
+    # Запускать через профиль monitoring:
+    #   docker compose --profile monitoring up -d
+    # Если app запущена в контейнере одновременно:
+    #   docker compose --profile full --profile monitoring up -d
+    profiles: ["monitoring"]
+    image: prom/prometheus:v2.54.1
+    container_name: plants-care-prometheus
+    restart: unless-stopped
+    extra_hosts:
+      # На Linux позволяет резолвить host.docker.internal в IP хоста.
+      # На macOS / Windows host.docker.internal работает без этой опции.
+      - "host.docker.internal:host-gateway"
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=7d'
+      - '--web.enable-lifecycle'
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+
+  grafana:
+    # Локальная Grafana с автопровиженным дашбордом из grafana/.
+    # Запускать через профиль monitoring:
+    #   docker compose --profile monitoring up -d
+    # Открыть: http://localhost:3000
+    # Anonymous auth включён, логин не нужен; роль — Admin (только для dev).
+    profiles: ["monitoring"]
+    image: grafana/grafana:11.2.2
+    container_name: plants-care-grafana
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: "/var/lib/grafana/dashboards/plants-care-dashboard.json"
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "${GRAFANA_PORT:-3000}:3000"
+
 volumes:
   postgres_data:
+  prometheus_data:
+  grafana_data:

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+providers:
+  - name: 'plants-care'
+    orgId: 1
+    folder: 'Plants Care'
+    folderUid: 'plants-care'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+    jsonData:
+      timeInterval: 15s
+      httpMethod: POST

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,27 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    monitor: 'plants-care-local'
+
+scrape_configs:
+  - job_name: 'plants-care-bot'
+    metrics_path: '/actuator/prometheus'
+    scheme: http
+    # Локальный dev-стек скрейпит приложение по двум возможным адресам:
+    # 1) host.docker.internal:8080 — когда приложение запущено на хосте
+    #    через `mvn spring-boot:run` (типичный режим разработки).
+    # 2) app:8080 — когда приложение запущено в docker compose
+    #    через `docker compose --profile full --profile monitoring up -d`.
+    # Один из таргетов всегда будет DOWN — это ожидаемо, не алерт.
+    static_configs:
+      - targets:
+          - 'host.docker.internal:8080'
+          - 'app:8080'
+    # На dev-профиле /actuator/prometheus открыт без auth.
+    # На prod (когда заданы ADMIN_USERNAME / ADMIN_PASSWORD_BCRYPT_HASH)
+    # тут понадобится basic_auth — но prod в этом docker-compose не запускается.
+
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']


### PR DESCRIPTION
Follow-up к смерженному PR #122 (Grafana dashboard JSON).

В PR #122 я по таймингу не успел запушить второй коммит до его мерджа — коммит с docker-compose stack остался висеть на ветке вне develop. Этот PR его догоняет.

## Что сделано

Локальный стек мониторинга через `docker compose --profile monitoring up -d` — поднимает Prometheus + Grafana с автопровиженным datasource и нашим дашбордом (`grafana/plants-care-dashboard.json` уже в develop из PR #122).

- **`docker-compose.yml`** — два новых сервиса под профилем `monitoring`:
  - `prometheus` (prom/prometheus:v2.54.1, порт 9090, 7-дневная retention)
  - `grafana` (grafana/grafana:11.2.2, порт 3000, anonymous Admin для dev)
  - **Дефолтное `docker compose up -d` поведение не меняется** — поднимется только Postgres, как раньше. Профили `full` и `monitoring` опт-ин.
- **`monitoring/prometheus.yml`** — scrape config с двумя таргетами:
  - `host.docker.internal:8080` — для `mvn spring-boot:run` на хосте
  - `app:8080` — для `docker compose --profile full --profile monitoring up -d`
  - Один всегда DOWN — это норма, не алерт.
- **`monitoring/grafana/provisioning/datasources/prometheus.yml`** — Prometheus добавляется как **default** datasource с `uid=prometheus`. Темплейтная переменная `$datasource` в дашборде сразу подхватывает его.
- **`monitoring/grafana/provisioning/dashboards/dashboards.yml`** — auto-import всего из `/var/lib/grafana/dashboards` (bind mount из `./grafana/`).
- **`README.md`** — новая subsection «Локальный стек одной командой» внутри Observability с usage и примерами.

## Usage

```bash
docker compose --profile monitoring up -d
mvn spring-boot:run -Dspring-boot.run.profiles=dev
open http://localhost:3000     # Grafana, дашборд сразу
open http://localhost:9090     # Prometheus
```

Если app тоже хочется в Docker:
```bash
docker compose --profile full --profile monitoring up -d
```

## Проверено мной локально

- ✅ Стек поднимается: prometheus (9090) + grafana (3000) up
- ✅ Prometheus targets: scrape config корректный, оба endpoint'а видны
- ✅ Grafana datasource Prometheus auto-provisioned, default, `uid=prometheus`
- ✅ Grafana dashboard «Plants Care Bot — Business Metrics» auto-provisioned в папке `Plants Care`
- ⚠️ Реальный data flow не проверил — на 8080 был запущенный из IDE экземпляр app со старым `target/classes` (без `/actuator/prometheus`). После rebuild должно потечь.

## Миграции

Нет.

## Backward-compat риски

Нулевые:
- Дефолтное `docker compose up -d` поведение не меняется.
- Новые контейнеры под опциональным профилем.
- Никаких изменений в Java-коде, миграциях, прод-конфигах.

## Тесты

`docker compose --profile monitoring config --quiet` — passes (валидирует все 4 yaml).

`mvn verify` не запускал — Java-код не задет.

## Чек

- [x] Profile `monitoring` опт-ин, дефолтное поведение не сломано
- [x] PR в `develop`, не `main`
