### PR TITLE
feat(observability): integrate Sentry for error aggregation (#114)

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,26 @@ docker compose --profile full --profile monitoring up -d
 
 Настройка самого Prometheus-сервера и алертов — вне scope этого PR.
 
+### Sentry — агрегация ошибок (issue #114)
+
+Необработанные исключения и проглоченные `catch` в шедулерах и Telegram-диспетчере
+отправляются в Sentry через `sentry-spring-boot-starter-jakarta`.
+
+Включён **только на prod** (`application-prod.yml`); на dev/test выключен (no-op), чтобы
+не тратить квоту и не слать события из тестов. Даже на prod, если `SENTRY_DSN` не задан,
+стартер инициализируется в no-op и ничего не отправляет.
+
+PII не уходит в Sentry: `SentryPiiFilter` (`BeforeSendCallback`) хеширует `chat_id` и
+`telegram_user_id`, маскирует имена растений, заметки и параметры/breadcrumbs, чистит
+данные пользователя. `send-default-pii: false` на всех профилях.
+
+События размечаются тегами `layer` (`telegram` / `scheduler` / `admin` / `weather`) и
+`feature` (имя класса) для фильтрации в Sentry UI.
+
+| Переменная | Дефолт | Где | Обязательная |
+|---|---|---|---|
+| `SENTRY_DSN` | пусто | prod | нет — пустой DSN = Sentry no-op |
+
 ## Деплой на Railway
 
 ### Первичная настройка
@@ -295,6 +315,7 @@ docker compose --profile full --profile monitoring up -d
    - Скопировать `Reference` для `${{Postgres.PGHOST}}`, `${{Postgres.PGPORT}}`, `${{Postgres.PGDATABASE}}`, `${{Postgres.PGUSER}}`, `${{Postgres.PGPASSWORD}}` — Railway сам подставит реальные значения
    - Добавить `TELEGRAM_BOT_TOKEN`, `TELEGRAM_BOT_USERNAME`, `TELEGRAM_BOT_ENABLED=true` — когда дойдём до интеграции с ботом
    - Добавить `CALENDAR_BASE_URL` — внешний https-URL приложения (например, `https://plants-care-production.up.railway.app`). Используется для построения ссылок `/calendar/{token}.ics`. Дефолт `https://example.com` для прода не годится.
+   - (опционально) Добавить `SENTRY_DSN` — DSN проекта Sentry для агрегации ошибок (см. секцию Observability). Если не задан, Sentry на prod работает в no-op.
 5. Включить **Public Networking** в Settings → получишь URL вида `plants-care-production.up.railway.app`
 6. Дождаться завершения первой сборки
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,9 @@
         <openapi-generator.version>7.10.0</openapi-generator.version>
         <swagger-annotations.version>2.2.25</swagger-annotations.version>
         <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
+        <!-- Issue #114: Sentry 7.x. -jakarta-вариант таргетит jakarta.* и совместим
+             со Spring Boot 3.5.x (текущая 3.5.14). 7.22.5 — последняя стабильная в линии 7.x. -->
+        <sentry.version>7.22.5</sentry.version>
 
         <!-- Sonar -->
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
@@ -65,6 +68,14 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!-- Issue #114: агрегация ошибок в Sentry. Единственный канал error-aggregation
+             на проде после запуска REST API (#84) и mobile (#88+). Обоснование в issue. -->
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-spring-boot-starter-jakarta</artifactId>
+            <version>${sentry.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/plantcare/bot/admin/ratelimit/LoginRateLimitFilter.java
+++ b/src/main/java/com/plantcare/bot/admin/ratelimit/LoginRateLimitFilter.java
@@ -1,5 +1,7 @@
 package com.plantcare.bot.admin.ratelimit;
 
+import com.plantcare.bot.observability.SentryTags;
+import com.plantcare.bot.observability.SentryTags.Layer;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -33,9 +35,20 @@ public class LoginRateLimitFilter extends OncePerRequestFilter {
                 && "/admin/login".equals(request.getRequestURI());
 
         if (isLoginPost) {
-            String ip = request.getRemoteAddr();
-            if (rateLimiter.isBlocked(ip)) {
-                log.warn("Admin login rate-limit triggered: ip={}", ip);
+            // Issue #114: тег layer=admin на изолированном scope только на время
+            // rate-check. На HTTP-потоке scope push/pop'ает Sentry-ContextWebFilter,
+            // но withScope гарантирует, что admin-тег не утечёт за пределы фильтра
+            // даже если порядок фильтров изменится. Возвращаем флаг «заблокировано»,
+            // чтобы short-circuit 429 действительно прервал цепочку.
+            boolean blocked = SentryTags.callWithLayer(Layer.ADMIN, "LoginRateLimitFilter", () -> {
+                String ip = request.getRemoteAddr();
+                if (rateLimiter.isBlocked(ip)) {
+                    log.warn("Admin login rate-limit triggered: ip={}", ip);
+                    return true;
+                }
+                return false;
+            });
+            if (blocked) {
                 response.setStatus(429);
                 response.setHeader("Retry-After", "60");
                 response.getWriter().write("Too many login attempts. Try again in a minute.");

--- a/src/main/java/com/plantcare/bot/beans/PlantsCareBot.java
+++ b/src/main/java/com/plantcare/bot/beans/PlantsCareBot.java
@@ -8,8 +8,11 @@ import com.plantcare.bot.domain.enums.ConversationState;
 import com.plantcare.bot.service.MenuCallbackService;
 import com.plantcare.bot.service.NotificationCallbackService;
 import com.plantcare.bot.service.NotificationDigestCallbackService;
+import com.plantcare.bot.observability.SentryTags;
+import com.plantcare.bot.observability.SentryTags.Layer;
 import com.plantcare.bot.service.UserService;
 import com.plantcare.bot.state.StateResolver;
+import io.sentry.Sentry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -76,6 +79,19 @@ public class PlantsCareBot implements LongPollingSingleThreadUpdateConsumer, Tel
             return;
         }
 
+        // Issue #114: обработку ОДНОГО апдейта оборачиваем в изолированный scope.
+        // poll-поток Telegram — shared (один на бота): без withScope теги layer/chat_id
+        // от предыдущего апдейта прилипли бы к событию следующего юзера. withScope
+        // клонирует scope, проставляет теги локально и откатывает после апдейта.
+        // chat_id хешируется в SentryPiiFilter перед отправкой.
+        Sentry.withScope(scope -> {
+            SentryTags.mark(scope, Layer.TELEGRAM, "PlantsCareBot");
+            scope.setTag("chat_id", String.valueOf(chatId));
+            handleUpdate(update, chatId);
+        });
+    }
+
+    private void handleUpdate(Update update, Long chatId) {
         try {
             if (update.hasCallbackQuery()) {
                 String data = update.getCallbackQuery().getData();
@@ -138,6 +154,15 @@ public class PlantsCareBot implements LongPollingSingleThreadUpdateConsumer, Tel
             }
         } catch (Exception e) {
             log.error("Failed to consume update for chatId={}", chatId, e);
+            // Issue #114: ЕДИНСТВЕННАЯ точка capture для poll-потока Telegram.
+            // sentry-spring-boot-starter перехватывает только необработанные
+            // исключения MVC (@RestControllerAdvice / DispatcherServlet) — poll-поток
+            // он НЕ видит. Все исключения обработки апдейта (в т.ч. из
+            // NotificationCallbackService) глотаются здесь, чтобы не уронить поток, —
+            // поэтому репортим явно. НЕ добавлять второй capture выше по стеку: будет
+            // дубль события. captureException вызван внутри withScope из consume() —
+            // теги layer=telegram/chat_id проставлены корректно.
+            Sentry.captureException(e);
         }
     }
 

--- a/src/main/java/com/plantcare/bot/metrics/DauMetricsUpdater.java
+++ b/src/main/java/com/plantcare/bot/metrics/DauMetricsUpdater.java
@@ -1,6 +1,9 @@
 package com.plantcare.bot.metrics;
 
+import com.plantcare.bot.observability.SentryTags;
+import com.plantcare.bot.observability.SentryTags.Layer;
 import com.plantcare.bot.repository.CareHistoryRepository;
+import io.sentry.Sentry;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,6 +54,7 @@ public class DauMetricsUpdater {
             // Не валим контекст из-за метрики. Просто оставляем 0,
             // следующий @Scheduled-тик переcчитает.
             log.warn("Initial DAU refresh failed, will retry on schedule: {}", e.getMessage());
+            Sentry.captureException(e);
         }
     }
 
@@ -61,9 +65,13 @@ public class DauMetricsUpdater {
     @Scheduled(cron = "0 0 * * * *", zone = "UTC")
     @Transactional(readOnly = true)
     public void refresh() {
-        LocalDateTime cutoff = LocalDateTime.now(clock).minusHours(WINDOW_HOURS);
-        long dau = careHistoryRepository.countDistinctActiveUsersSince(cutoff);
-        metricsService.updateActiveDau(dau);
-        log.info("DAU updated: {} active users in last {}h (cutoff={})", dau, WINDOW_HOURS, cutoff);
+        // Issue #114: изолированный scope на тик — тег layer не течёт на соседние
+        // задачи shared-потока @Scheduled.
+        SentryTags.runWithLayer(Layer.SCHEDULER, "DauMetricsUpdater", () -> {
+            LocalDateTime cutoff = LocalDateTime.now(clock).minusHours(WINDOW_HOURS);
+            long dau = careHistoryRepository.countDistinctActiveUsersSince(cutoff);
+            metricsService.updateActiveDau(dau);
+            log.info("DAU updated: {} active users in last {}h (cutoff={})", dau, WINDOW_HOURS, cutoff);
+        });
     }
 }

--- a/src/main/java/com/plantcare/bot/observability/SentryConfig.java
+++ b/src/main/java/com/plantcare/bot/observability/SentryConfig.java
@@ -1,0 +1,32 @@
+package com.plantcare.bot.observability;
+
+import io.sentry.Sentry;
+import io.sentry.SentryOptions;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Регистрация кастомных опций Sentry поверх автоконфигурации стартера (issue #114).
+ *
+ * <p>Базовые проперти ({@code sentry.dsn}, {@code sentry.enabled},
+ * {@code sentry.environment}, {@code sentry.release}, {@code sentry.send-default-pii})
+ * читает сам {@code sentry-spring-boot-starter-jakarta} из {@code application*.yml}.
+ * Здесь докручиваем только то, что нельзя выразить пропертями — {@link SentryPiiFilter}
+ * как {@code beforeSend}-хук.
+ *
+ * <p>{@link Sentry.OptionsConfiguration} применяется стартером ко всем экземплярам
+ * опций, в т.ч. когда Sentry выключен/no-op — тогда beforeSend просто никогда не
+ * вызовется, побочных эффектов нет.
+ */
+@Configuration
+@RequiredArgsConstructor
+public class SentryConfig {
+
+    private final SentryPiiFilter sentryPiiFilter;
+
+    @Bean
+    public Sentry.OptionsConfiguration<SentryOptions> sentryPiiOptionsConfiguration() {
+        return options -> options.setBeforeSend(sentryPiiFilter);
+    }
+}

--- a/src/main/java/com/plantcare/bot/observability/SentryPiiFilter.java
+++ b/src/main/java/com/plantcare/bot/observability/SentryPiiFilter.java
@@ -1,0 +1,229 @@
+package com.plantcare.bot.observability;
+
+import io.sentry.Breadcrumb;
+import io.sentry.Hint;
+import io.sentry.SentryEvent;
+import io.sentry.SentryOptions.BeforeSendCallback;
+import io.sentry.protocol.Message;
+import io.sentry.protocol.User;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * PII-фильтр для событий Sentry (issue #114).
+ *
+ * <p>Регистрируется как {@link BeforeSendCallback} в опциях Sentry-стартера
+ * (см. {@link SentryConfig}). Перед отправкой любого события:
+ * <ul>
+ *   <li>{@code chat_id} / {@code telegram_user_id} в тегах и extra — заменяются
+ *       на короткий SHA-256 хеш (PII не уходит в открытом виде);</li>
+ *   <li>идентификатор пользователя ({@link User}) хешируется тем же способом,
+ *       e-mail/username/IP вычищаются;</li>
+ *   <li>тексты сообщений юзера (содержимое заметок, имена растений) в message и
+ *       extra — маскируются заглушкой, чтобы не утекали в Sentry.</li>
+ * </ul>
+ *
+ * <p>Вся логика маскирования вынесена в чистый package-private метод
+ * {@link #sanitize(SentryEvent)}, который не зависит от живого Sentry-хаба —
+ * это точка юнит-тестируемости (отдельный тест напишет другой агент).
+ */
+@Slf4j
+@Component
+public class SentryPiiFilter implements BeforeSendCallback {
+
+    /** Длина hex-префикса хеша — достаточно для дедупликации, но не обратима к id. */
+    static final int HASH_PREFIX_LEN = 16;
+
+    /** Заглушка вместо вырезанного текста юзера. */
+    static final String REDACTED = "[redacted]";
+
+    /** Ключи тегов/extra, значение которых считается PII-идентификатором и хешируется. */
+    static final Set<String> ID_KEYS = Set.of(
+            "chat_id", "chatId",
+            "telegram_user_id", "telegramUserId", "telegram_chat_id", "telegramChatId"
+    );
+
+    /**
+     * Ключи extra, значение которых — свободный пользовательский текст (имена
+     * растений, заметки). Полностью маскируются.
+     */
+    static final Set<String> FREE_TEXT_KEYS = Set.of(
+            "plant_name", "plantName",
+            "note", "notes",
+            "message_text", "messageText",
+            "user_text", "userText",
+            "callback_data", "callbackData"
+    );
+
+    @Override
+    @Nullable
+    public SentryEvent execute(@NonNull SentryEvent event, @NonNull Hint hint) {
+        return sanitize(event);
+    }
+
+    /**
+     * Чистая логика маскирования над {@link SentryEvent}. Возвращает тот же event
+     * (мутирует его на месте, как и ожидает Sentry SDK). Не обращается к Sentry-хабу,
+     * поэтому полностью юнит-тестируема без живого SDK.
+     */
+    @NonNull
+    SentryEvent sanitize(@NonNull SentryEvent event) {
+        sanitizeTags(event);
+        sanitizeExtras(event);
+        sanitizeUser(event);
+        sanitizeMessage(event);
+        sanitizeBreadcrumbs(event);
+        // Сообщение эксепшена (event.getThrowable().getMessage()) НЕ затираем:
+        // (1) Throwable иммутабелен — message задаётся в конструкторе, сеттера нет,
+        //     правка только через reflection, что хрупко и небезопасно;
+        // (2) полное затирание убило бы диагностику (стек без текста бесполезен).
+        // Текущие бизнес-исключения кладут в message максимум справочные данные
+        // (напр. имя ВИДА растения в DuplicateSpeciesNameException — это admin-
+        // curated reference, не персональный текст юзера). Заметки/клички растений,
+        // которые AC запрещает отправлять, в message исключений не попадают. Если в
+        // будущем появится исключение, несущее такой текст, санитизировать его нужно в
+        // самом throw. Основной авто-PII-канал — breadcrumbs — закрыт ниже.
+        return event;
+    }
+
+    private void sanitizeTags(SentryEvent event) {
+        Map<String, String> tags = event.getTags();
+        if (tags == null) {
+            return;
+        }
+        for (Map.Entry<String, String> entry : tags.entrySet()) {
+            if (ID_KEYS.contains(entry.getKey())) {
+                entry.setValue(hash(entry.getValue()));
+            } else if (FREE_TEXT_KEYS.contains(entry.getKey())) {
+                entry.setValue(REDACTED);
+            }
+        }
+    }
+
+    private void sanitizeExtras(SentryEvent event) {
+        Map<String, Object> extras = event.getExtras();
+        if (extras == null) {
+            return;
+        }
+        for (Map.Entry<String, Object> entry : extras.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if (value == null) {
+                continue;
+            }
+            if (ID_KEYS.contains(key)) {
+                entry.setValue(hash(String.valueOf(value)));
+            } else if (FREE_TEXT_KEYS.contains(key)) {
+                entry.setValue(REDACTED);
+            }
+        }
+    }
+
+    private void sanitizeUser(SentryEvent event) {
+        User user = event.getUser();
+        if (user == null) {
+            return;
+        }
+        if (user.getId() != null) {
+            user.setId(hash(user.getId()));
+        }
+        // Никакой остальной PII в Sentry не отправляем.
+        user.setEmail(null);
+        user.setUsername(null);
+        user.setIpAddress(null);
+    }
+
+    private void sanitizeMessage(SentryEvent event) {
+        Message message = event.getMessage();
+        if (message == null) {
+            return;
+        }
+        // formatted — это отрендеренная строка с подставленными значениями юзера
+        // (имя растения, заметка). Маскируем ВСЕГДА, независимо от наличия шаблона
+        // и текущего значения: именно formatted содержит PII.
+        message.setFormatted(REDACTED);
+        // params — конкретные значения, подставляемые в шаблон (тоже могут быть
+        // именами растений/заметками). Заменяем каждое на заглушку.
+        List<String> params = message.getParams();
+        if (params != null && !params.isEmpty()) {
+            message.setParams(params.stream().map(p -> REDACTED).toList());
+        }
+        // message.getMessage() — статический параметризованный шаблон
+        // (напр. "failed to send reminder for plant {}"). PII не содержит, оставляем.
+    }
+
+    /**
+     * Breadcrumbs — автоматический PII-канал: SDK/логи могут осесть в них текстом
+     * сообщений юзера (содержимое заметок, имена растений, callback_data). AC #114
+     * прямо требует «не отправлять текст сообщений юзера», поэтому защитно:
+     * <ul>
+     *   <li>{@code message} крошки маскируем заглушкой (это свободный текст — может
+     *       содержать эхо пользовательского ввода из лога);</li>
+     *   <li>{@code data} крошки чистим по тем же правилам, что extras: id-ключи
+     *       хешируем, free-text-ключи и любые прочие строковые значения маскируем
+     *       (строка в breadcrumb.data — потенциальный носитель PII).</li>
+     * </ul>
+     */
+    private void sanitizeBreadcrumbs(SentryEvent event) {
+        List<Breadcrumb> breadcrumbs = event.getBreadcrumbs();
+        if (breadcrumbs == null || breadcrumbs.isEmpty()) {
+            return;
+        }
+        for (Breadcrumb crumb : breadcrumbs) {
+            if (crumb.getMessage() != null) {
+                crumb.setMessage(REDACTED);
+            }
+            Map<String, Object> data = crumb.getData();
+            if (data == null || data.isEmpty()) {
+                continue;
+            }
+            for (Map.Entry<String, Object> entry : data.entrySet()) {
+                String key = entry.getKey();
+                Object value = entry.getValue();
+                if (value == null) {
+                    continue;
+                }
+                if (ID_KEYS.contains(key)) {
+                    entry.setValue(hash(String.valueOf(value)));
+                } else if (value instanceof String) {
+                    // Любая строка в data может быть PII — заглушаем. Числа/booleans
+                    // (статусы, коды, длительности) оставляем для диагностики.
+                    entry.setValue(REDACTED);
+                }
+            }
+        }
+    }
+
+    /**
+     * Короткий стабильный хеш идентификатора: SHA-256 → первые
+     * {@link #HASH_PREFIX_LEN} hex-символов. Детерминирован (одинаковый chat_id даёт
+     * одинаковый хеш → дедуп в Sentry работает), но не обратим к исходному id.
+     */
+    @NonNull
+    String hash(@Nullable String raw) {
+        if (raw == null || raw.isBlank()) {
+            return REDACTED;
+        }
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest(raw.getBytes(StandardCharsets.UTF_8));
+            String hex = HexFormat.of().formatHex(bytes);
+            return hex.substring(0, Math.min(HASH_PREFIX_LEN, hex.length()));
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 есть в любой стандартной JVM; сюда не попадём. Подстраховка —
+            // не отправлять сырой id, лучше потерять значение.
+            log.warn("SHA-256 unavailable, redacting id instead of hashing");
+            return REDACTED;
+        }
+    }
+}

--- a/src/main/java/com/plantcare/bot/observability/SentryStartupListener.java
+++ b/src/main/java/com/plantcare/bot/observability/SentryStartupListener.java
@@ -1,0 +1,38 @@
+package com.plantcare.bot.observability;
+
+import io.sentry.Breadcrumb;
+import io.sentry.Sentry;
+import io.sentry.SentryLevel;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Health-чек инициализации Sentry (issue #114).
+ *
+ * <p>Бин активен только когда {@code sentry.enabled=true} (т.е. на prod). При старте
+ * приложения пишет info-breadcrumb «Sentry initialized» и лог-строку, по которой в
+ * Railway-логах видно, что DSN подхватился и Sentry-клиент готов отправлять события.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "sentry", name = "enabled", havingValue = "true")
+public class SentryStartupListener {
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() {
+        boolean enabled = Sentry.isEnabled();
+
+        Breadcrumb breadcrumb = new Breadcrumb();
+        breadcrumb.setCategory("startup");
+        breadcrumb.setMessage("Sentry initialized");
+        breadcrumb.setLevel(SentryLevel.INFO);
+        Sentry.addBreadcrumb(breadcrumb);
+
+        // По этой строке в Railway-логах видно, что DSN корректный (Sentry.isEnabled()
+        // == true только когда стартер получил непустой DSN и enabled=true).
+        log.info("Sentry initialized: enabled={} (breadcrumb 'Sentry initialized' recorded)", enabled);
+    }
+}

--- a/src/main/java/com/plantcare/bot/observability/SentryTags.java
+++ b/src/main/java/com/plantcare/bot/observability/SentryTags.java
@@ -1,0 +1,95 @@
+package com.plantcare.bot.observability;
+
+import io.sentry.IScope;
+import io.sentry.Sentry;
+
+import java.util.function.Supplier;
+
+/**
+ * Хелпер для проставления тегов события Sentry (issue #114).
+ *
+ * <p>Теги ({@code layer}, {@code feature}) описывают, из какого слоя/фичи пришёл
+ * апдейт или запрос:
+ * <ul>
+ *   <li>{@code layer} — слой приложения (см. {@link Layer});</li>
+ *   <li>{@code feature} — имя бина-сервиса, где произошла обработка (для группировки
+ *       по фиче в Sentry).</li>
+ * </ul>
+ *
+ * <p><b>Изоляция scope (issue #114, blocking).</b> {@link Sentry#setTag} пишет в
+ * thread-bound scope. На HTTP-потоках стартер push/pop'ает scope per-request, но на
+ * shared-потоках (poll-поток Telegram, единственный поток {@code @Scheduled}) scope
+ * НЕ сбрасывается между задачами — теги «протекают» из одной единицы работы в
+ * следующую (напр. {@code layer=weather} прилипает к scheduler-событию). Поэтому
+ * единицу работы нужно оборачивать в {@link #runWithLayer}/{@link #callWithLayer},
+ * которые через {@link Sentry#withScope(io.sentry.ScopeCallback)} проставляют теги на
+ * КЛОНИРОВАННЫЙ scope только на время операции и гарантированно откатывают его после.
+ * {@code Sentry.captureException}, вызванный ВНУТРИ лямбды, видит корректные теги и не
+ * загрязняет внешний scope.
+ *
+ * <p>Когда Sentry выключен/no-op, все методы безопасно ничего не делают.
+ */
+public final class SentryTags {
+
+    public static final String TAG_LAYER = "layer";
+    public static final String TAG_FEATURE = "feature";
+
+    /** Слой приложения для тега {@code layer}. */
+    public enum Layer {
+        TELEGRAM("telegram"),
+        SCHEDULER("scheduler"),
+        REST("rest"),
+        ADMIN("admin"),
+        WEATHER("weather");
+
+        private final String value;
+
+        Layer(String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return value;
+        }
+    }
+
+    private SentryTags() {
+    }
+
+    /** Проставить теги {@code layer}/{@code feature} на переданный scope. */
+    public static void mark(IScope scope, Layer layer, String feature) {
+        scope.setTag(TAG_LAYER, layer.value());
+        if (feature != null && !feature.isBlank()) {
+            scope.setTag(TAG_FEATURE, feature);
+        }
+    }
+
+    /**
+     * Выполнить {@code body} в изолированном scope с проставленными {@code layer}/
+     * {@code feature}. Теги живут только на время выполнения и откатываются после —
+     * не текут на следующую задачу shared-потока. {@code Sentry.captureException}
+     * внутри {@code body} получит корректные теги.
+     */
+    public static void runWithLayer(Layer layer, String feature, Runnable body) {
+        Sentry.withScope(scope -> {
+            mark(scope, layer, feature);
+            body.run();
+        });
+    }
+
+    /**
+     * Версия {@link #runWithLayer} с возвращаемым значением. {@link Sentry#withScope}
+     * сам по себе значения не возвращает, поэтому прокидываем результат через
+     * однопроходный holder.
+     */
+    public static <T> T callWithLayer(Layer layer, String feature, Supplier<T> body) {
+        var holder = new Object() {
+            T result;
+        };
+        Sentry.withScope(scope -> {
+            mark(scope, layer, feature);
+            holder.result = body.get();
+        });
+        return holder.result;
+    }
+}

--- a/src/main/java/com/plantcare/bot/service/AcclimationSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/AcclimationSchedulerService.java
@@ -3,6 +3,9 @@ package com.plantcare.bot.service;
 import com.plantcare.bot.client.TelegramClientProvider;
 import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.User;
+import com.plantcare.bot.observability.SentryTags;
+import com.plantcare.bot.observability.SentryTags.Layer;
+import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -42,37 +45,43 @@ public class AcclimationSchedulerService {
     @Scheduled(fixedRate = 3_600_000L)  // раз в час
     @Transactional
     public void tick() {
-        LocalDateTime now = LocalDateTime.now();
+        // Issue #114: изолированный scope на тик — captureException внутри получит
+        // тег layer=scheduler, и он не утечёт на соседние задачи shared-потока.
+        SentryTags.runWithLayer(Layer.SCHEDULER, "AcclimationSchedulerService", () -> {
+            LocalDateTime now = LocalDateTime.now();
 
-        // 1) Финализация — растения, у которых истёк период акклиматизации.
-        for (Plant plant : plantAcclimationService.findPlantsToFinish(now)) {
-            try {
-                User user = plant.getUser();
-                if (user.isPaused() || isQuietHours(user, now)) {
-                    continue;  // подождём до следующего тика
+            // 1) Финализация — растения, у которых истёк период акклиматизации.
+            for (Plant plant : plantAcclimationService.findPlantsToFinish(now)) {
+                try {
+                    User user = plant.getUser();
+                    if (user.isPaused() || isQuietHours(user, now)) {
+                        continue;  // подождём до следующего тика
+                    }
+                    sendFinishMessage(user, plant);
+                    plantAcclimationService.finish(plant);
+                } catch (Exception e) {
+                    log.error("Failed to finish acclimation for plant {}: {}",
+                            plant.getId(), e.getMessage(), e);
+                    Sentry.captureException(e);
                 }
-                sendFinishMessage(user, plant);
-                plantAcclimationService.finish(plant);
-            } catch (Exception e) {
-                log.error("Failed to finish acclimation for plant {}: {}",
-                        plant.getId(), e.getMessage(), e);
             }
-        }
 
-        // 2) Check-in вопросы — растения, у которых пришло время следующего опроса.
-        for (Plant plant : plantAcclimationService.findPlantsForCheckin(now)) {
-            try {
-                User user = plant.getUser();
-                if (user.isPaused() || isQuietHours(user, now)) {
-                    continue;
+            // 2) Check-in вопросы — растения, у которых пришло время следующего опроса.
+            for (Plant plant : plantAcclimationService.findPlantsForCheckin(now)) {
+                try {
+                    User user = plant.getUser();
+                    if (user.isPaused() || isQuietHours(user, now)) {
+                        continue;
+                    }
+                    sendCheckinMessage(user, plant);
+                    plantAcclimationService.scheduleNextCheckin(plant);
+                } catch (Exception e) {
+                    log.error("Failed to send acclimation checkin for plant {}: {}",
+                            plant.getId(), e.getMessage(), e);
+                    Sentry.captureException(e);
                 }
-                sendCheckinMessage(user, plant);
-                plantAcclimationService.scheduleNextCheckin(plant);
-            } catch (Exception e) {
-                log.error("Failed to send acclimation checkin for plant {}: {}",
-                        plant.getId(), e.getMessage(), e);
             }
-        }
+        });
     }
 
     private void sendFinishMessage(User user, Plant plant) {

--- a/src/main/java/com/plantcare/bot/service/NotificationSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/NotificationSchedulerService.java
@@ -10,11 +10,14 @@ import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.NotificationType;
 import com.plantcare.bot.domain.enums.TaskType;
 import com.plantcare.bot.metrics.MetricsService;
+import com.plantcare.bot.observability.SentryTags;
+import com.plantcare.bot.observability.SentryTags.Layer;
 import com.plantcare.bot.repository.CareScheduleRepository;
 import com.plantcare.bot.repository.NotificationDigestRepository;
 import com.plantcare.bot.repository.NotificationLogRepository;
 import com.plantcare.bot.repository.UserRepository;
 import io.micrometer.core.instrument.Timer;
+import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -57,16 +60,22 @@ public class NotificationSchedulerService {
     @Scheduled(fixedRate = 60_000)
     @Transactional
     public void checkAndSendNotifications() {
-        // Issue #115: оборачиваем тик в Timer, чтобы в Prometheus была видна
-        // длительность обработки (p50/p95/p99). Сам executeTick остаётся
-        // без изменений — Timer.Sample.stop() запишет latency в hot path
-        // только один раз за тик.
-        Timer.Sample sample = metricsService.startSchedulerTickTimer();
-        try {
-            executeTick();
-        } finally {
-            metricsService.stopSchedulerTickTimer(sample);
-        }
+        // Issue #114: весь тик выполняется в изолированном scope с тегом
+        // layer=scheduler/feature — captureException внутри получит верные теги,
+        // а вызовы weather внутри тика не загрязнят scope соседних задач
+        // shared-потока @Scheduled.
+        SentryTags.runWithLayer(Layer.SCHEDULER, "NotificationSchedulerService", () -> {
+            // Issue #115: оборачиваем тик в Timer, чтобы в Prometheus была видна
+            // длительность обработки (p50/p95/p99). Сам executeTick остаётся
+            // без изменений — Timer.Sample.stop() запишет latency в hot path
+            // только один раз за тик.
+            Timer.Sample sample = metricsService.startSchedulerTickTimer();
+            try {
+                executeTick();
+            } finally {
+                metricsService.stopSchedulerTickTimer(sample);
+            }
+        });
     }
 
     /**
@@ -131,6 +140,7 @@ public class NotificationSchedulerService {
             return SendOneResult.sent();
         } catch (Exception e) {
             log.error("sendOneSchedule failed for schedule={}: {}", scheduleId, e.getMessage(), e);
+            Sentry.captureException(e);
             return SendOneResult.failed(e.getMessage());
         }
     }
@@ -214,6 +224,7 @@ public class NotificationSchedulerService {
                         .add(schedule);
             } catch (Exception e) {
                 log.error("Error checking schedule id={}: {}", schedule.getId(), e.getMessage(), e);
+                Sentry.captureException(e);
             }
         }
 
@@ -222,6 +233,7 @@ public class NotificationSchedulerService {
                 sendNotification(soilCheck.getPlant().getUser(), soilCheck.getPlant(), soilCheck);
             } catch (Exception e) {
                 log.error("Error sending soil-check notification: {}", e.getMessage(), e);
+                Sentry.captureException(e);
             }
         }
 
@@ -230,6 +242,7 @@ public class NotificationSchedulerService {
                 sendNotification(acclim.getPlant().getUser(), acclim.getPlant(), acclim);
             } catch (Exception e) {
                 log.error("Error sending acclimation watering notification: {}", e.getMessage(), e);
+                Sentry.captureException(e);
             }
         }
 
@@ -243,6 +256,7 @@ public class NotificationSchedulerService {
                 }
             } catch (Exception e) {
                 log.error("Error sending notifications group: {}", e.getMessage(), e);
+                Sentry.captureException(e);
             }
         }
 

--- a/src/main/java/com/plantcare/bot/service/PhotoProgressSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/PhotoProgressSchedulerService.java
@@ -3,7 +3,10 @@ package com.plantcare.bot.service;
 import com.plantcare.bot.client.TelegramClientProvider;
 import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.User;
+import com.plantcare.bot.observability.SentryTags;
+import com.plantcare.bot.observability.SentryTags.Layer;
 import com.plantcare.bot.repository.PlantRepository;
+import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -56,36 +59,41 @@ public class PhotoProgressSchedulerService {
 
     @Scheduled(fixedRate = INTERVAL_MS)
     public void checkPhotoPrompts() {
-        LocalDateTime now = LocalDateTime.now();
-        List<Plant> due = loadDuePlants(now);
+        // Issue #114: изолированный scope на тик — тег layer=scheduler не течёт на
+        // соседние задачи shared-потока @Scheduled.
+        SentryTags.runWithLayer(Layer.SCHEDULER, "PhotoProgressSchedulerService", () -> {
+            LocalDateTime now = LocalDateTime.now();
+            List<Plant> due = loadDuePlants(now);
 
-        if (due.isEmpty()) {
-            return;
-        }
-        log.info("Photo-progress tick: {} plants due", due.size());
-
-        for (Plant plant : due) {
-            try {
-                User user = plant.getUser();
-                if (user == null) {
-                    continue;
-                }
-                if (user.isPaused() || user.isBlocked()) {
-                    continue;
-                }
-                if (isQuietHours(user, now)) {
-                    continue;
-                }
-
-                boolean sent = sendPhotoPrompt(user, plant);
-                if (sent) {
-                    photoProgressService.markPromptSent(plant.getId(), LocalDateTime.now());
-                }
-            } catch (Exception e) {
-                log.error("Failed to handle photo-progress prompt for plant {}: {}",
-                        plant.getId(), e.getMessage(), e);
+            if (due.isEmpty()) {
+                return;
             }
-        }
+            log.info("Photo-progress tick: {} plants due", due.size());
+
+            for (Plant plant : due) {
+                try {
+                    User user = plant.getUser();
+                    if (user == null) {
+                        continue;
+                    }
+                    if (user.isPaused() || user.isBlocked()) {
+                        continue;
+                    }
+                    if (isQuietHours(user, now)) {
+                        continue;
+                    }
+
+                    boolean sent = sendPhotoPrompt(user, plant);
+                    if (sent) {
+                        photoProgressService.markPromptSent(plant.getId(), LocalDateTime.now());
+                    }
+                } catch (Exception e) {
+                    log.error("Failed to handle photo-progress prompt for plant {}: {}",
+                            plant.getId(), e.getMessage(), e);
+                    Sentry.captureException(e);
+                }
+            }
+        });
     }
 
     /**

--- a/src/main/java/com/plantcare/bot/service/PlantAnniversaryScheduler.java
+++ b/src/main/java/com/plantcare/bot/service/PlantAnniversaryScheduler.java
@@ -1,7 +1,10 @@
 package com.plantcare.bot.service;
 
 import com.plantcare.bot.client.TelegramClientProvider;
+import com.plantcare.bot.observability.SentryTags;
+import com.plantcare.bot.observability.SentryTags.Layer;
 import com.plantcare.bot.repository.UserRepository;
+import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -57,35 +60,40 @@ public class PlantAnniversaryScheduler {
      */
     @Scheduled(cron = "0 5 * * * *", zone = "UTC")
     public void tick() {
-        Instant now = clock.instant();
-        List<PlantAnniversaryService.Anniversary> due =
-                plantAnniversaryService.findDueAnniversaries(now);
+        // Issue #114: изолированный scope на тик — captureException внутри получит
+        // тег layer=scheduler, и он не утечёт на соседние задачи shared-потока.
+        SentryTags.runWithLayer(Layer.SCHEDULER, "PlantAnniversaryScheduler", () -> {
+            Instant now = clock.instant();
+            List<PlantAnniversaryService.Anniversary> due =
+                    plantAnniversaryService.findDueAnniversaries(now);
 
-        if (due.isEmpty()) {
-            return;
-        }
-        log.info("Anniversary tick: {} candidates found", due.size());
-
-        for (PlantAnniversaryService.Anniversary anniversary : due) {
-            try {
-                if (!isMorningInUserZone(anniversary.userId(), now)) {
-                    continue;
-                }
-                if (sendAnniversary(anniversary)) {
-                    plantAnniversaryService.markSent(
-                            anniversary.plantId(),
-                            anniversary.anniversaryYear(),
-                            now);
-                    log.info("Anniversary sent: plant={} years={} user={}",
-                            anniversary.plantId(),
-                            anniversary.yearsOld(),
-                            anniversary.telegramChatId());
-                }
-            } catch (Exception e) {
-                log.error("Failed to handle anniversary for plant {}: {}",
-                        anniversary.plantId(), e.getMessage(), e);
+            if (due.isEmpty()) {
+                return;
             }
-        }
+            log.info("Anniversary tick: {} candidates found", due.size());
+
+            for (PlantAnniversaryService.Anniversary anniversary : due) {
+                try {
+                    if (!isMorningInUserZone(anniversary.userId(), now)) {
+                        continue;
+                    }
+                    if (sendAnniversary(anniversary)) {
+                        plantAnniversaryService.markSent(
+                                anniversary.plantId(),
+                                anniversary.anniversaryYear(),
+                                now);
+                        log.info("Anniversary sent: plant={} years={} user={}",
+                                anniversary.plantId(),
+                                anniversary.yearsOld(),
+                                anniversary.telegramChatId());
+                    }
+                } catch (Exception e) {
+                    log.error("Failed to handle anniversary for plant {}: {}",
+                            anniversary.plantId(), e.getMessage(), e);
+                    Sentry.captureException(e);
+                }
+            }
+        });
     }
 
     /**

--- a/src/main/java/com/plantcare/bot/service/VacationSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/VacationSchedulerService.java
@@ -4,8 +4,11 @@ import com.plantcare.bot.client.TelegramClientProvider;
 import com.plantcare.bot.domain.CareSchedule;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.observability.SentryTags;
+import com.plantcare.bot.observability.SentryTags.Layer;
 import com.plantcare.bot.repository.CareScheduleRepository;
 import com.plantcare.bot.repository.UserRepository;
+import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
@@ -62,26 +65,32 @@ public class VacationSchedulerService {
 
     @Scheduled(cron = "0 0 * * * *", zone = "UTC")
     public void tick() {
-        LocalDateTime now = LocalDateTime.now(clock);
-        VacationSchedulerService self = self();
+        // Issue #114: изолированный scope на тик — captureException внутри получит
+        // тег layer=scheduler, и он не утечёт на соседние задачи shared-потока.
+        SentryTags.runWithLayer(Layer.SCHEDULER, "VacationSchedulerService", () -> {
+            LocalDateTime now = LocalDateTime.now(clock);
+            VacationSchedulerService self = self();
 
-        try {
-            List<Long> chatIds = self.collectChatIdsForTomorrowReminder(now);
-            for (Long chatId : chatIds) {
-                sendTomorrowBackMessage(chatId);
+            try {
+                List<Long> chatIds = self.collectChatIdsForTomorrowReminder(now);
+                for (Long chatId : chatIds) {
+                    sendTomorrowBackMessage(chatId);
+                }
+            } catch (Exception e) {
+                log.error("Failed to send tomorrow-back reminders: {}", e.getMessage(), e);
+                Sentry.captureException(e);
             }
-        } catch (Exception e) {
-            log.error("Failed to send tomorrow-back reminders: {}", e.getMessage(), e);
-        }
 
-        try {
-            List<WelcomeBackPayload> payloads = self.collectAndCloseVacations(now);
-            for (WelcomeBackPayload payload : payloads) {
-                sendWelcomeBackMessage(payload);
+            try {
+                List<WelcomeBackPayload> payloads = self.collectAndCloseVacations(now);
+                for (WelcomeBackPayload payload : payloads) {
+                    sendWelcomeBackMessage(payload);
+                }
+            } catch (Exception e) {
+                log.error("Failed to process vacation ends: {}", e.getMessage(), e);
+                Sentry.captureException(e);
             }
-        } catch (Exception e) {
-            log.error("Failed to process vacation ends: {}", e.getMessage(), e);
-        }
+        });
     }
 
     @Transactional(readOnly = true)
@@ -131,6 +140,7 @@ public class VacationSchedulerService {
                         "Failed to close vacation for user {}: {}",
                         user.getTelegramChatId(), e.getMessage(), e
                 );
+                Sentry.captureException(e);
             }
         }
         return result;

--- a/src/main/java/com/plantcare/bot/weather/client/OpenMeteoClient.java
+++ b/src/main/java/com/plantcare/bot/weather/client/OpenMeteoClient.java
@@ -23,6 +23,10 @@ public class OpenMeteoClient {
     private final RestClient openMeteoRestClient;
 
     public Optional<OpenMeteoResponse> fetchHourlyHumidity(double lat, double lon) {
+        // Issue #114: НЕ ставим тег layer=weather на общий scope. Клиент вызывается
+        // из shared-потока @Scheduled (через WeatherService) и сам Sentry никогда не
+        // зовёт (любой сбой → WARN + Optional.empty()). Глобальный setTag здесь
+        // загрязнял бы scope тика шедулера тегом weather (см. issue #114, blocking).
         try {
             OpenMeteoResponse response = openMeteoRestClient.get()
                     .uri(uriBuilder -> uriBuilder

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,3 +9,8 @@ logging:
   level:
     org.hibernate.SQL: DEBUG
     org.hibernate.orm.jdbc.bind: TRACE
+
+# Issue #114: на dev Sentry отключён — локально ошибки смотрим в логах,
+# квоту free-tier не тратим.
+sentry:
+  enabled: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -6,3 +6,14 @@ logging:
   level:
     root: INFO
     com.plantcare.bot: INFO
+
+# Issue #114: на prod Sentry включён. DSN приходит из env SENTRY_DSN (пустой дефолт —
+# если не задан, стартер инициализируется в no-op и просто не шлёт события).
+# release берётся из Maven project.version через resource filtering (@...@-плейсхолдер,
+# фильтрация application*.yml включена в spring-boot-starter-parent).
+sentry:
+  enabled: true
+  dsn: ${SENTRY_DSN:}
+  environment: prod
+  release: @project.version@
+  send-default-pii: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -113,4 +113,12 @@ logging:
     root: INFO
     com.plantcare.bot: DEBUG
 
+# Issue #114: Sentry. По умолчанию выключен (no-op) — включается только на prod-профиле.
+# На dev/test остаётся false, поэтому реальные отправки в Sentry из тестов невозможны.
+sentry:
+  enabled: false
+  # Никогда не отправляем PII по умолчанию: chat_id/telegram_user_id хешируются
+  # в SentryPiiFilter, тексты заметок/имена растений вырезаются.
+  send-default-pii: false
+
 kind: Application

--- a/src/test/java/com/plantcare/bot/observability/SentryPiiFilterTest.java
+++ b/src/test/java/com/plantcare/bot/observability/SentryPiiFilterTest.java
@@ -1,0 +1,511 @@
+package com.plantcare.bot.observability;
+
+import io.sentry.Breadcrumb;
+import io.sentry.SentryEvent;
+import io.sentry.protocol.Message;
+import io.sentry.protocol.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Юнит-тесты PII-фильтра Sentry (issue #114). Без Spring/Testcontainers/живого Sentry-хаба —
+ * только {@code new SentryPiiFilter()} и собранный руками {@link SentryEvent}.
+ */
+class SentryPiiFilterTest {
+
+    private SentryPiiFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new SentryPiiFilter();
+    }
+
+    // ---------------------------------------------------------------------
+    // 1. chat_id / telegram_user_id маскируются (happy path)
+    // ---------------------------------------------------------------------
+
+    @Test
+    void should_hash_id_tags_when_snake_case_id_keys_present() {
+        // arrange
+        var event = new SentryEvent();
+        event.setTag("chat_id", "123456789");
+        event.setTag("telegram_user_id", "42");
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        assertThat(event.getTags())
+                .containsEntry("chat_id", filter.hash("123456789"))
+                .containsEntry("telegram_user_id", filter.hash("42"));
+        assertThat(event.getTags().get("chat_id")).isNotEqualTo("123456789");
+    }
+
+    @Test
+    void should_hash_id_tags_when_camel_case_id_keys_present() {
+        // arrange
+        var event = new SentryEvent();
+        event.setTag("chatId", "987654321");
+        event.setTag("telegramUserId", "7");
+        event.setTag("telegramChatId", "555");
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        assertThat(event.getTags())
+                .containsEntry("chatId", filter.hash("987654321"))
+                .containsEntry("telegramUserId", filter.hash("7"))
+                .containsEntry("telegramChatId", filter.hash("555"));
+    }
+
+    @Test
+    void should_hash_id_extra_when_numeric_value_in_id_key() {
+        // arrange
+        var event = new SentryEvent();
+        event.setExtra("telegram_user_id", 42L);
+        event.setExtra("chatId", 123456789L);
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        assertThat(event.getExtras())
+                .containsEntry("telegram_user_id", filter.hash("42"))
+                .containsEntry("chatId", filter.hash("123456789"));
+    }
+
+    @Test
+    void should_produce_hex_value_of_prefix_length_when_hashing_id_tag() {
+        // arrange
+        var event = new SentryEvent();
+        event.setTag("chat_id", "123456789");
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        String hashed = event.getTags().get("chat_id");
+        assertThat(hashed)
+                .hasSize(SentryPiiFilter.HASH_PREFIX_LEN)
+                .matches("[0-9a-f]+");
+    }
+
+    // ---------------------------------------------------------------------
+    // 2. Имена растений / заметки НЕ уходят (FREE_TEXT_KEYS) — явный AC
+    // ---------------------------------------------------------------------
+
+    @Test
+    void should_redact_free_text_tags_when_user_text_keys_present() {
+        // arrange
+        var event = new SentryEvent();
+        event.setTag("plant_name", "Фикус Бенджамина");
+        event.setTag("note", "полить через 3 дня");
+        event.setTag("message_text", "/start secret");
+        event.setTag("callback_data", "delete:42");
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        assertThat(event.getTags())
+                .containsEntry("plant_name", SentryPiiFilter.REDACTED)
+                .containsEntry("note", SentryPiiFilter.REDACTED)
+                .containsEntry("message_text", SentryPiiFilter.REDACTED)
+                .containsEntry("callback_data", SentryPiiFilter.REDACTED);
+    }
+
+    @Test
+    void should_redact_free_text_extra_when_user_text_keys_present() {
+        // arrange
+        var event = new SentryEvent();
+        event.setExtra("plantName", "Монстера");
+        event.setExtra("notes", "заметка пользователя");
+        event.setExtra("userText", "что-то приватное");
+        event.setExtra("callbackData", "edit:7");
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        assertThat(event.getExtras())
+                .containsEntry("plantName", SentryPiiFilter.REDACTED)
+                .containsEntry("notes", SentryPiiFilter.REDACTED)
+                .containsEntry("userText", SentryPiiFilter.REDACTED)
+                .containsEntry("callbackData", SentryPiiFilter.REDACTED);
+    }
+
+    // ---------------------------------------------------------------------
+    // 3. User PII вычищается
+    // ---------------------------------------------------------------------
+
+    @Test
+    void should_hash_user_id_and_clear_other_pii_when_user_present() {
+        // arrange
+        var user = new User();
+        user.setId("123456789");
+        user.setEmail("user@example.com");
+        user.setUsername("john_doe");
+        user.setIpAddress("203.0.113.7");
+        var event = new SentryEvent();
+        event.setUser(user);
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        User sanitized = event.getUser();
+        assertThat(sanitized.getId())
+                .isEqualTo(filter.hash("123456789"))
+                .isNotEqualTo("123456789");
+        assertThat(sanitized.getEmail()).isNull();
+        assertThat(sanitized.getUsername()).isNull();
+        assertThat(sanitized.getIpAddress()).isNull();
+    }
+
+    @Test
+    void should_clear_user_pii_when_user_id_is_null() {
+        // arrange
+        var user = new User();
+        user.setEmail("user@example.com");
+        user.setUsername("john_doe");
+        var event = new SentryEvent();
+        event.setUser(user);
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        User sanitized = event.getUser();
+        assertThat(sanitized.getId()).isNull();
+        assertThat(sanitized.getEmail()).isNull();
+        assertThat(sanitized.getUsername()).isNull();
+    }
+
+    // ---------------------------------------------------------------------
+    // 4. hash: детерминированность, необратимость, длина, null/blank
+    // ---------------------------------------------------------------------
+
+    @Test
+    void should_return_same_hash_when_same_input_for_dedup() {
+        // arrange
+        String raw = "123456789";
+
+        // act
+        String first = filter.hash(raw);
+        String second = filter.hash(raw);
+
+        // assert
+        assertThat(first).isEqualTo(second);
+    }
+
+    @Test
+    void should_return_different_hash_when_different_input() {
+        // arrange / act
+        String a = filter.hash("123456789");
+        String b = filter.hash("987654321");
+
+        // assert
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    void should_match_independent_sha256_prefix_when_hashing() throws NoSuchAlgorithmException {
+        // arrange
+        String raw = "telegram-chat-42";
+        byte[] digest = MessageDigest.getInstance("SHA-256")
+                .digest(raw.getBytes(StandardCharsets.UTF_8));
+        String expected = HexFormat.of().formatHex(digest).substring(0, SentryPiiFilter.HASH_PREFIX_LEN);
+
+        // act
+        String actual = filter.hash(raw);
+
+        // assert
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void should_not_leak_raw_value_when_hashing() {
+        // arrange
+        String raw = "123456789";
+
+        // act
+        String hashed = filter.hash(raw);
+
+        // assert
+        assertThat(hashed)
+                .isNotEqualTo(raw)
+                .doesNotContain(raw)
+                .hasSize(SentryPiiFilter.HASH_PREFIX_LEN);
+    }
+
+    @Test
+    void should_redact_when_hash_input_is_null() {
+        // arrange / act
+        String result = filter.hash(null);
+
+        // assert
+        assertThat(result).isEqualTo(SentryPiiFilter.REDACTED);
+    }
+
+    @Test
+    void should_redact_when_hash_input_is_blank() {
+        // arrange / act
+        String result = filter.hash("   ");
+
+        // assert
+        assertThat(result).isEqualTo(SentryPiiFilter.REDACTED);
+    }
+
+    // ---------------------------------------------------------------------
+    // 5. edge / failure: NPE-safety, non-PII keys untouched, message behaviour
+    // ---------------------------------------------------------------------
+
+    @Test
+    void should_not_throw_and_return_same_event_when_event_is_empty() {
+        // arrange
+        var event = new SentryEvent();
+
+        // act / assert
+        assertThatNoException().isThrownBy(() -> filter.sanitize(event));
+        assertThat(filter.sanitize(event)).isSameAs(event);
+    }
+
+    @Test
+    void should_leave_non_pii_tags_untouched_when_sanitizing() {
+        // arrange
+        var event = new SentryEvent();
+        event.setTag("layer", "scheduler");
+        event.setTag("feature", "watering-reminder");
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        assertThat(event.getTags())
+                .containsEntry("layer", "scheduler")
+                .containsEntry("feature", "watering-reminder");
+    }
+
+    @Test
+    void should_leave_non_pii_extras_untouched_when_sanitizing() {
+        // arrange
+        var event = new SentryEvent();
+        event.setExtra("attempt", 3);
+        event.setExtra("region", "eu-central");
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        assertThat(event.getExtras())
+                .containsEntry("attempt", 3)
+                .containsEntry("region", "eu-central");
+    }
+
+    @Test
+    void should_redact_formatted_message_when_template_message_is_null() {
+        // arrange
+        var message = new Message();
+        message.setFormatted("Failed to water plant Фикус for user 42");
+        // message.getMessage() остаётся null
+        var event = new SentryEvent();
+        event.setMessage(message);
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        assertThat(event.getMessage().getFormatted()).isEqualTo(SentryPiiFilter.REDACTED);
+    }
+
+    @Test
+    void should_redact_formatted_when_template_message_is_present() {
+        // arrange
+        // formatted содержит интерполированный PII (имя растения, id юзера) —
+        // его маскируем ВСЕГДА, даже когда задан статический шаблон message.
+        // Сам шаблон message PII не содержит и должен остаться нетронутым.
+        var message = new Message();
+        message.setMessage("Failed to water plant {} for user {}");
+        message.setFormatted("Failed to water plant Фикус Бенджамина for user 42");
+        var event = new SentryEvent();
+        event.setMessage(message);
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        assertThat(event.getMessage().getFormatted()).isEqualTo(SentryPiiFilter.REDACTED);
+        assertThat(event.getMessage().getMessage()).isEqualTo("Failed to water plant {} for user {}");
+    }
+
+    @Test
+    void should_redact_message_params_when_present() {
+        // arrange
+        var message = new Message();
+        message.setMessage("Failed to water plant {} for user {}");
+        message.setParams(List.of("Фикус Бенджамина", "42"));
+        var event = new SentryEvent();
+        event.setMessage(message);
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        assertThat(event.getMessage().getParams())
+                .containsExactly(SentryPiiFilter.REDACTED, SentryPiiFilter.REDACTED);
+        assertThat(event.getMessage().getMessage()).isEqualTo("Failed to water plant {} for user {}");
+    }
+
+    @Test
+    void should_not_throw_when_message_present_without_formatted_or_template() {
+        // arrange
+        var event = new SentryEvent();
+        event.setMessage(new Message());
+
+        // act / assert
+        assertThatNoException().isThrownBy(() -> filter.sanitize(event));
+        assertThat(event.getMessage().getFormatted()).isEqualTo(SentryPiiFilter.REDACTED);
+    }
+
+    // ---------------------------------------------------------------------
+    // 6. breadcrumbs — авто-PII-канал (новый шаг sanitizeBreadcrumbs)
+    // ---------------------------------------------------------------------
+
+    @Test
+    void should_redact_breadcrumb_message_when_it_contains_user_text() {
+        // arrange
+        var crumb = new Breadcrumb();
+        crumb.setMessage("user sent: полить Фикус через 3 дня");
+        var event = new SentryEvent();
+        event.addBreadcrumb(crumb);
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        assertThat(event.getBreadcrumbs())
+                .singleElement()
+                .extracting(Breadcrumb::getMessage)
+                .isEqualTo(SentryPiiFilter.REDACTED);
+    }
+
+    @Test
+    void should_hash_id_keys_in_breadcrumb_data_when_present() {
+        // arrange
+        var crumb = new Breadcrumb();
+        crumb.setData("chat_id", "123456789");
+        crumb.setData("telegram_user_id", 42L);
+        var event = new SentryEvent();
+        event.addBreadcrumb(crumb);
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        Map<String, Object> data = event.getBreadcrumbs().get(0).getData();
+        assertThat(data)
+                .containsEntry("chat_id", filter.hash("123456789"))
+                .containsEntry("telegram_user_id", filter.hash("42"));
+        assertThat(data.get("chat_id")).isNotEqualTo("123456789");
+    }
+
+    @Test
+    void should_redact_string_values_in_breadcrumb_data_when_not_id_key() {
+        // arrange
+        var crumb = new Breadcrumb();
+        crumb.setData("plant_name", "Монстера");
+        crumb.setData("free_text", "произвольная заметка юзера");
+        var event = new SentryEvent();
+        event.addBreadcrumb(crumb);
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        // Любая строка в breadcrumb.data — потенциальный PII, даже под произвольным
+        // ключом (не только FREE_TEXT_KEYS): код маскирует ВСЕ строки.
+        Map<String, Object> data = event.getBreadcrumbs().get(0).getData();
+        assertThat(data)
+                .containsEntry("plant_name", SentryPiiFilter.REDACTED)
+                .containsEntry("free_text", SentryPiiFilter.REDACTED);
+    }
+
+    @Test
+    void should_keep_numeric_and_boolean_breadcrumb_data_when_sanitizing() {
+        // arrange
+        // числа/booleans (статусы, коды, длительности) НЕ PII — оставляем для диагностики.
+        var crumb = new Breadcrumb();
+        crumb.setData("status_code", 500);
+        crumb.setData("duration_ms", 1234L);
+        crumb.setData("retried", true);
+        var event = new SentryEvent();
+        event.addBreadcrumb(crumb);
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        Map<String, Object> data = event.getBreadcrumbs().get(0).getData();
+        assertThat(data)
+                .containsEntry("status_code", 500)
+                .containsEntry("duration_ms", 1234L)
+                .containsEntry("retried", true);
+    }
+
+    @Test
+    void should_apply_all_data_rules_in_single_breadcrumb_when_mixed_values() {
+        // arrange
+        // один crumb со всеми тремя видами data + message: id → hash, string → redact,
+        // number → kept.
+        var crumb = new Breadcrumb();
+        crumb.setMessage("handling callback delete:42");
+        crumb.setData("chat_id", "999000");
+        crumb.setData("callback_data", "delete:42");
+        crumb.setData("attempt", 2);
+        var event = new SentryEvent();
+        event.addBreadcrumb(crumb);
+
+        // act
+        filter.sanitize(event);
+
+        // assert
+        Breadcrumb sanitized = event.getBreadcrumbs().get(0);
+        assertThat(sanitized.getMessage()).isEqualTo(SentryPiiFilter.REDACTED);
+        assertThat(sanitized.getData())
+                .containsEntry("chat_id", filter.hash("999000"))
+                .containsEntry("callback_data", SentryPiiFilter.REDACTED)
+                .containsEntry("attempt", 2);
+    }
+
+    @Test
+    void should_not_throw_when_event_has_no_breadcrumbs() {
+        // arrange
+        // SentryEvent без единого addBreadcrumb — getBreadcrumbs() пуст/нет крошек.
+        var event = new SentryEvent();
+
+        // act / assert
+        assertThatNoException().isThrownBy(() -> filter.sanitize(event));
+        assertThat(event.getBreadcrumbs()).isNullOrEmpty();
+    }
+
+    @Test
+    void should_not_throw_when_breadcrumb_has_no_message_or_data() {
+        // arrange
+        var event = new SentryEvent();
+        event.addBreadcrumb(new Breadcrumb());
+
+        // act / assert
+        assertThatNoException().isThrownBy(() -> filter.sanitize(event));
+    }
+}


### PR DESCRIPTION
Closes #114

## Что сделано
- Подключён `sentry-spring-boot-starter-jakarta:7.22.5` (Spring Boot 3.5.14). Активен только на `prod` (`SENTRY_DSN` env); на `dev`/`test` — `enabled: false`, no-op, реальных отправок из тестов нет. Release берётся из Maven `@project.version@`.
- `Sentry.captureException` добавлен в глотающие `catch`-блоки 6 `@Scheduled`-сервисов и в catch-all telegram-диспетчера `PlantsCareBot` (через него всплывают и ошибки `NotificationCallbackService`). Туда, где исключение и так пробрасывается, capture не дублируется.
- Теги события `layer` (`telegram`/`scheduler`/`admin`/`weather`) + `feature` (имя класса). Проставляются через `Sentry.withScope`-хелперы (`SentryTags.runWithLayer`/`callWithLayer`), чтобы теги жили в пределах единицы работы и **не текли** между задачами на общих потоках шедулера/поллинга.
- PII-фильтр `SentryPiiFilter` (`BeforeSendCallback`): `chat_id`/`telegram_user_id` хешируются (SHA-256, префикс), имена растений/заметки/`formatted`/`params`/breadcrumbs маскируются, `User` PII (email/username/ip) вычищается, `send-default-pii: false`.
- Health-чек: `SentryStartupListener` пишет info-breadcrumb «Sentry initialized» на старте (prod-only, `@ConditionalOnProperty`).
- README: добавлен `SENTRY_DSN` (опциональная, prod) в Observability и Railway-деплой.

## Миграции
Нет — это observability-слой, схему БД не трогает.

## Backward-compat риски
Safe. Новая опциональная env-переменная `SENTRY_DSN`; без неё стартер no-op даже на prod. Без изменений схемы/публичного API. `Dockerfile`/`railway.toml` не тронуты.

## Тесты
- `SentryPiiFilterTest` (28 кейсов, unit): хеширование chat_id/telegram_user_id в тегах и extra (snake+camelCase), редактирование имён/заметок/`formatted`/`params`, очистка User PII, детерминированность/необратимость `hash`, санитизация breadcrumbs (message/data: id→hash, строки→redact, числа/booleans остаются), edge-кейсы (null tags/extras/user/message/breadcrumbs).
- Файл: `src/test/java/com/plantcare/bot/observability/SentryPiiFilterTest.java`.

## Чек
- [x] `mvn verify` зелёное (падают только 2 pre-existing baseline-flaky теста про ordering популярных видов — `SpeciesRepositoryTest.topPopularReturnsInCorrectOrder`, `PlantServiceTest.getPopularSpecies_orderedByPopularity`; к Sentry отношения не имеют)
- [x] reviewer прошёл — найденный BLOCKING (утечка scope-тегов на shared-потоках) исправлен через `withScope`; новых блокеров нет

> Примечание: AC issue упоминал «Spring Boot 3.3», но проект фактически на 3.5.14 — взята совместимая линия Sentry 7.x (7.22.5).
