### PR TITLE
feat: monthly care report (#137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 - **V20** — добавляет `plants.acquired_at DATE NULL` — дата, когда юзер завёл растение. Используется шедулером годовщин и строкой «С тобой с …» в карточке. NULL = в годовщинах не участвует
 - **V21** — таблица `plant_anniversaries_sent` (PK `(plant_id, anniversary_year)`) для идемпотентности годовщин: один пуш на растение в год. FK `ON DELETE CASCADE`. Здесь же — частичный индекс `idx_plants_acquired_active` на `plants(acquired_at) WHERE acquired_at IS NOT NULL AND archived_at IS NULL` под запрос шедулера
 - **V22** — таблица `species_facts` (энциклопедия видов, ADR-011): кураторские факты по видам с категориями `ORIGIN`/`CARE`/`TOXICITY`/`CURIOSITY` (CHECK), `title`/`body`/`source`/`display_order`. FK на `species` `ON DELETE CASCADE`, btree-индекс `(species_id, category, display_order)`. GIN-индекс намеренно не создаётся (обоснование в комментарии миграции). Сидинг — отдельной задачей
+- **V23** — таблица `monthly_report_sent` (PK `(user_id, year_month)`) для идемпотентности месячных отчётов: одна отправка на юзера за отчётный месяц. `year_month` хранится как `YYYYMM` по календарю в TZ юзера. FK `ON DELETE CASCADE` на `users`
 
 ## REST API
 

--- a/src/main/java/com/plantcare/bot/domain/MonthlyReportSent.java
+++ b/src/main/java/com/plantcare/bot/domain/MonthlyReportSent.java
@@ -1,0 +1,64 @@
+package com.plantcare.bot.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+/**
+ * Запись «месячный отчёт уже отправлен этому юзеру за этот месяц» (issue #137).
+ * Используется для идемпотентности шедулера месячных отчётов: перед отправкой
+ * шедулер пытается INSERT в эту таблицу; первичный ключ {@code (user_id, year_month)}
+ * гарантирует, что за один и тот же отчётный месяц (по календарю TZ юзера) не уйдёт
+ * второй отчёт — независимо от повторных тиков, рестарта пода и rolling deploy.
+ *
+ * <p>{@code year_month} — это {@code YYYYMM} прошлого месяца в TZ юзера
+ * (например 202604 для отчёта за апрель 2026).
+ *
+ * <p>FK на {@link User} c {@code ON DELETE CASCADE} (см. миграцию V23):
+ * при удалении пользователя история отправленных отчётов уезжает вместе с ним.
+ */
+@Entity
+@Table(name = "monthly_report_sent")
+@IdClass(MonthlyReportSentId.class)
+@Getter
+@Setter
+@NoArgsConstructor
+public class MonthlyReportSent {
+
+    public MonthlyReportSent(Long userId, Integer yearMonth, Instant sentAt) {
+        this.userId = userId;
+        this.yearMonth = yearMonth;
+        this.sentAt = sentAt;
+    }
+
+    @Id
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Id
+    @Column(name = "year_month", nullable = false)
+    private Integer yearMonth;
+
+    /**
+     * Пользователь, на которого ссылается запись. LAZY — для вставки-проверки
+     * сама ассоциация не нужна, нужен только userId. Маппится
+     * {@code insertable=false/updatable=false}, чтобы PK-колонка писалась через
+     * поле {@link #userId}, а не через эту связь.
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", insertable = false, updatable = false)
+    private User user;
+
+    @Column(name = "sent_at", nullable = false)
+    private Instant sentAt;
+}

--- a/src/main/java/com/plantcare/bot/domain/MonthlyReportSentId.java
+++ b/src/main/java/com/plantcare/bot/domain/MonthlyReportSentId.java
@@ -1,0 +1,43 @@
+package com.plantcare.bot.domain;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Композитный PK для {@link MonthlyReportSent} (issue #137).
+ * Имена и типы полей должны точно соответствовать @Id-полям сущности.
+ */
+public class MonthlyReportSentId implements Serializable {
+
+    private Long userId;
+    private Integer yearMonth;
+
+    public MonthlyReportSentId() {
+    }
+
+    public MonthlyReportSentId(Long userId, Integer yearMonth) {
+        this.userId = userId;
+        this.yearMonth = yearMonth;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public Integer getYearMonth() {
+        return yearMonth;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MonthlyReportSentId that)) return false;
+        return Objects.equals(userId, that.userId)
+                && Objects.equals(yearMonth, that.yearMonth);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, yearMonth);
+    }
+}

--- a/src/main/java/com/plantcare/bot/repository/CareHistoryRepository.java
+++ b/src/main/java/com/plantcare/bot/repository/CareHistoryRepository.java
@@ -147,4 +147,72 @@ public interface CareHistoryRepository extends JpaRepository<CareHistory, Long> 
             @Param("limit") int limit,
             @Param("offset") int offset
     );
+
+    // ===== Месячный отчёт (issue #137) =====
+
+    /**
+     * Всего активных (не-cancelled) действий ухода по всем растениям юзера за
+     * отчётный период {@code [from; toExclusive)}. Границы передаёт вызывающий —
+     * это «начало/конец месяца в TZ юзера, сконвертированные в UTC».
+     */
+    @Query("SELECT COUNT(h) FROM CareHistory h " +
+            "WHERE h.plant.user.id = :userId AND h.cancelledBy IS NULL " +
+            "AND h.doneAt >= :from AND h.doneAt < :toExclusive")
+    long countActiveByUserIdInRange(
+            @Param("userId") Long userId,
+            @Param("from") LocalDateTime from,
+            @Param("toExclusive") LocalDateTime toExclusive
+    );
+
+    /**
+     * Разбивка активных действий юзера по типам ухода за отчётный период
+     * {@code [from; toExclusive)}. Только типы с ≥1 действием попадают в результат.
+     */
+    @Query("SELECT h.taskType AS taskType, COUNT(h) AS count FROM CareHistory h " +
+            "WHERE h.plant.user.id = :userId AND h.cancelledBy IS NULL " +
+            "AND h.doneAt >= :from AND h.doneAt < :toExclusive " +
+            "GROUP BY h.taskType")
+    List<TaskTypeCount> countActiveByUserIdGroupedByTaskType(
+            @Param("userId") Long userId,
+            @Param("from") LocalDateTime from,
+            @Param("toExclusive") LocalDateTime toExclusive
+    );
+
+    /**
+     * «Растение, которое юзер ни разу не пропустил» за отчётный период: среди
+     * активных не-архивных растений выбираются те, у которых ВСЕ активные записи
+     * за период были on-time ({@code was_on_time = true}) и записей ≥1. Из них
+     * берётся растение с наибольшим числом действий (tie-break — меньший id).
+     *
+     * <p>Условие «все on-time» выражено через
+     * {@code MIN(was_on_time) = true} в HAVING: если хоть одна запись была не
+     * on-time, минимум по группе станет false и группа отсеется.
+     */
+    @Query("SELECT h.plant.id AS plantId, h.plant.name AS plantName, COUNT(h) AS count " +
+            "FROM CareHistory h " +
+            "WHERE h.plant.user.id = :userId AND h.cancelledBy IS NULL " +
+            "AND h.plant.archivedAt IS NULL " +
+            "AND h.doneAt >= :from AND h.doneAt < :toExclusive " +
+            "GROUP BY h.plant.id, h.plant.name " +
+            "HAVING MIN(CASE WHEN h.onTime = true THEN 1 ELSE 0 END) = 1 " +
+            "ORDER BY COUNT(h) DESC, h.plant.id ASC")
+    List<PlantActionCount> findFlawlessPlantsByUserInRange(
+            @Param("userId") Long userId,
+            @Param("from") LocalDateTime from,
+            @Param("toExclusive") LocalDateTime toExclusive,
+            Limit limit
+    );
+
+    /** Проекция «тип ухода → количество» для разбивки месячного отчёта (issue #137). */
+    interface TaskTypeCount {
+        TaskType getTaskType();
+        long getCount();
+    }
+
+    /** Проекция «растение → количество действий» для месячного отчёта (issue #137). */
+    interface PlantActionCount {
+        Long getPlantId();
+        String getPlantName();
+        long getCount();
+    }
 }

--- a/src/main/java/com/plantcare/bot/repository/MonthlyReportSentRepository.java
+++ b/src/main/java/com/plantcare/bot/repository/MonthlyReportSentRepository.java
@@ -1,0 +1,43 @@
+package com.plantcare.bot.repository;
+
+import com.plantcare.bot.domain.MonthlyReportSent;
+import com.plantcare.bot.domain.MonthlyReportSentId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+
+/**
+ * Идемпотентность месячных отчётов (issue #137).
+ * Маркер «(user_id, year_month) уже отправлен» — наличие записи в таблице.
+ */
+@Repository
+public interface MonthlyReportSentRepository
+        extends JpaRepository<MonthlyReportSent, MonthlyReportSentId> {
+
+    boolean existsByUserIdAndYearMonth(Long userId, Integer yearMonth);
+
+    /**
+     * Insert-only пометка «отчёт отправлен». Атомарный {@code ON CONFLICT DO NOTHING}
+     * по PK {@code (user_id, year_month)}: повторная пометка той же пары (гонка
+     * параллельных тиков, рестарт пода) — no-op, без SELECT-then-UPDATE и без
+     * перетирания {@code sent_at} первого отчёта. Возвращает число вставленных строк
+     * (1 — вставили, 0 — запись уже была).
+     *
+     * <p>Через JPA-save с присвоенным {@code @IdClass}-id Hibernate сделал бы merge
+     * (SELECT, затем UPDATE), а не INSERT — поэтому идемпотентность реализована
+     * нативным запросом, а не {@code save()}.
+     */
+    @Modifying
+    @Query(value = """
+            INSERT INTO monthly_report_sent (user_id, year_month, sent_at)
+            VALUES (:userId, :yearMonth, :sentAt)
+            ON CONFLICT (user_id, year_month) DO NOTHING
+            """, nativeQuery = true)
+    int insertIfAbsent(@Param("userId") Long userId,
+                       @Param("yearMonth") Integer yearMonth,
+                       @Param("sentAt") Instant sentAt);
+}

--- a/src/main/java/com/plantcare/bot/repository/PlantRepository.java
+++ b/src/main/java/com/plantcare/bot/repository/PlantRepository.java
@@ -143,4 +143,25 @@ public interface PlantRepository extends JpaRepository<Plant, Long> {
             @Param("until") java.time.LocalDateTime until,
             @Param("dedupBefore") java.time.LocalDateTime dedupBefore
     );
+
+    // ===== Месячный отчёт (issue #137) =====
+
+    /**
+     * Самые старые живые (не-архивные) растения юзера с заполненной
+     * {@code acquiredAt} — для блока «самое старое живое растение и его возраст».
+     * Сортировка по {@code acquiredAt ASC}: первым идёт растение с самой ранней
+     * датой «заведения», то есть самое старое. Вызывающий берёт первый элемент
+     * через {@link org.springframework.data.domain.Limit}.
+     */
+    @Query("""
+            SELECT p FROM Plant p
+            WHERE p.user.id = :userId
+              AND p.archivedAt IS NULL
+              AND p.acquiredAt IS NOT NULL
+            ORDER BY p.acquiredAt ASC, p.id ASC
+            """)
+    List<Plant> findOldestLivingByUser(
+            @Param("userId") Long userId,
+            org.springframework.data.domain.Limit limit
+    );
 }

--- a/src/main/java/com/plantcare/bot/service/MonthlyReportScheduler.java
+++ b/src/main/java/com/plantcare/bot/service/MonthlyReportScheduler.java
@@ -1,0 +1,95 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.client.TelegramClientProvider;
+import com.plantcare.bot.observability.SentryTags;
+import com.plantcare.bot.observability.SentryTags.Layer;
+import io.sentry.Sentry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Hourly-шедулер месячных отчётов по уходу (issue #137).
+ *
+ * <p>Каждый час дёргает {@link MonthlyReportService#findDueReports}, который сам
+ * отбирает юзеров, у кого в TZ юзера сейчас наступило 1-е число нового месяца И
+ * идёт утреннее окно (09:00–10:00 локально), и для каждого готовит
+ * retention-карточку с итогами за прошлый месяц.
+ *
+ * <p>Фильтр «1-е число + утро» живёт в сервисе (перед тяжёлыми агрегатами по
+ * {@code care_history}), а не здесь — иначе ежечасный тик гонял бы агрегаты по
+ * всем юзерам все 30 дней месяца. Шедулер лишь отправляет уже отобранных
+ * кандидатов. Идемпотентность — на уровне БД ({@code monthly_report_sent}, PK
+ * {@code (user_id, year_month)}): второй отчёт за тот же отчётный месяц невозможен
+ * независимо от числа тиков.
+ *
+ * <p>Telegram-вызовы намеренно вне транзакции к БД: сначала read-only выборка
+ * кандидатов с расчётом метрик, затем отправка, затем отдельная транзакция на
+ * пометку «отправлено».
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MonthlyReportScheduler {
+
+    private final MonthlyReportService monthlyReportService;
+    private final TelegramClientProvider telegramClientProvider;
+    private final Clock clock;
+
+    /**
+     * Cron в UTC: каждый час в 15-ю минуту. Смещение 15 минут — чтобы не толкаться
+     * ни с PlantAnniversaryScheduler ('0 5 * * * *'), ни с hourly fixedRate-задачами,
+     * стартующими в 0-ю минуту.
+     */
+    @Scheduled(cron = "0 15 * * * *", zone = "UTC")
+    public void tick() {
+        // Issue #114: изолированный scope на тик — captureException внутри получит
+        // тег layer=scheduler, и он не утечёт на соседние задачи shared-потока.
+        SentryTags.runWithLayer(Layer.SCHEDULER, "MonthlyReportScheduler", () -> {
+            Instant now = clock.instant();
+            List<MonthlyReportService.MonthlyReport> due =
+                    monthlyReportService.findDueReports(now);
+
+            if (due.isEmpty()) {
+                return;
+            }
+            log.info("Monthly report tick: {} candidates found", due.size());
+
+            for (MonthlyReportService.MonthlyReport report : due) {
+                try {
+                    if (sendReport(report)) {
+                        monthlyReportService.markSent(report.userId(), report.yearMonth(), now);
+                        log.info("Monthly report sent: user={} yearMonth={} actions={}",
+                                report.userId(), report.yearMonth(), report.totalActions());
+                    }
+                } catch (Exception e) {
+                    log.error("Failed to handle monthly report for user {}: {}",
+                            report.userId(), e.getMessage(), e);
+                    Sentry.captureException(e);
+                }
+            }
+        });
+    }
+
+    private boolean sendReport(MonthlyReportService.MonthlyReport report) {
+        SendMessage message = SendMessage.builder()
+                .chatId(report.telegramChatId().toString())
+                .text(report.buildText())
+                .build();
+        try {
+            telegramClientProvider.getTelegramClient().execute(message);
+            return true;
+        } catch (TelegramApiException e) {
+            log.error("Failed to send monthly report (user={}, chat={}): {}",
+                    report.userId(), report.telegramChatId(), e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/plantcare/bot/service/MonthlyReportService.java
+++ b/src/main/java/com/plantcare/bot/service/MonthlyReportService.java
@@ -1,0 +1,324 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.repository.CareHistoryRepository;
+import com.plantcare.bot.repository.CareHistoryRepository.PlantActionCount;
+import com.plantcare.bot.repository.CareHistoryRepository.TaskTypeCount;
+import com.plantcare.bot.repository.MonthlyReportSentRepository;
+import com.plantcare.bot.repository.PlantRepository;
+import com.plantcare.bot.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Limit;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Period;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.TextStyle;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Сервис месячного отчёта по уходу (issue #137) — раз в месяц активный юзер
+ * получает retention-карточку с итогами за прошлый месяц: всего действий,
+ * разбивка по типам ухода, самое старое живое растение и его возраст, растение,
+ * которое юзер ни разу не пропустил.
+ *
+ * <p>Отчётный месяц считается по календарю в TZ юзера ({@link User#getTimezone}),
+ * а не в UTC — это даёт устойчивость к моменту запуска шедулера на стыке месяцев.
+ * Границы периода: {@code [начало 1-го числа прошлого месяца 00:00 локально;
+ * начало текущего месяца 00:00 локально)}, обе границы конвертируются в UTC
+ * {@link LocalDateTime} для запроса по {@code care_history.done_at}.
+ *
+ * <p>Если за месяц меньше {@link CareHistoryService#MIN_ACTIONS_FOR_STATS}
+ * действий — отчёт не формируется (порог из #51).
+ *
+ * <p>Идемпотентность реализована таблицей {@code monthly_report_sent}
+ * (PK {@code (user_id, year_month)}). Telegram-вызов остаётся за рамками сервиса:
+ * сервис подбирает кандидатов в read-only транзакции и для каждого готовит
+ * {@link MonthlyReport}-DTO с готовым текстом, чтобы шедулер отправил отчёт вне
+ * транзакции. После успешной отправки шедулер дёргает {@link #markSent} в
+ * отдельной транзакции.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MonthlyReportService {
+
+    /** Минимум действий за месяц, ниже которого отчёт не шлётся (порог из #51). */
+    static final int MIN_ACTIONS = CareHistoryService.MIN_ACTIONS_FOR_STATS;
+
+    /** Час дня (локальный), с которого отчёт считается уместным. */
+    private static final int MORNING_HOUR_START = 9;
+    /** Час дня (локальный), до которого отчёт считается уместным (exclusive). */
+    private static final int MORNING_HOUR_END = 10;
+
+    private final UserRepository userRepository;
+    private final PlantRepository plantRepository;
+    private final CareHistoryRepository careHistoryRepository;
+    private final MonthlyReportSentRepository sentRepository;
+
+    /**
+     * Подобрать юзеров, которым сейчас (в TZ юзера) пора отправить отчёт за
+     * прошлый месяц, и для каждого собрать метрики и готовый текст.
+     *
+     * <p>Фильтр «локально 1-е число месяца + утреннее окно [09:00, 10:00)»
+     * применяется здесь, в сервисе, и притом ПЕРВЫМ — до любых запросов по
+     * {@code monthly_report_sent} и тяжёлых агрегатов по {@code care_history}.
+     * В обычный час/день предикат отсекает юзера сразу, поэтому за пределами окна
+     * 1-го числа не исполняется ни одного count/group-by — иначе ежечасный тик
+     * прогонял бы агрегаты по всем юзерам все 30 дней месяца (N+1-зона риска).
+     *
+     * <p>Среди прошедших окно остаются те, у кого за прошлый месяц было
+     * ≥ {@link #MIN_ACTIONS} действий и которым отчёт за этот месяц ещё не слали.
+     *
+     * @param now момент проверки (UTC). Передаётся явно — для unit-тестов и для
+     *            согласованности с {@code Clock}-бином в caller'е.
+     */
+    @Transactional(readOnly = true)
+    public List<MonthlyReport> findDueReports(Instant now) {
+        List<User> users = userRepository.findAllNotBlocked();
+        if (users.isEmpty()) {
+            return List.of();
+        }
+
+        List<MonthlyReport> due = new ArrayList<>();
+        for (User user : users) {
+            MonthlyReport report = buildReport(user, now);
+            if (report != null) {
+                due.add(report);
+            }
+        }
+        return due;
+    }
+
+    /**
+     * Собрать отчёт для одного юзера за прошлый месяц или вернуть {@code null},
+     * если отчёт не положен (мало действий / уже отправлен).
+     */
+    private MonthlyReport buildReport(User user, Instant now) {
+        ZoneId zone = safeZone(user.getTimezone());
+
+        // Дешёвый TZ-фильтр ПЕРВЫМ: вне окна «1-е число + утро» агрегаты не считаем.
+        if (!isFirstDayMorning(now, zone)) {
+            return null;
+        }
+
+        YearMonth reportMonth = YearMonth.from(now.atZone(zone).toLocalDate()).minusMonths(1);
+        int yearMonth = reportMonth.getYear() * 100 + reportMonth.getMonthValue();
+
+        if (sentRepository.existsByUserIdAndYearMonth(user.getId(), yearMonth)) {
+            return null;
+        }
+
+        // Границы месяца в TZ юзера → UTC LocalDateTime для запроса по done_at.
+        LocalDateTime from = reportMonth.atDay(1).atStartOfDay(zone)
+                .toInstant().atZone(ZoneOffset.UTC).toLocalDateTime();
+        LocalDateTime toExclusive = reportMonth.plusMonths(1).atDay(1).atStartOfDay(zone)
+                .toInstant().atZone(ZoneOffset.UTC).toLocalDateTime();
+
+        long totalActions = careHistoryRepository.countActiveByUserIdInRange(
+                user.getId(), from, toExclusive);
+        if (totalActions < MIN_ACTIONS) {
+            return null;
+        }
+
+        Map<TaskType, Long> breakdown = loadBreakdown(user.getId(), from, toExclusive);
+        OldestPlant oldest = loadOldestPlant(user.getId(), now, zone);
+        String flawlessPlant = loadFlawlessPlant(user.getId(), from, toExclusive);
+
+        return new MonthlyReport(
+                user.getId(),
+                user.getTelegramChatId(),
+                yearMonth,
+                monthLabel(reportMonth),
+                totalActions,
+                breakdown,
+                oldest,
+                flawlessPlant
+        );
+    }
+
+    private Map<TaskType, Long> loadBreakdown(Long userId, LocalDateTime from, LocalDateTime toExclusive) {
+        Map<TaskType, Long> breakdown = new LinkedHashMap<>();
+        for (TaskTypeCount row : careHistoryRepository.countActiveByUserIdGroupedByTaskType(
+                userId, from, toExclusive)) {
+            breakdown.put(row.getTaskType(), row.getCount());
+        }
+        return breakdown;
+    }
+
+    private OldestPlant loadOldestPlant(Long userId, Instant now, ZoneId zone) {
+        List<Plant> oldest = plantRepository.findOldestLivingByUser(userId, Limit.of(1));
+        if (oldest.isEmpty()) {
+            return null;
+        }
+        Plant plant = oldest.getFirst();
+        LocalDate todayLocal = now.atZone(zone).toLocalDate();
+        Period age = Period.between(plant.getAcquiredAt(), todayLocal);
+        return new OldestPlant(plant.getName(), age.getYears(), age.getMonths());
+    }
+
+    private String loadFlawlessPlant(Long userId, LocalDateTime from, LocalDateTime toExclusive) {
+        List<PlantActionCount> flawless = careHistoryRepository.findFlawlessPlantsByUserInRange(
+                userId, from, toExclusive, Limit.of(1));
+        return flawless.isEmpty() ? null : flawless.getFirst().getPlantName();
+    }
+
+    /**
+     * Зафиксировать факт отправки отчёта — отдельная транзакция, чтобы caller мог
+     * дёрнуть её сразу после успешного Telegram send.
+     *
+     * <p>Insert-only через {@code INSERT ... ON CONFLICT (user_id, year_month) DO
+     * NOTHING}: повторная пометка той же пары (гонка параллельных тиков, рестарт
+     * пода) атомарно становится no-op на уровне БД — без SELECT-then-UPDATE и без
+     * перетирания {@code sent_at} первого отчёта. Возвращаемое число вставленных
+     * строк используем только для лога.
+     */
+    @Transactional
+    public void markSent(Long userId, int yearMonth, Instant sentAt) {
+        int inserted = sentRepository.insertIfAbsent(userId, yearMonth, sentAt);
+        if (inserted == 0) {
+            log.debug("Monthly report already marked for user={} yearMonth={}", userId, yearMonth);
+        }
+    }
+
+    /**
+     * DTO с готовыми данными для одного месячного отчёта. Сделан record — чтобы
+     * шедулер мог использовать поля напрямую без лазания в entity, у которых уже
+     * могла закрыться JPA-сессия.
+     */
+    public record MonthlyReport(
+            Long userId,
+            Long telegramChatId,
+            int yearMonth,
+            String monthLabel,
+            long totalActions,
+            Map<TaskType, Long> breakdown,
+            OldestPlant oldestPlant,
+            String flawlessPlantName
+    ) {
+        /**
+         * Готовый текст отчёта на русском. Формат — retention-карточка по issue #137.
+         */
+        public String buildText() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("📊 Твой отчёт за ").append(monthLabel).append("\n\n");
+            sb.append("Всего действий по уходу: ").append(totalActions)
+                    .append(" ").append(pluralizeActions(totalActions)).append("\n");
+
+            if (!breakdown.isEmpty()) {
+                sb.append("\nПо типам ухода:\n");
+                for (TaskType type : TaskType.values()) {
+                    Long count = breakdown.get(type);
+                    if (count != null && count > 0) {
+                        sb.append(taskTypeLabel(type)).append(": ").append(count).append("\n");
+                    }
+                }
+            }
+
+            if (oldestPlant != null) {
+                sb.append("\n🌳 Самое старое живое растение — ").append(oldestPlant.name())
+                        .append(", ").append(oldestPlant.ageText()).append(".\n");
+            }
+
+            if (flawlessPlantName != null) {
+                sb.append("\n🏆 Ни разу не пропустил уход за ").append(flawlessPlantName)
+                        .append(" — так держать!\n");
+            }
+
+            sb.append("\nСпасибо, что заботишься о своих растениях 🌱");
+            return sb.toString();
+        }
+
+        private static String taskTypeLabel(TaskType type) {
+            return switch (type) {
+                case WATERING -> "💧 Полив";
+                case MISTING -> "💨 Опрыскивание";
+                case FERTILIZING -> "🌱 Удобрение";
+                case SOIL_CHECK -> "🌍 Проверка грунта";
+            };
+        }
+    }
+
+    /** Самое старое живое растение и его возраст на момент отчёта. */
+    public record OldestPlant(String name, int years, int months) {
+        /** Человекочитаемый возраст: «N лет M месяцев» / «M месяцев». */
+        public String ageText() {
+            if (years <= 0) {
+                int m = Math.max(months, 0);
+                return m + " " + pluralizeMonths(m);
+            }
+            StringBuilder sb = new StringBuilder();
+            sb.append(years).append(" ").append(pluralizeYears(years));
+            if (months > 0) {
+                sb.append(" ").append(months).append(" ").append(pluralizeMonths(months));
+            }
+            return sb.toString();
+        }
+    }
+
+    private static String monthLabel(YearMonth ym) {
+        String month = ym.getMonth().getDisplayName(TextStyle.FULL_STANDALONE, new Locale("ru"));
+        return month + " " + ym.getYear();
+    }
+
+    private static String pluralizeActions(long n) {
+        long mod10 = Math.abs(n) % 10;
+        long mod100 = Math.abs(n) % 100;
+        if (mod10 == 1 && mod100 != 11) return "действие";
+        if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return "действия";
+        return "действий";
+    }
+
+    private static String pluralizeYears(int n) {
+        int mod10 = Math.abs(n) % 10;
+        int mod100 = Math.abs(n) % 100;
+        if (mod10 == 1 && mod100 != 11) return "год";
+        if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return "года";
+        return "лет";
+    }
+
+    private static String pluralizeMonths(int n) {
+        int mod10 = Math.abs(n) % 10;
+        int mod100 = Math.abs(n) % 100;
+        if (mod10 == 1 && mod100 != 11) return "месяц";
+        if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return "месяца";
+        return "месяцев";
+    }
+
+    /**
+     * Сейчас в TZ юзера 1-е число месяца И локальное время в окне
+     * [{@value #MORNING_HOUR_START}:00, {@value #MORNING_HOUR_END}:00)? Окно не даёт
+     * отчёту прилететь ночью юзеру в дальнем восточном поясе и ограничивает рассылку
+     * первым днём месяца.
+     */
+    private static boolean isFirstDayMorning(Instant now, ZoneId zone) {
+        var local = now.atZone(zone);
+        LocalTime localTime = local.toLocalTime();
+        return local.getDayOfMonth() == 1
+                && !localTime.isBefore(LocalTime.of(MORNING_HOUR_START, 0))
+                && localTime.isBefore(LocalTime.of(MORNING_HOUR_END, 0));
+    }
+
+    private static ZoneId safeZone(String tz) {
+        if (tz == null || tz.isBlank()) return ZoneOffset.UTC;
+        try {
+            return ZoneId.of(tz);
+        } catch (Exception e) {
+            return ZoneOffset.UTC;
+        }
+    }
+}

--- a/src/main/resources/db/migration/V23__create_monthly_reports_sent.sql
+++ b/src/main/resources/db/migration/V23__create_monthly_reports_sent.sql
@@ -1,0 +1,40 @@
+-- V23__create_monthly_reports_sent.sql
+-- Issue #137: месячный отчёт по уходу.
+--
+-- Идемпотентность шедулера месячных отчётов: не отправлять отчёт одному и тому
+-- же юзеру дважды за один и тот же отчётный месяц. Шедулер перед отправкой
+-- делает INSERT в эту таблицу — если PK конфликт, значит за этот период уже
+-- слали (повторный тик / рестарт пода / двойной запуск при rolling deploy).
+--
+-- Отчётный период year_month берётся по календарю в TZ юзера (users.timezone):
+-- «отчёт за апрель» считается по месяцу пользователя, а не по UTC, что даёт
+-- устойчивость к сдвигу времени запуска шедулера на стыке месяцев.
+--
+-- Backward-compat note:
+--   * Новая таблица — для старого кода невидима (аддитивно, один релиз).
+--   * ON DELETE CASCADE на user_id: при удалении пользователя история
+--     отправленных отчётов уезжает вместе с ним — это ок, id не переиспользуется.
+--   * Безопасно для rolling deploy.
+
+BEGIN;
+
+CREATE TABLE monthly_report_sent (
+    user_id     BIGINT      NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    year_month  INT         NOT NULL,
+    sent_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, year_month)
+);
+
+COMMENT ON TABLE monthly_report_sent IS
+    'Идемпотентность месячных отчётов (issue #137): по одной строке на '
+        '(user_id, отчётный месяц). Шедулер перед отправкой пытается INSERT — '
+        'конфликт PK означает «отчёт за этот месяц уже отправлен».';
+
+COMMENT ON COLUMN monthly_report_sent.year_month IS
+    'Отчётный месяц в формате YYYYMM (в TZ юзера, users.timezone). '
+        'Например, 202604 для отчёта за апрель 2026.';
+
+COMMENT ON COLUMN monthly_report_sent.sent_at IS
+    'Момент отправки отчёта в UTC (TIMESTAMPTZ). Для дебага и метрик.';
+
+COMMIT;

--- a/src/test/java/com/plantcare/bot/repository/MonthlyReportQueriesRepositoryTest.java
+++ b/src/test/java/com/plantcare/bot/repository/MonthlyReportQueriesRepositoryTest.java
@@ -1,0 +1,248 @@
+package com.plantcare.bot.repository;
+
+import com.plantcare.bot.domain.CareHistory;
+import com.plantcare.bot.domain.Location;
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.TaskType;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Limit;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @DataJpaTest на реальном Postgres (Testcontainers, НЕ H2) для запросов месячного
+ * отчёта (issue #137). Цель — прогнать на Postgres-диалекте именно те конструкции,
+ * где H2 врёт: {@code GROUP BY}-проекции и особенно
+ * {@code HAVING MIN(CASE WHEN was_on_time ...)} в {@code findFlawlessPlantsByUserInRange}.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=true",
+        "spring.flyway.locations=classpath:db/migration"
+})
+@Testcontainers
+@DisplayName("Запросы месячного отчёта на Postgres (issue #137)")
+class MonthlyReportQueriesRepositoryTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withReuse(true);
+
+    @DynamicPropertySource
+    static void configureDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private LocationRepository locationRepository;
+    @Autowired private PlantRepository plantRepository;
+    @Autowired private CareHistoryRepository careHistoryRepository;
+    @Autowired private EntityManager entityManager;
+
+    private static final LocalDateTime FROM = LocalDateTime.of(2026, 4, 1, 0, 0);
+    private static final LocalDateTime TO = LocalDateTime.of(2026, 5, 1, 0, 0);
+
+    @Test
+    @DisplayName("should_count_only_active_actions_in_range")
+    void should_count_only_active_actions_in_range() {
+        // arrange
+        User user = newUser(9001L);
+        Plant plant = newPlant(user, "Фикус", LocalDate.of(2024, 1, 1));
+        // 2 в апреле (in range), 1 в марте (out), 1 в мае (out)
+        care(plant, TaskType.WATERING, LocalDateTime.of(2026, 4, 10, 12, 0), true);
+        care(plant, TaskType.WATERING, LocalDateTime.of(2026, 4, 20, 12, 0), true);
+        care(plant, TaskType.WATERING, LocalDateTime.of(2026, 3, 31, 23, 0), true);
+        care(plant, TaskType.WATERING, LocalDateTime.of(2026, 5, 1, 0, 0), true);
+        // одна отменённая в апреле — не должна считаться
+        CareHistory cancelled = care(plant, TaskType.WATERING, LocalDateTime.of(2026, 4, 15, 12, 0), true);
+        CareHistory comp = care(plant, TaskType.WATERING, LocalDateTime.of(2026, 4, 16, 12, 0), true);
+        cancelled.setCancelledBy(comp);
+        careHistoryRepository.save(cancelled);
+        entityManager.flush();
+
+        // act: активных в [апрель] = 10-е, 20-е, 16-е(comp) = 3 (15-е отменено)
+        long count = careHistoryRepository.countActiveByUserIdInRange(user.getId(), FROM, TO);
+
+        // assert
+        assertThat(count).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("should_group_active_actions_by_task_type")
+    void should_group_active_actions_by_task_type() {
+        // arrange
+        User user = newUser(9002L);
+        Plant plant = newPlant(user, "Монстера", LocalDate.of(2024, 1, 1));
+        care(plant, TaskType.WATERING, LocalDateTime.of(2026, 4, 5, 12, 0), true);
+        care(plant, TaskType.WATERING, LocalDateTime.of(2026, 4, 12, 12, 0), true);
+        care(plant, TaskType.MISTING, LocalDateTime.of(2026, 4, 14, 12, 0), false);
+        care(plant, TaskType.FERTILIZING, LocalDateTime.of(2026, 4, 18, 12, 0), true);
+        entityManager.flush();
+
+        // act
+        Map<TaskType, Long> breakdown = careHistoryRepository
+                .countActiveByUserIdGroupedByTaskType(user.getId(), FROM, TO)
+                .stream()
+                .collect(Collectors.toMap(
+                        CareHistoryRepository.TaskTypeCount::getTaskType,
+                        CareHistoryRepository.TaskTypeCount::getCount));
+
+        // assert
+        assertThat(breakdown)
+                .containsEntry(TaskType.WATERING, 2L)
+                .containsEntry(TaskType.MISTING, 1L)
+                .containsEntry(TaskType.FERTILIZING, 1L)
+                .doesNotContainKey(TaskType.SOIL_CHECK);
+    }
+
+    @Test
+    @DisplayName("should_return_flawless_plant_when_all_actions_on_time")
+    void should_return_flawless_plant_when_all_actions_on_time() {
+        // arrange: два растения. Идеальное — все on-time; прогульщик — есть один false.
+        User user = newUser(9003L);
+        Plant flawless = newPlant(user, "Идеальное", LocalDate.of(2024, 1, 1));
+        Plant missed = newPlant(user, "Прогульщик", LocalDate.of(2024, 1, 1));
+
+        care(flawless, TaskType.WATERING, LocalDateTime.of(2026, 4, 5, 12, 0), true);
+        care(flawless, TaskType.WATERING, LocalDateTime.of(2026, 4, 15, 12, 0), true);
+
+        care(missed, TaskType.WATERING, LocalDateTime.of(2026, 4, 6, 12, 0), true);
+        care(missed, TaskType.WATERING, LocalDateTime.of(2026, 4, 16, 12, 0), false);
+        care(missed, TaskType.WATERING, LocalDateTime.of(2026, 4, 26, 12, 0), true);
+        entityManager.flush();
+
+        // act
+        List<CareHistoryRepository.PlantActionCount> result = careHistoryRepository
+                .findFlawlessPlantsByUserInRange(user.getId(), FROM, TO, Limit.of(5));
+
+        // assert: только идеальное растение (HAVING MIN(CASE...) отсёк прогульщика)
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getPlantId()).isEqualTo(flawless.getId());
+        assertThat(result.get(0).getPlantName()).isEqualTo("Идеальное");
+        assertThat(result.get(0).getCount()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("should_order_flawless_by_action_count_desc")
+    void should_order_flawless_by_action_count_desc() {
+        // arrange: два идеальных растения, у одного больше действий → оно первым.
+        User user = newUser(9004L);
+        Plant few = newPlant(user, "Мало", LocalDate.of(2024, 1, 1));
+        Plant many = newPlant(user, "Много", LocalDate.of(2024, 1, 1));
+
+        care(few, TaskType.WATERING, LocalDateTime.of(2026, 4, 5, 12, 0), true);
+
+        care(many, TaskType.WATERING, LocalDateTime.of(2026, 4, 5, 12, 0), true);
+        care(many, TaskType.WATERING, LocalDateTime.of(2026, 4, 12, 12, 0), true);
+        care(many, TaskType.MISTING, LocalDateTime.of(2026, 4, 19, 12, 0), true);
+        entityManager.flush();
+
+        // act
+        List<CareHistoryRepository.PlantActionCount> result = careHistoryRepository
+                .findFlawlessPlantsByUserInRange(user.getId(), FROM, TO, Limit.of(5));
+
+        // assert
+        assertThat(result).extracting(CareHistoryRepository.PlantActionCount::getPlantName)
+                .containsExactly("Много", "Мало");
+    }
+
+    @Test
+    @DisplayName("should_exclude_archived_plant_from_flawless")
+    void should_exclude_archived_plant_from_flawless() {
+        // arrange: идеальное, но архивное растение
+        User user = newUser(9005L);
+        Plant archived = newPlant(user, "Архивное идеальное", LocalDate.of(2024, 1, 1));
+        archived.setArchivedAt(LocalDateTime.of(2026, 4, 30, 12, 0));
+        plantRepository.save(archived);
+        care(archived, TaskType.WATERING, LocalDateTime.of(2026, 4, 5, 12, 0), true);
+        care(archived, TaskType.WATERING, LocalDateTime.of(2026, 4, 15, 12, 0), true);
+        entityManager.flush();
+
+        // act
+        List<CareHistoryRepository.PlantActionCount> result = careHistoryRepository
+                .findFlawlessPlantsByUserInRange(user.getId(), FROM, TO, Limit.of(5));
+
+        // assert
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_find_oldest_living_plant_by_acquired_date")
+    void should_find_oldest_living_plant_by_acquired_date() {
+        // arrange
+        User user = newUser(9006L);
+        newPlant(user, "Молодое", LocalDate.of(2025, 6, 1));
+        Plant oldest = newPlant(user, "Самое старое", LocalDate.of(2020, 1, 1));
+        newPlant(user, "Среднее", LocalDate.of(2023, 1, 1));
+        Plant archivedOlder = newPlant(user, "Архивный древний", LocalDate.of(2010, 1, 1));
+        archivedOlder.setArchivedAt(LocalDateTime.of(2026, 1, 1, 0, 0));
+        plantRepository.save(archivedOlder);
+        entityManager.flush();
+
+        // act
+        List<Plant> result = plantRepository.findOldestLivingByUser(user.getId(), Limit.of(1));
+
+        // assert: архивный 2010 исключён, самое старое живое — 2020.
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(oldest.getId());
+        assertThat(result.get(0).getName()).isEqualTo("Самое старое");
+    }
+
+    // ===================== helpers =====================
+
+    private User newUser(Long chatId) {
+        return userRepository.save(User.builder()
+                .telegramChatId(chatId)
+                .timezone("Europe/Moscow")
+                .blocked(false)
+                .build());
+    }
+
+    private int locationSeq = 0;
+
+    private Plant newPlant(User user, String name, LocalDate acquiredAt) {
+        Location location = locationRepository.save(Location.builder()
+                .user(user)
+                .name("Loc " + (++locationSeq))
+                .emoji(Location.DEFAULT_EMOJI)
+                .defaultLocation(false)
+                .build());
+        return plantRepository.save(Plant.builder()
+                .user(user)
+                .location(location)
+                .name(name)
+                .acquiredAt(acquiredAt)
+                .build());
+    }
+
+    private CareHistory care(Plant plant, TaskType type, LocalDateTime doneAt, boolean onTime) {
+        return careHistoryRepository.save(CareHistory.builder()
+                .plant(plant)
+                .taskType(type)
+                .doneAt(doneAt)
+                .onTime(onTime)
+                .build());
+    }
+}

--- a/src/test/java/com/plantcare/bot/service/MonthlyReportSchedulerTest.java
+++ b/src/test/java/com/plantcare/bot/service/MonthlyReportSchedulerTest.java
@@ -1,0 +1,153 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.client.TelegramClientProvider;
+import com.plantcare.bot.service.MonthlyReportService.MonthlyReport;
+import com.plantcare.bot.service.MonthlyReportService.OldestPlant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit-тесты {@link MonthlyReportScheduler} (issue #137) с фиксированным {@link Clock}.
+ * Внешний мир (Telegram) замокан; сервис — мок, чтобы изолировать оркестрацию
+ * шедулера: отправку отобранных кандидатов и порядок «send → markSent».
+ *
+ * <p>Окно «1-е число + утро 09:00–10:00 в TZ юзера» здесь НЕ проверяется — оно
+ * переехало внутрь {@link MonthlyReportService#findDueReports} (перед агрегатами),
+ * и покрывается {@code MonthlyReportServiceTest} на Testcontainers. Шедулер
+ * отправляет всё, что вернул {@code findDueReports}, и сам окно не считает.
+ */
+@DisplayName("MonthlyReportScheduler — оркестрация отправки (issue #137)")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MonthlyReportSchedulerTest {
+
+    @Mock private MonthlyReportService monthlyReportService;
+    @Mock private TelegramClientProvider telegramClientProvider;
+    @Mock private TelegramClient telegramClient;
+
+    private MonthlyReportScheduler newScheduler(Clock clock) {
+        when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
+        return new MonthlyReportScheduler(
+                monthlyReportService, telegramClientProvider, clock);
+    }
+
+    @Test
+    @DisplayName("should_send_and_mark_when_report_is_due")
+    void should_send_and_mark_when_report_is_due() throws TelegramApiException {
+        // arrange: сервис уже отобрал кандидата (окно посчитано внутри сервиса).
+        Instant now = Instant.parse("2026-05-01T06:30:00Z");
+        MonthlyReportScheduler scheduler = newScheduler(fixed(now));
+
+        MonthlyReport report = report(1L, 555L, 202604);
+        when(monthlyReportService.findDueReports(now)).thenReturn(List.of(report));
+
+        // act
+        scheduler.tick();
+
+        // assert
+        verify(telegramClient, times(1)).execute(any(SendMessage.class));
+        verify(monthlyReportService).markSent(eq(1L), eq(202604), eq(now));
+    }
+
+    @Test
+    @DisplayName("should_not_mark_when_telegram_send_fails")
+    void should_not_mark_when_telegram_send_fails() throws TelegramApiException {
+        // arrange: кандидат есть, но Telegram падает → markSent НЕ зовём.
+        Instant now = Instant.parse("2026-05-01T06:30:00Z");
+        MonthlyReportScheduler scheduler = newScheduler(fixed(now));
+
+        when(monthlyReportService.findDueReports(now))
+                .thenReturn(List.of(report(1L, 555L, 202604)));
+        when(telegramClient.execute(any(SendMessage.class)))
+                .thenThrow(new TelegramApiException("boom"));
+
+        // act
+        scheduler.tick();
+
+        // assert
+        verify(telegramClient, times(1)).execute(any(SendMessage.class));
+        verify(monthlyReportService, never()).markSent(anyLong(), anyInt(), any(Instant.class));
+    }
+
+    @Test
+    @DisplayName("should_do_nothing_when_no_due_reports")
+    void should_do_nothing_when_no_due_reports() throws TelegramApiException {
+        // arrange
+        Instant now = Instant.parse("2026-05-01T06:30:00Z");
+        MonthlyReportScheduler scheduler = newScheduler(fixed(now));
+        when(monthlyReportService.findDueReports(now)).thenReturn(List.of());
+
+        // act
+        scheduler.tick();
+
+        // assert
+        verify(telegramClient, never()).execute(any(SendMessage.class));
+        verify(monthlyReportService, never()).markSent(anyLong(), anyInt(), any(Instant.class));
+    }
+
+    @Test
+    @DisplayName("should_continue_when_telegram_fails_for_one_user")
+    void should_continue_when_telegram_fails_for_one_user() throws TelegramApiException {
+        // arrange: два кандидата, у первого Telegram падает — второй всё равно
+        // обрабатывается и помечается.
+        Instant now = Instant.parse("2026-05-01T06:30:00Z");
+        MonthlyReportScheduler scheduler = newScheduler(fixed(now));
+
+        when(monthlyReportService.findDueReports(now)).thenReturn(List.of(
+                report(1L, 555L, 202604),
+                report(2L, 666L, 202604)));
+        when(telegramClient.execute(any(SendMessage.class)))
+                .thenThrow(new TelegramApiException("boom"))
+                .thenReturn(null);
+
+        // act
+        scheduler.tick();
+
+        // assert
+        verify(telegramClient, times(2)).execute(any(SendMessage.class));
+        verify(monthlyReportService, never()).markSent(eq(1L), anyInt(), any(Instant.class));
+        verify(monthlyReportService).markSent(eq(2L), eq(202604), eq(now));
+    }
+
+    // ===================== helpers =====================
+
+    private static Clock fixed(Instant instant) {
+        return Clock.fixed(instant, ZoneOffset.UTC);
+    }
+
+    private static MonthlyReport report(Long userId, Long chatId, int yearMonth) {
+        return new MonthlyReport(
+                userId,
+                chatId,
+                yearMonth,
+                "апрель 2026",
+                5L,
+                Map.of(),
+                new OldestPlant("Фикус", 1, 2),
+                "Фикус"
+        );
+    }
+}

--- a/src/test/java/com/plantcare/bot/service/MonthlyReportServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/MonthlyReportServiceTest.java
@@ -1,0 +1,543 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.CareHistory;
+import com.plantcare.bot.domain.Location;
+import com.plantcare.bot.domain.MonthlyReportSent;
+import com.plantcare.bot.domain.MonthlyReportSentId;
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.repository.CareHistoryRepository;
+import com.plantcare.bot.repository.LocationRepository;
+import com.plantcare.bot.repository.MonthlyReportSentRepository;
+import com.plantcare.bot.repository.PlantRepository;
+import com.plantcare.bot.repository.UserRepository;
+import com.plantcare.bot.support.IntegrationTestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Интеграционные тесты сервиса месячного отчёта (issue #137) на реальном Postgres
+ * через Testcontainers — реальные агрегаты ({@code COUNT}, {@code GROUP BY},
+ * {@code HAVING MIN(CASE...)}) прогоняются на Postgres-диалекте, а не на H2.
+ *
+ * <p>Покрывает AC:
+ *   - happy path: ≥3 активных действия за прошлый месяц → отчёт с корректными метриками;
+ *   - порог: ровно 2 → нет отчёта, ровно 3 → есть;
+ *   - 0 действий и blocked-юзер → нет отчёта;
+ *   - идемпотентность через {@link MonthlyReportSentRepository} и race на markSent;
+ *   - не-UTC TZ: действие в последний день месяца 23:00 локально (в UTC уже след. месяц)
+ *     учитывается в локальном месяце; year_month = YYYYMM прошлого месяца в TZ юзера.
+ */
+@DisplayName("MonthlyReportService — месячный отчёт (issue #137)")
+class MonthlyReportServiceTest extends IntegrationTestBase {
+
+    @Autowired private MonthlyReportService reportService;
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private LocationRepository locationRepository;
+    @Autowired private PlantRepository plantRepository;
+    @Autowired private CareHistoryRepository careHistoryRepository;
+    @Autowired private MonthlyReportSentRepository sentRepository;
+
+    @AfterEach
+    void cleanup() {
+        sentRepository.deleteAll();
+        careHistoryRepository.deleteAll();
+        plantRepository.deleteAll();
+        locationRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("should_build_report_with_correct_metrics_when_user_active_last_month")
+    void should_build_report_with_correct_metrics_when_user_active_last_month() {
+        // arrange: юзер в Москве; отчёт считается за апрель 2026, тик 1 мая в окне.
+        User user = savedUser(3001L, "Europe/Moscow");
+        // Самое старое живое растение — заведено 2 года назад.
+        Plant oldest = savedPlant(user, "Старый фикус", LocalDate.of(2024, 5, 1));
+        Plant monstera = savedPlant(user, "Монстера", LocalDate.of(2025, 12, 1));
+
+        // Апрель 2026 в TZ Москвы. Все действия в середине месяца — без краёв.
+        // Фикус: 2 полива (оба on-time) → flawless-кандидат.
+        saveCare(oldest, TaskType.WATERING, moscow(2026, 4, 10, 12), true);
+        saveCare(oldest, TaskType.WATERING, moscow(2026, 4, 20, 12), true);
+        // Монстера: 1 полив on-time + 1 опрыскивание НЕ on-time + 1 удобрение on-time
+        //  → не flawless (есть пропуск), но всего 3 действия у неё.
+        saveCare(monstera, TaskType.WATERING, moscow(2026, 4, 5, 12), true);
+        saveCare(monstera, TaskType.MISTING, moscow(2026, 4, 12, 12), false);
+        saveCare(monstera, TaskType.FERTILIZING, moscow(2026, 4, 25, 12), true);
+
+        // 2026-05-01 09:30 Москва — 1-е число, утреннее окно; прошлый месяц = апрель 2026.
+        Instant now = moscow(2026, 5, 1, 9).plusSeconds(30 * 60);
+
+        // act
+        List<MonthlyReportService.MonthlyReport> due = reportService.findDueReports(now);
+
+        // assert
+        assertThat(due).hasSize(1);
+        MonthlyReportService.MonthlyReport report = due.get(0);
+        assertThat(report.userId()).isEqualTo(user.getId());
+        assertThat(report.telegramChatId()).isEqualTo(3001L);
+        assertThat(report.yearMonth()).isEqualTo(202604);
+        assertThat(report.totalActions()).isEqualTo(5);
+        assertThat(report.breakdown())
+                .containsEntry(TaskType.WATERING, 3L)
+                .containsEntry(TaskType.MISTING, 1L)
+                .containsEntry(TaskType.FERTILIZING, 1L);
+        assertThat(report.breakdown()).doesNotContainKey(TaskType.SOIL_CHECK);
+        // Самое старое живое растение — фикус, заведён 2024-05-01, отчёт строится в мае 2026.
+        assertThat(report.oldestPlant()).isNotNull();
+        assertThat(report.oldestPlant().name()).isEqualTo("Старый фикус");
+        assertThat(report.oldestPlant().years()).isEqualTo(2);
+        // flawless: фикус (все on-time, 2 действия) обгоняет монстеру (есть не-on-time).
+        assertThat(report.flawlessPlantName()).isEqualTo("Старый фикус");
+
+        // текст содержит ключевые числа
+        String text = report.buildText();
+        assertThat(text)
+                .contains("апрель 2026")
+                .contains("5 действий")
+                .contains("Старый фикус")
+                .contains("Ни разу не пропустил уход за Старый фикус");
+    }
+
+    @Test
+    @DisplayName("should_not_send_report_when_not_first_day_of_month")
+    void should_not_send_report_when_not_first_day_of_month() {
+        // arrange: данных в апреле достаточно для отчёта, но тик 2 мая 09:30 Москва —
+        // НЕ 1-е число. Окно теперь считается в сервисе → агрегаты не запускаются.
+        User user = savedUser(3101L, "Europe/Moscow");
+        Plant plant = savedPlant(user, "Кактус", LocalDate.of(2025, 1, 1));
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 3, 10), true);
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 13, 10), true);
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 23, 10), true);
+
+        Instant now = moscow(2026, 5, 2, 9).plusSeconds(30 * 60);
+
+        // act
+        List<MonthlyReportService.MonthlyReport> due = reportService.findDueReports(now);
+
+        // assert
+        assertThat(due).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_not_send_report_when_before_morning_window")
+    void should_not_send_report_when_before_morning_window() {
+        // arrange: 1 мая 08:30 Москва — до начала окна 09:00.
+        User user = savedUser(3102L, "Europe/Moscow");
+        Plant plant = savedPlant(user, "Кактус", LocalDate.of(2025, 1, 1));
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 3, 10), true);
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 13, 10), true);
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 23, 10), true);
+
+        Instant now = moscow(2026, 5, 1, 8).plusSeconds(30 * 60);
+
+        // act
+        List<MonthlyReportService.MonthlyReport> due = reportService.findDueReports(now);
+
+        // assert
+        assertThat(due).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_not_send_report_when_at_window_end_boundary")
+    void should_not_send_report_when_at_window_end_boundary() {
+        // arrange: 1 мая 10:00 Москва — конец окна exclusive [09:00, 10:00).
+        User user = savedUser(3103L, "Europe/Moscow");
+        Plant plant = savedPlant(user, "Кактус", LocalDate.of(2025, 1, 1));
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 3, 10), true);
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 13, 10), true);
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 23, 10), true);
+
+        Instant now = moscow(2026, 5, 1, 10);
+
+        // act
+        List<MonthlyReportService.MonthlyReport> due = reportService.findDueReports(now);
+
+        // assert
+        assertThat(due).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_send_report_when_first_day_morning_in_almaty_zone")
+    void should_send_report_when_first_day_morning_in_almaty_zone() {
+        // arrange: окно считается в TZ юзера. 1 мая 04:30 UTC = 09:30 Алматы (UTC+5) → окно.
+        // Для Москвы тот же момент = 07:30 (вне окна) — отчёт уходит только из-за TZ юзера.
+        User user = savedUser(3104L, "Asia/Almaty");
+        Plant plant = savedPlant(user, "Алматинский кактус", LocalDate.of(2025, 1, 1));
+        saveCare(plant, TaskType.WATERING, almaty(2026, 4, 3, 10), true);
+        saveCare(plant, TaskType.WATERING, almaty(2026, 4, 13, 10), true);
+        saveCare(plant, TaskType.WATERING, almaty(2026, 4, 23, 10), true);
+
+        Instant now = Instant.parse("2026-05-01T04:30:00Z");
+
+        // act
+        List<MonthlyReportService.MonthlyReport> due = reportService.findDueReports(now);
+
+        // assert
+        assertThat(due).hasSize(1);
+        assertThat(due.get(0).yearMonth()).isEqualTo(202604);
+    }
+
+    @Test
+    @DisplayName("should_send_report_when_exactly_three_actions")
+    void should_send_report_when_exactly_three_actions() {
+        // arrange: ровно порог MIN_ACTIONS = 3
+        User user = savedUser(3002L, "Europe/Moscow");
+        Plant plant = savedPlant(user, "Кактус", LocalDate.of(2025, 1, 1));
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 3, 10), true);
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 13, 10), true);
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 23, 10), true);
+
+        Instant now = moscow(2026, 5, 1, 9);
+
+        // act
+        List<MonthlyReportService.MonthlyReport> due = reportService.findDueReports(now);
+
+        // assert
+        assertThat(due).hasSize(1);
+        assertThat(due.get(0).totalActions()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("should_not_send_report_when_exactly_two_actions")
+    void should_not_send_report_when_exactly_two_actions() {
+        // arrange: на одно действие меньше порога
+        User user = savedUser(3003L, "Europe/Moscow");
+        Plant plant = savedPlant(user, "Кактус", LocalDate.of(2025, 1, 1));
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 3, 10), true);
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 13, 10), true);
+
+        Instant now = moscow(2026, 5, 1, 9);
+
+        // act
+        List<MonthlyReportService.MonthlyReport> due = reportService.findDueReports(now);
+
+        // assert
+        assertThat(due).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_not_send_report_when_no_activity_at_all")
+    void should_not_send_report_when_no_activity_at_all() {
+        // arrange: растение есть, но за прошлый месяц ноль действий
+        User user = savedUser(3004L, "Europe/Moscow");
+        savedPlant(user, "Молчун", LocalDate.of(2025, 1, 1));
+
+        Instant now = moscow(2026, 5, 1, 9);
+
+        // act
+        List<MonthlyReportService.MonthlyReport> due = reportService.findDueReports(now);
+
+        // assert
+        assertThat(due).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_ignore_cancelled_actions_when_counting")
+    void should_ignore_cancelled_actions_when_counting() {
+        // arrange: 4 записи, но одна отменена (cancelled) → активных 3.
+        User user = savedUser(3005L, "Europe/Moscow");
+        Plant plant = savedPlant(user, "Алоэ", LocalDate.of(2025, 1, 1));
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 3, 10), true);
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 13, 10), true);
+        CareHistory cancelled = saveCare(plant, TaskType.WATERING, moscow(2026, 4, 20, 10), true);
+        CareHistory compensator = saveCare(plant, TaskType.WATERING, moscow(2026, 4, 23, 10), true);
+        cancelled.setCancelledBy(compensator);
+        careHistoryRepository.save(cancelled);
+
+        Instant now = moscow(2026, 5, 1, 9);
+
+        // act
+        List<MonthlyReportService.MonthlyReport> due = reportService.findDueReports(now);
+
+        // assert: cancelled запись не считается → активных ровно 3 (порог пройден)
+        assertThat(due).hasSize(1);
+        assertThat(due.get(0).totalActions()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("should_be_idempotent_when_report_already_sent_for_year_month")
+    void should_be_idempotent_when_report_already_sent_for_year_month() {
+        // arrange: отчёт за апрель уже отправлен (есть запись в monthly_report_sent)
+        User user = savedUser(3006L, "Europe/Moscow");
+        Plant plant = savedPlant(user, "Фиалка", LocalDate.of(2025, 1, 1));
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 3, 10), true);
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 13, 10), true);
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 23, 10), true);
+
+        Instant now = moscow(2026, 5, 1, 9);
+
+        // act 1 — кандидат есть, «отправляем» и помечаем
+        List<MonthlyReportService.MonthlyReport> firstRun = reportService.findDueReports(now);
+        assertThat(firstRun).hasSize(1);
+        reportService.markSent(user.getId(), 202604, now);
+
+        // act 2 — повторный запуск того же тика
+        List<MonthlyReportService.MonthlyReport> secondRun = reportService.findDueReports(now);
+
+        // assert
+        assertThat(secondRun).isEmpty();
+        assertThat(sentRepository.findById(new MonthlyReportSentId(user.getId(), 202604)))
+                .isPresent();
+        assertThat(sentRepository.count()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("should_not_create_second_row_when_mark_sent_called_twice")
+    void should_not_create_second_row_when_mark_sent_called_twice() {
+        // arrange
+        User user = savedUser(3007L, "Europe/Moscow");
+
+        // act: повторный markSent того же PK не должен падать (идемпотентность) и не
+        // должен плодить вторую строку — INSERT ... ON CONFLICT DO NOTHING делает
+        // второй вызов no-op на уровне БД, не перетирая sent_at первого.
+        reportService.markSent(user.getId(), 202604, Instant.parse("2026-05-01T06:00:00Z"));
+        reportService.markSent(user.getId(), 202604, Instant.parse("2026-05-01T07:00:00Z"));
+
+        // assert: ровно одна запись на (user_id, year_month), sent_at — от первого вызова.
+        assertThat(sentRepository.count()).isEqualTo(1L);
+        assertThat(sentRepository.findById(new MonthlyReportSentId(user.getId(), 202604)))
+                .isPresent()
+                .get()
+                .extracting(MonthlyReportSent::getSentAt)
+                .isEqualTo(Instant.parse("2026-05-01T06:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("should_not_throw_when_mark_sent_for_already_persisted_pk")
+    void should_not_throw_when_mark_sent_for_already_persisted_pk() {
+        // arrange: запись уже есть в БД (как после успешного предыдущего тика).
+        // markSent для того же PK обязан остаться идемпотентным — не пробросить
+        // исключение наружу (INSERT ... ON CONFLICT DO NOTHING → no-op).
+        User user = savedUser(3014L, "Europe/Moscow");
+        sentRepository.saveAndFlush(
+                new MonthlyReportSent(user.getId(), 202604, Instant.parse("2026-05-01T06:00:00Z")));
+
+        // act + assert: не бросает, остаётся ровно одна строка
+        reportService.markSent(user.getId(), 202604, Instant.parse("2026-05-01T07:00:00Z"));
+
+        assertThat(sentRepository.count()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("should_skip_blocked_users")
+    void should_skip_blocked_users() {
+        // arrange
+        User user = savedUser(3008L, "Europe/Moscow");
+        user.setBlocked(true);
+        userRepository.save(user);
+        Plant plant = savedPlant(user, "Цветок", LocalDate.of(2025, 1, 1));
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 3, 10), true);
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 13, 10), true);
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 23, 10), true);
+
+        Instant now = moscow(2026, 5, 1, 9);
+
+        // act
+        List<MonthlyReportService.MonthlyReport> due = reportService.findDueReports(now);
+
+        // assert
+        assertThat(due).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_count_action_in_local_month_when_done_late_last_day_almaty")
+    void should_count_action_in_local_month_when_done_late_last_day_almaty() {
+        // arrange: юзер в Алматы (UTC+5, без перехода). Действие сделано в последний
+        // день апреля в 23:00 локально. В UTC это 30 апреля 18:00 — всё ещё апрель UTC,
+        // НО проверяем зеркальный кейс отдельно (см. moscow-тест ниже). Здесь главное —
+        // что 1 мая 00:30 локально действие НЕ протекает в майский месяц.
+        User user = savedUser(3009L, "Asia/Almaty");
+        Plant plant = savedPlant(user, "Алматинское", LocalDate.of(2025, 1, 1));
+
+        // Два действия в апреле, и одно — 1 мая 00:30 ЛОКАЛЬНО (Алматы), что в UTC
+        // ещё 30 апреля 19:30. Это майское действие НЕ должно попасть в апрельский отчёт.
+        saveCare(plant, TaskType.WATERING, almaty(2026, 4, 15, 10), true);
+        saveCare(plant, TaskType.WATERING, almaty(2026, 4, 20, 10), true);
+        saveCare(plant, TaskType.WATERING, almaty(2026, 5, 1, 0).plusSeconds(30 * 60), true);
+
+        // тик 2026-05-01 09:00 локально Алматы (1-е число, окно) → прошлый месяц = апрель 2026
+        Instant now = almaty(2026, 5, 1, 9);
+
+        // act
+        List<MonthlyReportService.MonthlyReport> due = reportService.findDueReports(now);
+
+        // assert: только 2 апрельских действия → меньше порога, отчёта нет.
+        // Если бы границы месяца считались в UTC, майское действие (30 апр UTC) ошибочно
+        // попало бы в апрель и дало бы 3 → отчёт. Значит отсутствие отчёта доказывает
+        // расчёт границ в TZ юзера.
+        assertThat(due).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_include_action_done_late_last_day_in_local_month_almaty")
+    void should_include_action_done_late_last_day_in_local_month_almaty() {
+        // arrange: действие 30 апреля 23:00 ЛОКАЛЬНО Алматы = 30 апреля 18:00 UTC.
+        // Это апрель и в UTC, и локально — но добавим контрольный кейс: действие
+        // 1 апреля 02:00 локально (= 31 марта 21:00 UTC). По UTC-календарю это март,
+        // по локальному — апрель. Оно ДОЛЖНО учитываться в апреле.
+        User user = savedUser(3010L, "Asia/Almaty");
+        Plant plant = savedPlant(user, "Граничное", LocalDate.of(2025, 1, 1));
+
+        // 1 апреля 02:00 локально = 31 марта 21:00 UTC — по локальному календарю апрель.
+        saveCare(plant, TaskType.WATERING, almaty(2026, 4, 1, 2), true);
+        saveCare(plant, TaskType.WATERING, almaty(2026, 4, 15, 10), true);
+        saveCare(plant, TaskType.WATERING, almaty(2026, 4, 20, 10), true);
+
+        // тик 2026-05-01 09:00 локально Алматы (1-е число, окно).
+        Instant now = almaty(2026, 5, 1, 9);
+
+        // act
+        List<MonthlyReportService.MonthlyReport> due = reportService.findDueReports(now);
+
+        // assert: все 3 в апреле локально → отчёт есть, year_month = 202604.
+        // Если бы границы считались в UTC, действие 31 марта 21:00 UTC выпало бы из
+        // апреля → 2 действия → нет отчёта.
+        assertThat(due).hasSize(1);
+        assertThat(due.get(0).yearMonth()).isEqualTo(202604);
+        assertThat(due.get(0).totalActions()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("should_use_previous_local_month_year_month_in_western_zone")
+    void should_use_previous_local_month_year_month_in_western_zone() {
+        // arrange: западная TZ (UTC-7..-8). Тик 1 мая 09:00 локально LA = 1 мая 16:00 UTC.
+        // Прошлый месяц в TZ юзера = апрель → year_month 202604.
+        User user = savedUser(3011L, "America/Los_Angeles");
+        Plant plant = savedPlant(user, "Калифорнийское", LocalDate.of(2025, 1, 1));
+        saveCare(plant, TaskType.WATERING, la(2026, 4, 10, 12), true);
+        saveCare(plant, TaskType.WATERING, la(2026, 4, 15, 12), true);
+        saveCare(plant, TaskType.WATERING, la(2026, 4, 20, 12), true);
+
+        Instant now = la(2026, 5, 1, 9);
+
+        // act
+        List<MonthlyReportService.MonthlyReport> due = reportService.findDueReports(now);
+
+        // assert
+        assertThat(due).hasSize(1);
+        assertThat(due.get(0).yearMonth()).isEqualTo(202604);
+        assertThat(due.get(0).totalActions()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("should_exclude_archived_plant_from_flawless_and_oldest")
+    void should_exclude_archived_plant_from_flawless_and_oldest() {
+        // arrange: самое старое растение архивировано → не должно попасть ни в
+        // oldest, ни в flawless; берётся следующее живое.
+        User user = savedUser(3012L, "Europe/Moscow");
+        Plant archived = savedPlant(user, "Архивный старик", LocalDate.of(2020, 1, 1));
+        archived.setArchivedAt(LocalDateTime.now().truncatedTo(ChronoUnit.MICROS));
+        plantRepository.save(archived);
+        Plant living = savedPlant(user, "Живой", LocalDate.of(2024, 1, 1));
+
+        // Действия только у живого, все on-time.
+        saveCare(living, TaskType.WATERING, moscow(2026, 4, 3, 10), true);
+        saveCare(living, TaskType.WATERING, moscow(2026, 4, 13, 10), true);
+        saveCare(living, TaskType.WATERING, moscow(2026, 4, 23, 10), true);
+
+        Instant now = moscow(2026, 5, 1, 9);
+
+        // act
+        List<MonthlyReportService.MonthlyReport> due = reportService.findDueReports(now);
+
+        // assert
+        assertThat(due).hasSize(1);
+        MonthlyReportService.MonthlyReport report = due.get(0);
+        assertThat(report.oldestPlant().name()).isEqualTo("Живой");
+        assertThat(report.flawlessPlantName()).isEqualTo("Живой");
+    }
+
+    @Test
+    @DisplayName("should_have_no_flawless_plant_when_every_plant_missed_at_least_once")
+    void should_have_no_flawless_plant_when_every_plant_missed_at_least_once() {
+        // arrange: у единственного растения есть хотя бы одно не-on-time действие
+        User user = savedUser(3013L, "Europe/Moscow");
+        Plant plant = savedPlant(user, "Прогульщик", LocalDate.of(2024, 1, 1));
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 3, 10), true);
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 13, 10), false);
+        saveCare(plant, TaskType.WATERING, moscow(2026, 4, 23, 10), true);
+
+        Instant now = moscow(2026, 5, 1, 9);
+
+        // act
+        List<MonthlyReportService.MonthlyReport> due = reportService.findDueReports(now);
+
+        // assert: отчёт есть (3 действия), но flawless нет (HAVING MIN(...) отсёк)
+        assertThat(due).hasSize(1);
+        assertThat(due.get(0).flawlessPlantName()).isNull();
+        assertThat(due.get(0).buildText()).doesNotContain("Ни разу не пропустил");
+    }
+
+    // ===================== helpers =====================
+
+    private User savedUser(Long chatId, String timezone) {
+        return userRepository.save(User.builder()
+                .telegramChatId(chatId)
+                .timezone(timezone)
+                .blocked(false)
+                .build());
+    }
+
+    private Location savedDefaultLocation(User user) {
+        return locationRepository.findByUserIdAndDefaultLocationTrue(user.getId())
+                .orElseGet(() -> locationRepository.save(Location.builder()
+                        .user(user)
+                        .name(Location.DEFAULT_NAME)
+                        .emoji(Location.DEFAULT_EMOJI)
+                        .defaultLocation(true)
+                        .build()));
+    }
+
+    private Plant savedPlant(User user, String name, LocalDate acquiredAt) {
+        return plantRepository.save(Plant.builder()
+                .user(user)
+                .location(savedDefaultLocation(user))
+                .name(name)
+                .acquiredAt(acquiredAt)
+                .build());
+    }
+
+    /**
+     * Сохраняет запись ухода, у которой {@code done_at} — это локальный момент
+     * {@code localInstant} (TZ юзера), сконвертированный в UTC LocalDateTime —
+     * ровно так, как done_at хранится в БД (UTC).
+     */
+    private CareHistory saveCare(Plant plant, TaskType type, Instant localInstant, boolean onTime) {
+        LocalDateTime doneAtUtc = localInstant.atZone(ZoneOffset.UTC)
+                .toLocalDateTime().truncatedTo(ChronoUnit.MICROS);
+        return careHistoryRepository.save(CareHistory.builder()
+                .plant(plant)
+                .taskType(type)
+                .doneAt(doneAtUtc)
+                .onTime(onTime)
+                .build());
+    }
+
+    private static Instant moscow(int y, int mo, int d, int h) {
+        return LocalDateTime.of(y, mo, d, h, 0).atZone(ZoneId.of("Europe/Moscow")).toInstant();
+    }
+
+    private static Instant almaty(int y, int mo, int d, int h) {
+        return LocalDateTime.of(y, mo, d, h, 0).atZone(ZoneId.of("Asia/Almaty")).toInstant();
+    }
+
+    private static Instant la(int y, int mo, int d, int h) {
+        return LocalDateTime.of(y, mo, d, h, 0).atZone(ZoneId.of("America/Los_Angeles")).toInstant();
+    }
+}


### PR DESCRIPTION
Closes #137

## Что сделано
- Месячный retention-отчёт: раз в месяц бот шлёт юзеру карточку за прошлый месяц — всего действий, разбивка по типам ухода, самое старое живое растение + возраст, «растение, которое ни разу не пропустил».
- Отправка в утреннем окне (09:00–10:00 локально) 1-го числа месяца в TZ юзера. Порог: <3 действий за месяц → не шлём.
- Идемпотентность по `(user_id, year_month)` через таблицу `monthly_report_sent` + native `INSERT ... ON CONFLICT DO NOTHING`.
- Реализовано по образцу фичи «годовщины» (#117): read-only выбор кандидатов → Telegram-отправка вне транзакции → отдельная tx пометки «отправлено». Cron `0 15 * * * *` UTC.
- TZ-фильтр окна применяется ДО тяжёлых агрегатов — в обычный час/день per-user запросы к `care_history` не выполняются.

## Миграции
`V23__create_monthly_reports_sent.sql` — таблица `monthly_report_sent(user_id, year_month INT (YYYYMM), sent_at TIMESTAMPTZ)`, PK `(user_id, year_month)`, FK на `users` `ON DELETE CASCADE`.

## Backward-compat риски
Safe, один релиз. Чисто аддитивная таблица, старый код её не читает/не пишет. Подходит для rolling deploy.

## Тесты
28 новых тестов (`mvn verify` → 1056 / 0 fail на свежем Testcontainers):
- `MonthlyReportServiceTest` — метрики (happy), порог 2/3, 0 действий, cancelled не считаются, идемпотентность, окно (не 1-е / до окна / граница 10:00 exclusive), **не-UTC TZ на границе месяца (Asia/Almaty, America/Los_Angeles)**, blocked-юзер, архивные растения.
- `MonthlyReportSchedulerTest` — оркестрация: send→markSent, фейл Telegram → нет markSent, продолжение после фейла, пустой список.
- `MonthlyReportQueriesRepositoryTest` (`@DataJpaTest` + Testcontainers Postgres, не H2) — агрегаты, `findFlawlessPlantsByUserInRange` (HAVING MIN(CASE...)), `findOldestLivingByUser`.

## Чек
- [x] `mvn verify` зелёное (1056 тестов; 2 pre-existing flaky про популярность видов — не связаны с PR, зелено на свежем Testcontainers-контейнере)
- [x] reviewer прошёл — был 1 BLOCKING (фильтр окна после агрегатов), исправлен; повторное ревью LGTM
- [x] _Отложено (SHOULD-FIX, accepted):_ индекс под user-scoped range-скан `care_history.done_at` — reviewer понизил до NIT после фикса BLOCKING (агрегаты теперь идут только по юзерам в окне). Отдельной миграцией при необходимости.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
