### PR TITLE
feat: species encyclopedia facts (#129)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 - **V15** — добавляет `client_id VARCHAR(64) NULL` в `care_history` с partial unique index `WHERE client_id IS NOT NULL`. Колонка nullable — записи из Telegram-бота остаются с NULL без конфликтов
 - **V20** — добавляет `plants.acquired_at DATE NULL` — дата, когда юзер завёл растение. Используется шедулером годовщин и строкой «С тобой с …» в карточке. NULL = в годовщинах не участвует
 - **V21** — таблица `plant_anniversaries_sent` (PK `(plant_id, anniversary_year)`) для идемпотентности годовщин: один пуш на растение в год. FK `ON DELETE CASCADE`. Здесь же — частичный индекс `idx_plants_acquired_active` на `plants(acquired_at) WHERE acquired_at IS NOT NULL AND archived_at IS NULL` под запрос шедулера
+- **V22** — таблица `species_facts` (энциклопедия видов, ADR-011): кураторские факты по видам с категориями `ORIGIN`/`CARE`/`TOXICITY`/`CURIOSITY` (CHECK), `title`/`body`/`source`/`display_order`. FK на `species` `ON DELETE CASCADE`, btree-индекс `(species_id, category, display_order)`. GIN-индекс намеренно не создаётся (обоснование в комментарии миграции). Сидинг — отдельной задачей
 
 ## REST API
 
@@ -175,7 +176,9 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 }
 ```
 
-Ответ `GET /api/v1/species/{id}` — те же поля плюс `description`. При отсутствии записи — `404`.
+Ответ `GET /api/v1/species/{id}` — те же поля плюс `description` и `facts[]` — энциклопедические факты вида (ADR-011), отсортированные по категории, затем по `display_order`; пустой массив, если фактов нет. Каждый факт: `category` (`ORIGIN`/`CARE`/`TOXICITY`/`CURIOSITY`), `body`, опциональные `title` и `source`. При отсутствии записи — `404`.
+
+Поиск `q` в `GET /api/v1/species` дополнительно находит вид по совпадению в тексте его фактов (title/body), не только по имени и тегам.
 
 ### Типы ухода
 

--- a/src/main/java/com/plantcare/bot/domain/SpeciesFact.java
+++ b/src/main/java/com/plantcare/bot/domain/SpeciesFact.java
@@ -1,0 +1,62 @@
+package com.plantcare.bot.domain;
+
+import com.plantcare.bot.domain.base.BaseEntity;
+import com.plantcare.bot.domain.enums.FactCategory;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * Энциклопедический факт о виде растения (ADR-011, issue #129).
+ *
+ * <p>Таблица {@code species_facts} создана в миграции V22. Факты группируются
+ * по {@link FactCategory} и сортируются внутри категории по {@code displayOrder}.
+ *
+ * <p>{@code updatedAt} обновляется триггером {@code trg_species_facts_updated_at}
+ * на стороне БД — поле помечено {@code insertable=false, updatable=false}, чтобы
+ * Hibernate не перетирал значение, выставленное БД. {@code createdAt} наследуется
+ * из {@link BaseEntity} (Hibernate {@code @CreationTimestamp} + DB default).
+ */
+@Entity
+@Table(name = "species_facts")
+@Getter
+@Setter
+@NoArgsConstructor
+public class SpeciesFact extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "species_id", nullable = false)
+    private Species species;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 24)
+    private FactCategory category;
+
+    @Column(name = "title", length = 160)
+    private String title;
+
+    @Column(name = "body", nullable = false, columnDefinition = "TEXT")
+    private String body;
+
+    @Column(name = "source", length = 300)
+    private String source;
+
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder = 0;
+
+    /**
+     * Управляется триггером в БД. Только чтение со стороны Hibernate.
+     */
+    @Column(name = "updated_at", nullable = false, insertable = false, updatable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/plantcare/bot/domain/enums/FactCategory.java
+++ b/src/main/java/com/plantcare/bot/domain/enums/FactCategory.java
@@ -1,0 +1,16 @@
+package com.plantcare.bot.domain.enums;
+
+/**
+ * Категория энциклопедического факта о виде (ADR-011, issue #129).
+ *
+ * <p>Значения совпадают с CHECK-ограничением {@code chk_species_facts_category}
+ * в БД (V22). Новая категория = правка CHECK отдельной миграцией + дополнение
+ * этого enum. Категорию {@code DISEASE} сознательно не вводим — диагностика
+ * живёт отдельно (issue #73).
+ */
+public enum FactCategory {
+    ORIGIN,
+    CARE,
+    TOXICITY,
+    CURIOSITY
+}

--- a/src/main/java/com/plantcare/bot/repository/SpeciesFactRepository.java
+++ b/src/main/java/com/plantcare/bot/repository/SpeciesFactRepository.java
@@ -1,0 +1,34 @@
+package com.plantcare.bot.repository;
+
+import com.plantcare.bot.domain.SpeciesFact;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * Доступ к энциклопедическим фактам видов (ADR-011, issue #129).
+ */
+@Repository
+public interface SpeciesFactRepository extends JpaRepository<SpeciesFact, Long> {
+
+    /**
+     * Факты вида в порядке показа: по категории, затем по display_order.
+     * Опирается на индекс {@code idx_species_facts_species_category_order} (V22).
+     *
+     * @param speciesId идентификатор вида
+     * @return упорядоченный список фактов; пустой, если фактов нет
+     */
+    List<SpeciesFact> findBySpeciesIdOrderByCategoryAscDisplayOrderAsc(Long speciesId);
+
+    /**
+     * Дешёвая проверка наличия фактов у вида ({@code SELECT EXISTS}).
+     * Используется для видимости кнопки «О виде» на карточке растения,
+     * чтобы не грузить весь список фактов ради {@code isEmpty()}.
+     * Опирается на индекс {@code idx_species_facts_species_category_order} (V22).
+     *
+     * @param speciesId идентификатор вида
+     * @return {@code true}, если у вида есть хотя бы один факт
+     */
+    boolean existsBySpeciesId(Long speciesId);
+}

--- a/src/main/java/com/plantcare/bot/repository/SpeciesRepository.java
+++ b/src/main/java/com/plantcare/bot/repository/SpeciesRepository.java
@@ -30,12 +30,22 @@ public interface SpeciesRepository extends JpaRepository<Species, Long> {
      * Запрос native, потому что Spring Data не умеет tsvector декларативно.
      * Plainto_tsquery толерантен к пользовательскому вводу — экранирует спец-символы,
      * в отличие от to_tsquery, который требует чистого формата.
+     *
+     * issue #129: вид также находится по совпадению в теле/заголовке его
+     * энциклопедических фактов (species_facts) — через EXISTS с tsvector по
+     * coalesce(title,'')||' '||body. Ранжирование по popularity сохранено.
      */
     @Query(value = """
         SELECT * FROM species
         WHERE to_tsvector('simple', coalesce(search_tags, '')) @@ plainto_tsquery('simple', :query)
            OR LOWER(name) LIKE LOWER(CONCAT('%', :query, '%'))
            OR LOWER(coalesce(latin_name, '')) LIKE LOWER(CONCAT('%', :query, '%'))
+           OR EXISTS (
+                SELECT 1 FROM species_facts f
+                WHERE f.species_id = species.id
+                  AND to_tsvector('simple', coalesce(f.title, '') || ' ' || f.body)
+                      @@ plainto_tsquery('simple', :query)
+           )
         ORDER BY popularity DESC
         LIMIT :maxResults
         """, nativeQuery = true)

--- a/src/main/java/com/plantcare/bot/service/MenuCallbackService.java
+++ b/src/main/java/com/plantcare/bot/service/MenuCallbackService.java
@@ -632,6 +632,25 @@ public class MenuCallbackService {
             return;
         }
 
+        if (data.startsWith("PLANT:SPECIES_FACTS:")) {
+            String[] parts = data.substring("PLANT:SPECIES_FACTS:".length()).split(":");
+
+            Long plantId;
+
+            try {
+                plantId = Long.parseLong(parts[0]);
+            } catch (NumberFormatException e) {
+                answerCallback(client, callbackId, "❌ Неверный ID");
+                return;
+            }
+
+            String backTarget = parseBackTarget(parts, 1);
+
+            plantCardService.showSpeciesFactsScreen(user, plantId, messageId, backTarget, client);
+            answerCallback(client, callbackId, "");
+            return;
+        }
+
         if (data.startsWith("PLANT:EVENT:")) {
             handlePlantEventCallback(data, user, messageId, callbackId, client);
             return;

--- a/src/main/java/com/plantcare/bot/service/PlantCardService.java
+++ b/src/main/java/com/plantcare/bot/service/PlantCardService.java
@@ -84,6 +84,7 @@ public class PlantCardService {
     private final UserService userService;
     private final CareHistoryService careHistoryService;
     private final PlantEventService plantEventService;
+    private final SpeciesFactService speciesFactService;
     private final com.plantcare.bot.seasonal.service.SeasonalIntervalService seasonalIntervalService;
 
     // =================================================================
@@ -287,8 +288,14 @@ public class PlantCardService {
 
         List<CareSchedule> schedules = plantService.getActiveSchedules(plant.getId());
 
+        // issue #129: показываем кнопку «О виде» только если у вида есть факты.
+        // Пустой/неизвестный вид кнопку не получает.
+        boolean hasSpeciesFacts = plant.getSpecies() != null
+                && speciesFactService.hasFactsForSpecies(plant.getSpecies().getId());
+
         String text = buildDetailedCardText(plant, schedules);
-        InlineKeyboardMarkup keyboard = buildDetailedCardKeyboard(plant, schedules, backTarget);
+        InlineKeyboardMarkup keyboard =
+                buildDetailedCardKeyboard(plant, schedules, backTarget, hasSpeciesFacts);
 
         sendOrEditText(user.getTelegramChatId(), messageId, text, keyboard, client);
     }
@@ -796,6 +803,109 @@ public class PlantCardService {
     }
 
     // =================================================================
+    // 2d) Экран «🌍 О виде» — энциклопедия фактов (issue #129)
+    // =================================================================
+
+    /**
+     * Экран энциклопедических фактов вида (issue #129). Показывает факты,
+     * сгруппированные по категориям, с человекочитаемыми заголовками.
+     * Если у вида нет фактов (или вид не задан) — сообщаем об этом и
+     * предлагаем вернуться к карточке; кнопка «О виде» в норме сюда не ведёт,
+     * если фактов нет, но проверку дублируем на случай гонки/удаления контента.
+     */
+    @Transactional(readOnly = true)
+    public void showSpeciesFactsScreen(
+            User user,
+            Long plantId,
+            Integer messageId,
+            String backTarget,
+            TelegramClient client
+    ) {
+        Plant plant = plantRepository.findByUserIdAndIdAndArchivedAtIsNull(user.getId(), plantId)
+                .orElse(null);
+        if (plant == null) {
+            sendTextMessage(user.getTelegramChatId(), "❌ Растение не найдено.", client);
+            return;
+        }
+
+        java.util.Map<com.plantcare.bot.domain.enums.FactCategory, List<SpeciesFactDto>> factsByCategory =
+                plant.getSpecies() == null
+                        ? java.util.Map.of()
+                        : speciesFactService.getFactsBySpecies(plant.getSpecies().getId(), null);
+
+        String text = buildSpeciesFactsText(plant, factsByCategory);
+        InlineKeyboardMarkup keyboard = InlineKeyboardMarkup.builder()
+                .keyboardRow(new InlineKeyboardRow(List.of(
+                        InlineKeyboardButton.builder()
+                                .text("⬅️ К карточке")
+                                .callbackData(plantCardCallback(plant.getId(), backTarget))
+                                .build()
+                )))
+                .build();
+
+        sendOrEditText(user.getTelegramChatId(), messageId, text, keyboard, client);
+    }
+
+    private String buildSpeciesFactsText(
+            Plant plant,
+            java.util.Map<com.plantcare.bot.domain.enums.FactCategory, List<SpeciesFactDto>> factsByCategory
+    ) {
+        StringBuilder sb = new StringBuilder();
+
+        String speciesName = plant.getSpecies() != null ? plant.getSpecies().getName() : plant.getName();
+        sb.append("🌍 *О виде — ").append(escapeMd(speciesName)).append("*\n");
+
+        if (factsByCategory.isEmpty()) {
+            sb.append("\nПока нет фактов об этом виде.");
+            return sb.toString();
+        }
+
+        // Фиксированный порядок категорий для предсказуемого вида карточки.
+        for (com.plantcare.bot.domain.enums.FactCategory category :
+                com.plantcare.bot.domain.enums.FactCategory.values()) {
+            List<SpeciesFactDto> facts = factsByCategory.get(category);
+            if (facts == null || facts.isEmpty()) {
+                continue;
+            }
+
+            sb.append("\n").append(factCategoryEmoji(category)).append(" *")
+                    .append(factCategoryTitle(category)).append("*\n");
+
+            for (SpeciesFactDto fact : facts) {
+                sb.append("• ");
+                if (fact.title() != null && !fact.title().isBlank()) {
+                    sb.append("*").append(escapeMd(fact.title())).append("* — ");
+                }
+                sb.append(escapeMd(fact.body()));
+                if (fact.source() != null && !fact.source().isBlank()) {
+                    sb.append("\n  _Источник: ").append(escapeMd(fact.source())).append("_");
+                }
+                sb.append("\n");
+            }
+        }
+
+        return sb.toString();
+    }
+
+    private String factCategoryTitle(com.plantcare.bot.domain.enums.FactCategory category) {
+        return switch (category) {
+            case ORIGIN    -> "Происхождение";
+            case CARE      -> "Уход";
+            case TOXICITY  -> "Токсичность";
+            case CURIOSITY -> "Интересное";
+        };
+    }
+
+    private String factCategoryEmoji(com.plantcare.bot.domain.enums.FactCategory category) {
+        return switch (category) {
+            case ORIGIN    -> "🗺";
+            case CARE      -> "🪴";
+            case TOXICITY  -> "⚠️";
+            case CURIOSITY -> "✨";
+        };
+    }
+
+    // =================================================================
     // 3) Экран «📜 История» (issue #51)
     // =================================================================
 
@@ -1248,7 +1358,8 @@ public class PlantCardService {
     private InlineKeyboardMarkup buildDetailedCardKeyboard(
             Plant plant,
             List<CareSchedule> schedules,
-            String backTarget
+            String backTarget,
+            boolean hasSpeciesFacts
     ) {
         List<InlineKeyboardRow> rows = new ArrayList<>();
 
@@ -1309,6 +1420,17 @@ public class PlantCardService {
                 .callbackData("PLANT:DIAG:START:" + plant.getId())
                 .build());
         rows.add(diagnosisRow);
+
+        // 2a') «О виде» (issue #129): энциклопедические факты вида. Кнопку
+        // показываем только если у вида реально есть факты (hasSpeciesFacts).
+        if (hasSpeciesFacts) {
+            rows.add(new InlineKeyboardRow(List.of(
+                    InlineKeyboardButton.builder()
+                            .text("🌍 О виде")
+                            .callbackData("PLANT:SPECIES_FACTS:" + plant.getId() + backSuffix(backTarget))
+                            .build()
+            )));
+        }
 
         // 2b) Журнал событий (issue #76): добавить событие + просмотр журнала.
         // Отдельный ряд, чтобы не смешивать с регулярным уходом и не перегружать auxRow.

--- a/src/main/java/com/plantcare/bot/service/SpeciesFactDto.java
+++ b/src/main/java/com/plantcare/bot/service/SpeciesFactDto.java
@@ -1,0 +1,32 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.SpeciesFact;
+import com.plantcare.bot.domain.enums.FactCategory;
+
+/**
+ * DTO одного энциклопедического факта вида (ADR-011, issue #129).
+ *
+ * @param category     категория факта
+ * @param title        опциональный заголовок (может быть {@code null})
+ * @param body         текст факта
+ * @param source       опциональный источник (может быть {@code null})
+ * @param displayOrder порядок показа внутри категории
+ */
+public record SpeciesFactDto(
+        FactCategory category,
+        String title,
+        String body,
+        String source,
+        int displayOrder
+) {
+
+    public static SpeciesFactDto from(SpeciesFact entity) {
+        return new SpeciesFactDto(
+                entity.getCategory(),
+                entity.getTitle(),
+                entity.getBody(),
+                entity.getSource(),
+                entity.getDisplayOrder() == null ? 0 : entity.getDisplayOrder()
+        );
+    }
+}

--- a/src/main/java/com/plantcare/bot/service/SpeciesFactService.java
+++ b/src/main/java/com/plantcare/bot/service/SpeciesFactService.java
@@ -1,0 +1,71 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.SpeciesFact;
+import com.plantcare.bot.domain.enums.FactCategory;
+import com.plantcare.bot.repository.SpeciesFactRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Чтение энциклопедических фактов о видах (ADR-011, issue #129).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SpeciesFactService {
+
+    private final SpeciesFactRepository speciesFactRepository;
+
+    /**
+     * Факты вида, сгруппированные по категории в порядке показа.
+     *
+     * <p>Внутри каждой категории факты упорядочены по {@code displayOrder}
+     * (репозиторий отдаёт уже отсортированный по {@code (category, displayOrder)}
+     * список, порядок сохраняется в {@link LinkedHashMap}/{@link List}).
+     * Категории без фактов в результат не попадают.
+     *
+     * @param speciesId идентификатор вида
+     * @param locale    язык контента; пока игнорируется — мягкая закладка под
+     *                  будущий i18n из ADR-011
+     * @return карта категория → факты; пустая, если у вида нет фактов
+     */
+    @Transactional(readOnly = true)
+    public Map<FactCategory, List<SpeciesFactDto>> getFactsBySpecies(Long speciesId, String locale) {
+        log.debug("Loading species facts. speciesId={}, locale={}", speciesId, locale);
+
+        List<SpeciesFact> facts =
+                speciesFactRepository.findBySpeciesIdOrderByCategoryAscDisplayOrderAsc(speciesId);
+
+        Map<FactCategory, List<SpeciesFactDto>> grouped = new LinkedHashMap<>();
+        for (SpeciesFact fact : facts) {
+            grouped.computeIfAbsent(fact.getCategory(), k -> new java.util.ArrayList<>())
+                    .add(SpeciesFactDto.from(fact));
+        }
+
+        log.debug("Species facts loaded. speciesId={}, categories={}, total={}",
+                speciesId, grouped.size(), facts.size());
+
+        return grouped;
+    }
+
+    /**
+     * Есть ли у вида хотя бы один факт.
+     *
+     * <p>Дешёвый existence-check вместо загрузки полного списка фактов —
+     * используется для решения о видимости кнопки «О виде» на карточке
+     * растения (самый частый экран бота).
+     *
+     * @param speciesId идентификатор вида
+     * @return {@code true}, если у вида есть факты
+     */
+    @Transactional(readOnly = true)
+    public boolean hasFactsForSpecies(Long speciesId) {
+        return speciesFactRepository.existsBySpeciesId(speciesId);
+    }
+}

--- a/src/main/java/com/plantcare/bot/web/SpeciesController.java
+++ b/src/main/java/com/plantcare/bot/web/SpeciesController.java
@@ -3,8 +3,10 @@ package com.plantcare.bot.web;
 import com.plantcare.bot.api.generated.SpeciesApi;
 import com.plantcare.bot.api.generated.model.PageResponseSpeciesSummaryDto;
 import com.plantcare.bot.api.generated.model.SpeciesDetailDto;
+import com.plantcare.bot.api.generated.model.SpeciesFactDto;
 import com.plantcare.bot.api.generated.model.SpeciesSummaryDto;
 import com.plantcare.bot.domain.Species;
+import com.plantcare.bot.service.SpeciesFactService;
 import com.plantcare.bot.service.SpeciesService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +32,7 @@ public class SpeciesController implements SpeciesApi {
     private static final int MAX_LIMIT = 100;
 
     private final SpeciesService speciesService;
+    private final SpeciesFactService speciesFactService;
 
     @Override
     public PageResponseSpeciesSummaryDto listSpecies(String q, Integer offset, Integer limit) {
@@ -51,7 +54,18 @@ public class SpeciesController implements SpeciesApi {
     @Override
     public SpeciesDetailDto getSpecies(Long id) {
         log.debug("Species detail request. id={}", id);
-        return toDetail(speciesService.getById(id));
+
+        Species species = speciesService.getById(id);
+
+        // issue #129: факты вида в детальной карточке справочника. Сгруппированы
+        // по категориям сервисом; здесь разворачиваем в плоский список с уже
+        // правильным порядком (категория → displayOrder).
+        List<SpeciesFactDto> facts = speciesFactService.getFactsBySpecies(id, null).values().stream()
+                .flatMap(List::stream)
+                .map(SpeciesController::toFact)
+                .toList();
+
+        return toDetail(species).facts(facts);
     }
 
     private static SpeciesSummaryDto toSummary(Species s) {
@@ -63,6 +77,12 @@ public class SpeciesController implements SpeciesApi {
                 .soilCheckDays(s.getSoilCheckDays())
                 .careDifficulty(s.getCareDifficulty() != null ? s.getCareDifficulty().name() : null)
                 .lightPreference(s.getLightPreference() != null ? s.getLightPreference().name() : null);
+    }
+
+    private static SpeciesFactDto toFact(com.plantcare.bot.service.SpeciesFactDto fact) {
+        return new SpeciesFactDto(SpeciesFactDto.CategoryEnum.fromValue(fact.category().name()), fact.body())
+                .title(fact.title())
+                .source(fact.source());
     }
 
     private static SpeciesDetailDto toDetail(Species s) {

--- a/src/main/resources/db/migration/V22__create_species_facts.sql
+++ b/src/main/resources/db/migration/V22__create_species_facts.sql
@@ -1,0 +1,43 @@
+-- V22__create_species_facts.sql
+-- Энциклопедический контент по видам растений (ADR-011, issue #129).
+-- Хранит факты о видах: происхождение, уход, токсичность, любопытные факты.
+-- Backward-compat note: новая таблица, на старых строках бэкфилл не нужен,
+--   старый код её не читает и не пишет — NOT NULL колонки безопасны.
+--   Сидинг данных НЕ здесь (issue #132), только DDL.
+
+BEGIN;
+
+CREATE TABLE species_facts (
+    id              BIGSERIAL PRIMARY KEY,
+    species_id      BIGINT       NOT NULL REFERENCES species(id) ON DELETE CASCADE,
+    category        VARCHAR(24)  NOT NULL,
+    title           VARCHAR(160),
+    body            TEXT         NOT NULL,
+    source          VARCHAR(300),
+    display_order   INT          NOT NULL DEFAULT 0,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT chk_species_facts_category
+        CHECK (category IN ('ORIGIN', 'CARE', 'TOXICITY', 'CURIOSITY'))
+);
+
+COMMENT ON TABLE species_facts IS 'Энциклопедические факты по видам (ADR-011). Сид в issue #132.';
+COMMENT ON COLUMN species_facts.category IS 'ORIGIN / CARE / TOXICITY / CURIOSITY. Новая категория = правка CHECK + новая миграция.';
+COMMENT ON COLUMN species_facts.title IS 'Опциональный заголовок факта; NULL если факт без заголовка.';
+COMMENT ON COLUMN species_facts.source IS 'Опциональная ссылка/атрибуция источника.';
+COMMENT ON COLUMN species_facts.display_order IS 'Порядок показа фактов внутри (species_id, category).';
+
+-- Выборка фактов вида в порядке показа (покрывает FK species_id).
+CREATE INDEX idx_species_facts_species_category_order
+    ON species_facts (species_id, category, display_order);
+
+-- Полнотекстовый GIN-индекс намеренно НЕ создаётся: searchByQuery де-коррелирует
+-- подзапрос в hashed SubPlan + Seq Scan, GIN не задействуется (EXPLAIN ANALYZE на PG16,
+-- 5000 видов / 20000 фактов). species_facts — маленькая кураторская таблица (~30 видов),
+-- seq scan дешёвый. Индекс был бы чистым оверхедом на запись без выгоды.
+
+-- Автообновление updated_at — переиспользуем функцию из V1.
+CREATE TRIGGER trg_species_facts_updated_at BEFORE UPDATE ON species_facts
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+COMMIT;

--- a/src/main/resources/openapi/resources/species.yaml
+++ b/src/main/resources/openapi/resources/species.yaml
@@ -166,6 +166,34 @@ schemas:
         type: string
         nullable: true
         description: Длинное текстовое описание вида.
+      facts:
+        type: array
+        description: |
+          Энциклопедические факты о виде (ADR-011, issue #129), отсортированы
+          по категории, затем по `displayOrder`. Пустой массив, если фактов нет.
+        items:
+          $ref: '#/schemas/SpeciesFactDto'
+
+  SpeciesFactDto:
+    type: object
+    description: Один энциклопедический факт о виде (ADR-011, issue #129).
+    required: [category, body]
+    properties:
+      category:
+        type: string
+        description: Категория факта.
+        enum: [ORIGIN, CARE, TOXICITY, CURIOSITY]
+      title:
+        type: string
+        nullable: true
+        description: Опциональный заголовок факта.
+      body:
+        type: string
+        description: Текст факта.
+      source:
+        type: string
+        nullable: true
+        description: Опциональная ссылка/атрибуция источника.
 
   PageResponseSpeciesSummaryDto:
     type: object

--- a/src/test/java/com/plantcare/bot/repository/SpeciesFactRepositoryTest.java
+++ b/src/test/java/com/plantcare/bot/repository/SpeciesFactRepositoryTest.java
@@ -1,0 +1,180 @@
+package com.plantcare.bot.repository;
+
+import com.plantcare.bot.domain.Species;
+import com.plantcare.bot.domain.SpeciesFact;
+import com.plantcare.bot.domain.enums.FactCategory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Тесты репозитория энциклопедических фактов вида (ADR-011, issue #129).
+ *
+ * <p>Только Postgres (Testcontainers): таблица species_facts опирается на
+ * CHECK-констрейнт по категории и ON DELETE CASCADE из V22 — на H2 это бы не
+ * воспроизвелось. Каждый тест создаёт собственный вид со своим именем, чтобы
+ * быть изолированным при reuse-контейнере.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=true",
+        "spring.flyway.locations=classpath:db/migration"
+})
+@Testcontainers
+class SpeciesFactRepositoryTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withReuse(true);
+
+    @DynamicPropertySource
+    static void configureDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private SpeciesFactRepository speciesFactRepository;
+
+    @Autowired
+    private SpeciesRepository speciesRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void should_return_facts_ordered_by_category_then_display_order_when_facts_exist() {
+        // arrange
+        Species species = givenSpecies("Фикус для сортировки");
+        // Намеренно вставляем вперемешку — проверяем, что упорядочивает запрос, а не порядок вставки.
+        // category хранится как STRING (@Enumerated(STRING)), поэтому SQL сортирует
+        // по тексту имени лексикографически: CARE < CURIOSITY < ORIGIN < TOXICITY.
+        saveFact(species, FactCategory.TOXICITY, "токсично", 0);
+        saveFact(species, FactCategory.ORIGIN, "родина-2", 1);
+        saveFact(species, FactCategory.CARE, "уход", 0);
+        saveFact(species, FactCategory.CURIOSITY, "любопытно-2", 1);
+        saveFact(species, FactCategory.ORIGIN, "родина-1", 0);
+        saveFact(species, FactCategory.CURIOSITY, "любопытно-1", 0);
+
+        // act
+        List<SpeciesFact> facts =
+                speciesFactRepository.findBySpeciesIdOrderByCategoryAscDisplayOrderAsc(species.getId());
+
+        // assert — порядок: CARE, CURIOSITY(0,1), ORIGIN(0,1), TOXICITY
+        assertThat(facts)
+                .extracting(SpeciesFact::getCategory)
+                .containsExactly(
+                        FactCategory.CARE,
+                        FactCategory.CURIOSITY, FactCategory.CURIOSITY,
+                        FactCategory.ORIGIN, FactCategory.ORIGIN,
+                        FactCategory.TOXICITY);
+        assertThat(facts)
+                .extracting(SpeciesFact::getBody)
+                .containsExactly("уход", "любопытно-1", "любопытно-2", "родина-1", "родина-2", "токсично");
+    }
+
+    @Test
+    void should_return_empty_list_when_species_has_no_facts() {
+        // arrange
+        Species species = givenSpecies("Вид без фактов");
+
+        // act
+        List<SpeciesFact> facts =
+                speciesFactRepository.findBySpeciesIdOrderByCategoryAscDisplayOrderAsc(species.getId());
+
+        // assert
+        assertThat(facts).isEmpty();
+    }
+
+    @Test
+    void should_cascade_delete_facts_when_species_deleted() {
+        // arrange
+        Species species = givenSpecies("Вид под удаление");
+        saveFact(species, FactCategory.CARE, "поливать редко", 0);
+        saveFact(species, FactCategory.TOXICITY, "токсичен для кошек", 0);
+        Long speciesId = species.getId();
+        // Гарантируем, что и вид, и факты ушли в БД и вышли из persistence-контекста.
+        // Иначе managed SpeciesFact-сущности на flush после удаления вида ссылались бы
+        // на удалённый Species (Hibernate про DB-level ON DELETE CASCADE не знает).
+        entityManager.flush();
+        entityManager.clear();
+        assertThat(speciesFactRepository.findBySpeciesIdOrderByCategoryAscDisplayOrderAsc(speciesId))
+                .hasSize(2);
+
+        // act
+        speciesRepository.deleteById(speciesId);
+        entityManager.flush();
+        entityManager.clear();
+
+        // assert — факты удалены каскадом из V22 (ON DELETE CASCADE)
+        Number remaining = (Number) entityManager.createNativeQuery(
+                        "SELECT count(*) FROM species_facts WHERE species_id = :sid")
+                .setParameter("sid", speciesId)
+                .getSingleResult();
+        assertThat(remaining.longValue()).isZero();
+        assertThat(speciesFactRepository.findBySpeciesIdOrderByCategoryAscDisplayOrderAsc(speciesId))
+                .isEmpty();
+    }
+
+    @Test
+    void should_violate_check_constraint_when_category_outside_enum() {
+        // arrange
+        Species species = givenSpecies("Вид с плохой категорией");
+        entityManager.flush();
+
+        // act + assert — обходим JPA-enum нативной вставкой невалидной категории;
+        // CHECK chk_species_facts_category (V22) обязан отклонить.
+        assertThatThrownBy(() -> {
+            entityManager.createNativeQuery("""
+                    INSERT INTO species_facts (species_id, category, body, display_order)
+                    VALUES (:sid, 'DISEASE', 'некорректная категория', 0)
+                    """)
+                    .setParameter("sid", species.getId())
+                    .executeUpdate();
+            entityManager.flush();
+        })
+                // Голый EntityManager бросает jakarta PersistenceException (обёртка над
+                // Hibernate/JDBC), Spring-трансляция в DataIntegrityViolationException
+                // происходит только на границе Spring Data репозитория, не здесь.
+                .isInstanceOf(PersistenceException.class)
+                .hasRootCauseInstanceOf(org.postgresql.util.PSQLException.class)
+                .rootCause()
+                .hasMessageContaining("chk_species_facts_category");
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private Species givenSpecies(String name) {
+        var s = new Species();
+        s.setName(name);
+        s.setWateringDays(7);
+        s.setPopularity(0);
+        return speciesRepository.save(s);
+    }
+
+    private void saveFact(Species species, FactCategory category, String body, int displayOrder) {
+        var fact = new SpeciesFact();
+        fact.setSpecies(species);
+        fact.setCategory(category);
+        fact.setBody(body);
+        fact.setDisplayOrder(displayOrder);
+        speciesFactRepository.save(fact);
+    }
+}

--- a/src/test/java/com/plantcare/bot/repository/SpeciesSearchRepositoryTest.java
+++ b/src/test/java/com/plantcare/bot/repository/SpeciesSearchRepositoryTest.java
@@ -1,6 +1,9 @@
 package com.plantcare.bot.repository;
 
 import com.plantcare.bot.domain.Species;
+import com.plantcare.bot.domain.SpeciesFact;
+import com.plantcare.bot.domain.enums.FactCategory;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +17,8 @@ import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,6 +46,12 @@ class SpeciesSearchRepositoryTest {
     @Autowired
     private SpeciesRepository speciesRepository;
 
+    @Autowired
+    private SpeciesFactRepository speciesFactRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
     @BeforeEach
     void seedTestData() {
         // Seed only species used in these tests to stay isolated.
@@ -63,6 +74,55 @@ class SpeciesSearchRepositoryTest {
             lavanda.setPopularity(60);
             speciesRepository.save(lavanda);
         }
+        // issue #129: вид, у которого искомое слово есть ТОЛЬКО в теле факта,
+        // а не в name/latin_name/search_tags. Слово "мадагаскарский" нарочно
+        // отсутствует во всех остальных полях этого вида.
+        //
+        // Имя нарочно уникальное и НЕ совпадает с сидом V2 (там есть "Драцена"
+        // без такого факта) — иначе условие .isEmpty() было бы всегда false и факт
+        // не вставлялся бы вовсе, делая поиск по телу факта непроверяемым.
+        if (speciesRepository.findByName("Тестовый вид с фактом #129").isEmpty()) {
+            var dracaena = new Species();
+            dracaena.setName("Тестовый вид с фактом #129");
+            dracaena.setLatinName("Dracaena testfact");
+            dracaena.setWateringDays(10);
+            dracaena.setSearchTags("тествид, testfact");
+            dracaena.setPopularity(40);
+            speciesRepository.save(dracaena);
+
+            var fact = new SpeciesFact();
+            fact.setSpecies(dracaena);
+            fact.setCategory(FactCategory.ORIGIN);
+            fact.setBody("Это мадагаскарский эндемик, растёт в сухих лесах.");
+            fact.setDisplayOrder(0);
+            speciesFactRepository.save(fact);
+        }
+
+        // searchByQuery — native query; Hibernate не делает надёжный авто-flush
+        // перед native-запросами, поэтому факты не были бы видны. Явно флашим.
+        entityManager.flush();
+    }
+
+    @Test
+    void should_find_species_by_word_present_only_in_fact_body() {
+        // act — "мадагаскарский" есть только в species_facts.body тестового вида
+        List<Species> results = speciesRepository.searchByQuery("мадагаскарский", 5);
+
+        // assert
+        assertThat(results)
+                .extracting(Species::getName)
+                .contains("Тестовый вид с фактом #129");
+    }
+
+    @Test
+    void should_not_find_species_when_word_absent_from_facts_and_tags() {
+        // act — слова нет ни в одном поле и ни в одном факте
+        List<Species> results = speciesRepository.searchByQuery("марсианский", 5);
+
+        // assert
+        assertThat(results)
+                .extracting(Species::getName)
+                .doesNotContain("Тестовый вид с фактом #129");
     }
 
     @Test

--- a/src/test/java/com/plantcare/bot/service/PlantCardSpeciesFactsTest.java
+++ b/src/test/java/com/plantcare/bot/service/PlantCardSpeciesFactsTest.java
@@ -1,0 +1,153 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.Species;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.repository.PlantRepository;
+import com.plantcare.bot.seasonal.service.SeasonalIntervalService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardRow;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Юнит-тесты кнопки «🌍 О виде» в детальной карточке растения (ADR-011, issue #129).
+ *
+ * <p>Тяжёлый Telegram-контекст мокаем целиком (внешний API — {@link TelegramClient}),
+ * перехватываем отправленное {@link SendMessage} и инспектируем клавиатуру. Бизнес-
+ * коллабораторы (репозиторий, сервисы) подменены моками точечно — нас интересует
+ * только условие появления кнопки в зависимости от {@code speciesFactService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class PlantCardSpeciesFactsTest {
+
+    private static final String SPECIES_FACTS_BTN = "🌍 О виде";
+
+    @Mock private PlantService plantService;
+    @Mock private PlantRepository plantRepository;
+    @Mock private MainMenuService mainMenuService;
+    @Mock private UserService userService;
+    @Mock private CareHistoryService careHistoryService;
+    @Mock private PlantEventService plantEventService;
+    @Mock private SpeciesFactService speciesFactService;
+    @Mock private SeasonalIntervalService seasonalIntervalService;
+
+    @Mock private TelegramClient client;
+
+    private PlantCardService cardService;
+
+    @BeforeEach
+    void setUp() {
+        cardService = new PlantCardService(
+                plantService, plantRepository, mainMenuService, userService,
+                careHistoryService, plantEventService, speciesFactService, seasonalIntervalService);
+    }
+
+    @Test
+    void should_show_species_facts_button_when_species_has_facts() throws Exception {
+        // arrange
+        User user = givenUser(1L, 555L);
+        Plant plant = givenPlant(10L, user, givenSpecies(100L));
+        when(plantRepository.findByUserIdAndIdAndArchivedAtIsNull(1L, 10L)).thenReturn(Optional.of(plant));
+        when(plantService.getActiveSchedules(10L)).thenReturn(List.of());
+        when(speciesFactService.hasFactsForSpecies(100L)).thenReturn(true);
+
+        // act
+        cardService.showPlantCard(user, 10L, null, PlantCardService.BACK_TO_LIST, client);
+
+        // assert
+        assertThat(buttonTexts(captureKeyboard())).contains(SPECIES_FACTS_BTN);
+    }
+
+    @Test
+    void should_hide_species_facts_button_when_species_has_no_facts() throws Exception {
+        // arrange
+        User user = givenUser(1L, 555L);
+        Plant plant = givenPlant(10L, user, givenSpecies(100L));
+        when(plantRepository.findByUserIdAndIdAndArchivedAtIsNull(1L, 10L)).thenReturn(Optional.of(plant));
+        when(plantService.getActiveSchedules(10L)).thenReturn(List.of());
+        when(speciesFactService.hasFactsForSpecies(100L)).thenReturn(false);
+
+        // act
+        cardService.showPlantCard(user, 10L, null, PlantCardService.BACK_TO_LIST, client);
+
+        // assert
+        assertThat(buttonTexts(captureKeyboard())).doesNotContain(SPECIES_FACTS_BTN);
+    }
+
+    @Test
+    void should_hide_species_facts_button_when_species_is_null() throws Exception {
+        // arrange
+        User user = givenUser(1L, 555L);
+        Plant plant = givenPlant(10L, user, null);
+        when(plantRepository.findByUserIdAndIdAndArchivedAtIsNull(1L, 10L)).thenReturn(Optional.of(plant));
+        when(plantService.getActiveSchedules(10L)).thenReturn(List.of());
+
+        // act
+        cardService.showPlantCard(user, 10L, null, PlantCardService.BACK_TO_LIST, client);
+
+        // assert — без вида сервис фактов даже не дёргается, кнопки нет
+        assertThat(buttonTexts(captureKeyboard())).doesNotContain(SPECIES_FACTS_BTN);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private InlineKeyboardMarkup captureKeyboard() throws Exception {
+        var captor = ArgumentCaptor.forClass(SendMessage.class);
+        org.mockito.Mockito.verify(client).execute(captor.capture());
+        return (InlineKeyboardMarkup) captor.getValue().getReplyMarkup();
+    }
+
+    private List<String> buttonTexts(InlineKeyboardMarkup keyboard) {
+        return keyboard.getKeyboard().stream()
+                .flatMap(List::stream)
+                .map(InlineKeyboardButton::getText)
+                .toList();
+    }
+
+    private User givenUser(Long id, Long chatId) {
+        var u = User.builder().telegramChatId(chatId).build();
+        setId(u, id);
+        return u;
+    }
+
+    private Species givenSpecies(Long id) {
+        var s = new Species();
+        s.setName("Монстера");
+        setId(s, id);
+        return s;
+    }
+
+    private Plant givenPlant(Long id, User user, Species species) {
+        var p = new Plant();
+        p.setName("Моя монстера");
+        p.setUser(user);
+        p.setSpecies(species);
+        setId(p, id);
+        return p;
+    }
+
+    private static void setId(Object entity, Long id) {
+        try {
+            Field f = com.plantcare.bot.domain.base.BaseEntity.class.getDeclaredField("id");
+            f.setAccessible(true);
+            f.set(entity, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/plantcare/bot/service/SpeciesFactServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/SpeciesFactServiceTest.java
@@ -1,0 +1,137 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.Species;
+import com.plantcare.bot.domain.SpeciesFact;
+import com.plantcare.bot.domain.enums.FactCategory;
+import com.plantcare.bot.repository.SpeciesFactRepository;
+import com.plantcare.bot.repository.SpeciesRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Тесты сервиса чтения фактов вида (ADR-011, issue #129).
+ *
+ * <p>Репозиторий не мокаем (CLAUDE.md): используем реальный Postgres через
+ * Testcontainers, сервис собираем вручную поверх инжектированного репозитория.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=true",
+        "spring.flyway.locations=classpath:db/migration"
+})
+@Testcontainers
+class SpeciesFactServiceTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withReuse(true);
+
+    @DynamicPropertySource
+    static void configureDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private SpeciesFactRepository speciesFactRepository;
+
+    @Autowired
+    private SpeciesRepository speciesRepository;
+
+    private SpeciesFactService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SpeciesFactService(speciesFactRepository);
+    }
+
+    @Test
+    void should_group_facts_by_category_ordered_by_display_order_when_facts_exist() {
+        // arrange
+        Species species = givenSpecies("Монстера для группировки");
+        saveFact(species, FactCategory.ORIGIN, "родина-2", 1);
+        saveFact(species, FactCategory.ORIGIN, "родина-1", 0);
+        saveFact(species, FactCategory.CARE, "уход", 0);
+
+        // act
+        Map<FactCategory, List<SpeciesFactDto>> grouped =
+                service.getFactsBySpecies(species.getId(), "ru");
+
+        // assert
+        assertThat(grouped).containsOnlyKeys(FactCategory.CARE, FactCategory.ORIGIN);
+        assertThat(grouped.get(FactCategory.ORIGIN))
+                .extracting(SpeciesFactDto::body)
+                .containsExactly("родина-1", "родина-2");
+        assertThat(grouped.get(FactCategory.CARE))
+                .extracting(SpeciesFactDto::body)
+                .containsExactly("уход");
+    }
+
+    @Test
+    void should_return_empty_map_when_species_has_no_facts() {
+        // arrange
+        Species species = givenSpecies("Вид совсем без фактов");
+
+        // act
+        Map<FactCategory, List<SpeciesFactDto>> grouped =
+                service.getFactsBySpecies(species.getId(), "ru");
+
+        // assert
+        assertThat(grouped).isNotNull().isEmpty();
+    }
+
+    @Test
+    void should_return_identical_result_regardless_of_locale_when_i18n_is_stub() {
+        // arrange
+        Species species = givenSpecies("Вид для проверки locale-заглушки");
+        saveFact(species, FactCategory.CURIOSITY, "факт", 0);
+
+        // act
+        Map<FactCategory, List<SpeciesFactDto>> ru = service.getFactsBySpecies(species.getId(), "ru");
+        Map<FactCategory, List<SpeciesFactDto>> en = service.getFactsBySpecies(species.getId(), "en");
+        Map<FactCategory, List<SpeciesFactDto>> nullLocale = service.getFactsBySpecies(species.getId(), null);
+
+        // assert — locale пока игнорируется, фиксируем текущее поведение
+        assertThat(ru).isEqualTo(en);
+        assertThat(ru).isEqualTo(nullLocale);
+        assertThat(ru.get(FactCategory.CURIOSITY))
+                .extracting(SpeciesFactDto::body)
+                .containsExactly("факт");
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private Species givenSpecies(String name) {
+        var s = new Species();
+        s.setName(name);
+        s.setWateringDays(7);
+        s.setPopularity(0);
+        return speciesRepository.save(s);
+    }
+
+    private void saveFact(Species species, FactCategory category, String body, int displayOrder) {
+        var fact = new SpeciesFact();
+        fact.setSpecies(species);
+        fact.setCategory(category);
+        fact.setBody(body);
+        fact.setDisplayOrder(displayOrder);
+        speciesFactRepository.save(fact);
+    }
+}

--- a/src/test/java/com/plantcare/bot/web/SpeciesControllerTest.java
+++ b/src/test/java/com/plantcare/bot/web/SpeciesControllerTest.java
@@ -2,7 +2,10 @@ package com.plantcare.bot.web;
 
 import com.plantcare.bot.domain.Species;
 import com.plantcare.bot.domain.enums.CareDifficulty;
+import com.plantcare.bot.domain.enums.FactCategory;
 import com.plantcare.bot.domain.enums.LightPreference;
+import com.plantcare.bot.service.SpeciesFactDto;
+import com.plantcare.bot.service.SpeciesFactService;
 import com.plantcare.bot.service.SpeciesService;
 import com.plantcare.bot.web.exception.WebApiExceptionHandler;
 import jakarta.persistence.EntityNotFoundException;
@@ -18,6 +21,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -36,6 +40,9 @@ class SpeciesControllerTest {
 
     @MockitoBean
     private SpeciesService speciesService;
+
+    @MockitoBean
+    private SpeciesFactService speciesFactService;
 
     @Test
     void should_return_page_of_species_when_no_query() throws Exception {
@@ -77,6 +84,7 @@ class SpeciesControllerTest {
         var species = buildSpecies(1L, "Монстера", "Monstera deliciosa");
         species.setDescription("Тропическое растение с большими листьями");
         when(speciesService.getById(1L)).thenReturn(species);
+        when(speciesFactService.getFactsBySpecies(eq(1L), any())).thenReturn(Map.of());
 
         // act + assert
         mockMvc.perform(get("/api/v1/species/1"))
@@ -85,6 +93,44 @@ class SpeciesControllerTest {
                 .andExpect(jsonPath("$.name").value("Монстера"))
                 .andExpect(jsonPath("$.latinName").value("Monstera deliciosa"))
                 .andExpect(jsonPath("$.description").value("Тропическое растение с большими листьями"));
+    }
+
+    @Test
+    void should_include_facts_in_detail_when_service_returns_facts() throws Exception {
+        // arrange
+        var species = buildSpecies(1L, "Монстера", "Monstera deliciosa");
+        when(speciesService.getById(1L)).thenReturn(species);
+        // Сервис группирует по категориям; контроллер разворачивает в плоский facts[].
+        when(speciesFactService.getFactsBySpecies(eq(1L), any())).thenReturn(Map.of(
+                FactCategory.ORIGIN, List.of(
+                        new SpeciesFactDto(FactCategory.ORIGIN, "Родина", "Центральная Америка", "wiki", 0)),
+                FactCategory.TOXICITY, List.of(
+                        new SpeciesFactDto(FactCategory.TOXICITY, null, "Токсична для кошек", null, 0))
+        ));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/species/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.facts").isArray())
+                .andExpect(jsonPath("$.facts.length()").value(2))
+                .andExpect(jsonPath("$.facts[*].category",
+                        org.hamcrest.Matchers.containsInAnyOrder("ORIGIN", "TOXICITY")))
+                .andExpect(jsonPath("$.facts[*].body",
+                        org.hamcrest.Matchers.containsInAnyOrder("Центральная Америка", "Токсична для кошек")));
+    }
+
+    @Test
+    void should_return_empty_facts_when_species_has_no_facts() throws Exception {
+        // arrange
+        var species = buildSpecies(1L, "Монстера", "Monstera deliciosa");
+        when(speciesService.getById(1L)).thenReturn(species);
+        when(speciesFactService.getFactsBySpecies(eq(1L), any())).thenReturn(Map.of());
+
+        // act + assert — пустой Map → пустой массив facts (не отсутствует)
+        mockMvc.perform(get("/api/v1/species/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.facts").isArray())
+                .andExpect(jsonPath("$.facts").isEmpty());
     }
 
     @Test


### PR DESCRIPTION
Closes #129

Реализует принятый ADR-011 «Модель хранения энциклопедического контента по видам». Ядро фичи «Энциклопедия растений» — кураторские факты по видам.

## Что сделано
- **Таблица `species_facts`** (1:N к species) с enum-дискриминатором `category` (ORIGIN/CARE/TOXICITY/CURIOSITY) — паттерн ADR-004.
- **Telegram-бот:** в карточке растения кнопка «🌍 О виде» (показывается только если у вида есть факты), экран фактов сгруппирован по категориям.
- **REST-справочник (#8):** `SpeciesDetailDto.facts[]` + openapi-спека; поиск видов находит вид также по тексту его фактов (tsvector `simple`).
- `FactCategory` enum, `SpeciesFact` entity, `SpeciesFactRepository` (`findBySpeciesIdOrderBy...`, `existsBySpeciesId`), `SpeciesFactService` (`getFactsBySpecies(id, locale)` → Map по категориям; `hasFactsForSpecies(id)`). `locale` — заглушка под будущий i18n (значение игнорируется).

## Миграции
`V22__create_species_facts.sql` — новая таблица: `category VARCHAR+CHECK`, FK `species_id ON DELETE CASCADE`, btree-индекс `(species_id, category, display_order)`, триггер `updated_at` (переиспользует `update_updated_at_column()` из V1). Expression-GIN индекс **намеренно не создаётся** — EXPLAIN ANALYZE показал, что `searchByQuery` де-коррелирует подзапрос в seq scan по малой кураторской таблице, GIN не задействуется (по итогам ревью).

## Backward-compat риски
Safe. Новая таблица, старый код её не читает/не пишет, NOT NULL и FK безопасны (бэкфилл не нужен). Один релиз.

## Тесты
- `SpeciesFactRepositoryTest` — сортировка `(category, display_order)`, пустой вид, **ON DELETE CASCADE** (через flush+clear), нарушение **CHECK** на невалидной категории.
- `SpeciesFactServiceTest` — группировка по категориям, пустой вид → пустая Map, инвариантность к `locale` (ru/null/en).
- `SpeciesSearchRepositoryTest` — **ключевой кейс:** вид находится по слову, присутствующему ТОЛЬКО в теле факта; отрицательный кейс.
- `PlantCardSpeciesFactsTest` — видимость кнопки (есть факты / нет / species == null).
- `SpeciesControllerTest` — facts[] в REST-ответе.

`mvn verify` (после rebase на свежий develop с Sentry #114): **1028 тестов, 2 падения** — оба pre-existing flake (`SpeciesRepositoryTest.topPopularReturnsInCorrectOrder`, `PlantServiceTest.getPopularSpecies_orderedByPopularity`, неустойчивый порядок при равной популярности, не связаны с этим PR).

## Ревью
reviewer: **approve с условиями**, 🔴 BLOCKING нет. Закрыто в этом PR:
- 🟡 SHOULD-FIX #1 — мёртвый GIN-индекс убран из V22.
- 🟡 SHOULD-FIX #2 — видимость кнопки «О виде» через `existsBySpeciesId` (раньше грузились все факты в DTO ради `isEmpty()`).

Отложено (NIT, не блокирует):
- порядок категорий в REST `facts[]` алфавитный, в боте — enum-порядок (косметика);
- рендер экрана фактов (`buildSpeciesFactsText`) не покрыт юнит-тестом (чистый string-building).

## Чек
- [x] `mvn verify` зелёное (кроме 2 known pre-existing flakes)
- [x] reviewer прошёл, оба SHOULD-FIX закрыты
- [x] rebase на свежий origin/develop (включает Sentry #114), конфликтов нет
- [x] PR в `develop`, не `main`
