### PR TITLE
feat: species toxicity flags and plant card badge (#130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 - **V23** — таблица `monthly_report_sent` (PK `(user_id, year_month)`) для идемпотентности месячных отчётов: одна отправка на юзера за отчётный месяц. `year_month` хранится как `YYYYMM` по календарю в TZ юзера. FK `ON DELETE CASCADE` на `users`
 - **V24** — таблица `diseases` (справочник типичных болезней/вредителей, ADR-013): `name` (уникальное), `latin_name` (nullable), `symptoms`/`treatment`/`prevention`, `symptom_codes` (CSV кодов enum `DiagnosisSymptom` для матчинга с диагностикой #73) и `search_tags`. Expression-GIN индекс `idx_diseases_search` по `to_tsvector('simple', name || search_tags || symptoms)` для полнотекстового поиска (по образцу `species`). Сидинг — отдельной миграцией V25
 - **V25** — сидинг 20 типичных проблем в `diseases`: вредители, грибковые/бактериальные болезни, неинфекционные нарушения
+- **V26** — три nullable `BOOLEAN`-колонки `toxic_to_cats` / `toxic_to_dogs` / `toxic_to_humans` на `species`. Тройное состояние значимо: `true` — токсично, `false` — безопасно, `NULL` — нет данных. Детальная карточка растения показывает бейдж «⚠️ токсично для …» только для флагов `true`; при `false`/`NULL` блок отсутствует
 
 ## REST API
 

--- a/src/main/java/com/plantcare/bot/domain/Species.java
+++ b/src/main/java/com/plantcare/bot/domain/Species.java
@@ -58,4 +58,23 @@ public class Species extends BaseEntity {
     @Column(nullable = false)
     @Builder.Default
     private Integer popularity = 0;
+
+    /**
+     * Токсичность вида для кошек. Тройное состояние значимо:
+     * {@code true} — токсично, {@code false} — безопасно, {@code null} — нет данных.
+     */
+    @Column(name = "toxic_to_cats")
+    private Boolean toxicToCats;
+
+    /**
+     * Токсичность вида для собак. {@code null} — нет данных (см. {@link #toxicToCats}).
+     */
+    @Column(name = "toxic_to_dogs")
+    private Boolean toxicToDogs;
+
+    /**
+     * Токсичность вида для людей/детей. {@code null} — нет данных (см. {@link #toxicToCats}).
+     */
+    @Column(name = "toxic_to_humans")
+    private Boolean toxicToHumans;
 }

--- a/src/main/java/com/plantcare/bot/service/PlantCardService.java
+++ b/src/main/java/com/plantcare/bot/service/PlantCardService.java
@@ -288,6 +288,12 @@ public class PlantCardService {
 
         List<CareSchedule> schedules = plantService.getActiveSchedules(plant.getId());
 
+        // issue #130: инициализируем lazy-вид, чтобы прочитать флаги токсичности
+        // в buildDetailedCardText (иначе LazyInitializationException вне транзакции).
+        if (plant.getSpecies() != null) {
+            plant.getSpecies().getName();
+        }
+
         // issue #129: показываем кнопку «О виде» только если у вида есть факты.
         // Пустой/неизвестный вид кнопку не получает.
         boolean hasSpeciesFacts = plant.getSpecies() != null
@@ -1315,6 +1321,9 @@ public class PlantCardService {
             sb.append("\n📝 _").append(escapeMd(plant.getNotes().trim())).append("_\n");
         }
 
+        // issue #130: блок токсичности вида. Показываем только флаги == true.
+        appendToxicityBlock(sb, plant.getSpecies());
+
         if (schedules.isEmpty()) {
             sb.append("\n📅 Расписание ухода не настроено.");
             return sb.toString();
@@ -1353,6 +1362,36 @@ public class PlantCardService {
         }
 
         return sb.toString();
+    }
+
+    /**
+     * Дописывает блок токсичности вида (issue #130). Бейдж выводится только для
+     * флагов со значением {@code true}; {@code false} и {@code null} (нет данных)
+     * не показываются. Если ни один флаг не {@code true} — блок отсутствует целиком.
+     */
+    private void appendToxicityBlock(StringBuilder sb, com.plantcare.bot.domain.Species species) {
+        if (species == null) {
+            return;
+        }
+
+        boolean toCats = Boolean.TRUE.equals(species.getToxicToCats());
+        boolean toDogs = Boolean.TRUE.equals(species.getToxicToDogs());
+        boolean toHumans = Boolean.TRUE.equals(species.getToxicToHumans());
+
+        if (!toCats && !toDogs && !toHumans) {
+            return;
+        }
+
+        sb.append("\n");
+        if (toCats) {
+            sb.append("⚠️ токсично для кошек\n");
+        }
+        if (toDogs) {
+            sb.append("⚠️ токсично для собак\n");
+        }
+        if (toHumans) {
+            sb.append("⚠️ токсично для детей\n");
+        }
     }
 
     private InlineKeyboardMarkup buildDetailedCardKeyboard(

--- a/src/main/resources/db/migration/V26__add_species_toxicity_flags.sql
+++ b/src/main/resources/db/migration/V26__add_species_toxicity_flags.sql
@@ -1,0 +1,24 @@
+-- V26__add_species_toxicity_flags.sql
+-- Флаги токсичности вида для бейджа в карточке растения (ADR-011, issue #130).
+-- Версия V26 (не V24): V24/V25 параллельно заняты другими открытыми PR (#136, #140).
+-- Тройное состояние значимо: TRUE — токсично, FALSE — безопасно, NULL — нет данных.
+-- Backward-compat note: три nullable-колонки на существующую таблицу species — безопасно.
+--   Старый код колонки не читает и не пишет, на старых строках значение остаётся NULL
+--   ("нет данных") по дизайну. 3-шаговая процедура NOT NULL НЕ нужна и НЕ применяется.
+--   Сидинг значений токсичности НЕ здесь (вне scope #130), только DDL.
+
+BEGIN;
+
+ALTER TABLE species
+    ADD COLUMN IF NOT EXISTS toxic_to_cats   BOOLEAN,
+    ADD COLUMN IF NOT EXISTS toxic_to_dogs   BOOLEAN,
+    ADD COLUMN IF NOT EXISTS toxic_to_humans BOOLEAN;
+
+COMMENT ON COLUMN species.toxic_to_cats IS
+    'Токсичен для кошек. TRUE — токсично, FALSE — безопасно, NULL — нет данных (ADR-011).';
+COMMENT ON COLUMN species.toxic_to_dogs IS
+    'Токсичен для собак. TRUE — токсично, FALSE — безопасно, NULL — нет данных (ADR-011).';
+COMMENT ON COLUMN species.toxic_to_humans IS
+    'Токсичен для людей. TRUE — токсично, FALSE — безопасно, NULL — нет данных (ADR-011).';
+
+COMMIT;

--- a/src/test/java/com/plantcare/bot/service/PlantCardToxicityTest.java
+++ b/src/test/java/com/plantcare/bot/service/PlantCardToxicityTest.java
@@ -1,0 +1,228 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.Species;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.repository.PlantRepository;
+import com.plantcare.bot.seasonal.service.SeasonalIntervalService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Юнит-тесты блока токсичности вида в детальной карточке растения (issue #130).
+ *
+ * <p>Подход повторяет {@link PlantCardSpeciesFactsTest}: тяжёлый Telegram-API
+ * ({@link TelegramClient}) мокаем целиком, перехватываем отправленное
+ * {@link SendMessage} и инспектируем его текст. Бизнес-коллабораторы подменены
+ * моками точечно — проверяем именно появление/отсутствие бейджей токсичности в
+ * тексте карточки в зависимости от тройного состояния флагов вида.
+ */
+@ExtendWith(MockitoExtension.class)
+class PlantCardToxicityTest {
+
+    private static final String CATS_BADGE = "токсично для кошек";
+    private static final String DOGS_BADGE = "токсично для собак";
+    private static final String HUMANS_BADGE = "токсично для детей";
+
+    @Mock private PlantService plantService;
+    @Mock private PlantRepository plantRepository;
+    @Mock private MainMenuService mainMenuService;
+    @Mock private UserService userService;
+    @Mock private CareHistoryService careHistoryService;
+    @Mock private PlantEventService plantEventService;
+    @Mock private SpeciesFactService speciesFactService;
+    @Mock private SeasonalIntervalService seasonalIntervalService;
+
+    @Mock private TelegramClient client;
+
+    private PlantCardService cardService;
+
+    @BeforeEach
+    void setUp() {
+        cardService = new PlantCardService(
+                plantService, plantRepository, mainMenuService, userService,
+                careHistoryService, plantEventService, speciesFactService, seasonalIntervalService);
+    }
+
+    @Test
+    void should_show_cats_badge_when_species_toxic_to_cats() throws Exception {
+        // arrange
+        Species species = givenSpecies(100L);
+        species.setToxicToCats(true);
+        givenCardFor(species);
+
+        // act
+        cardService.showPlantCard(givenUser(1L, 555L), 10L, null, PlantCardService.BACK_TO_LIST, client);
+
+        // assert
+        assertThat(cardText()).contains(CATS_BADGE);
+    }
+
+    @Test
+    void should_show_cats_and_dogs_badges_but_not_humans_when_cats_and_dogs_true_and_humans_null()
+            throws Exception {
+        // arrange
+        Species species = givenSpecies(100L);
+        species.setToxicToCats(true);
+        species.setToxicToDogs(true);
+        species.setToxicToHumans(null);
+        givenCardFor(species);
+
+        // act
+        cardService.showPlantCard(givenUser(1L, 555L), 10L, null, PlantCardService.BACK_TO_LIST, client);
+
+        // assert
+        String text = cardText();
+        assertThat(text).contains(CATS_BADGE);
+        assertThat(text).contains(DOGS_BADGE);
+        assertThat(text).doesNotContain(HUMANS_BADGE);
+    }
+
+    @Test
+    void should_render_humans_flag_as_children_label_when_toxic_to_humans() throws Exception {
+        // arrange
+        Species species = givenSpecies(100L);
+        species.setToxicToHumans(true);
+        givenCardFor(species);
+
+        // act
+        cardService.showPlantCard(givenUser(1L, 555L), 10L, null, PlantCardService.BACK_TO_LIST, client);
+
+        // assert — именно «для детей», а не «для людей»
+        String text = cardText();
+        assertThat(text).contains(HUMANS_BADGE);
+        assertThat(text).doesNotContain("токсично для людей");
+    }
+
+    @Test
+    void should_not_show_cats_badge_when_toxic_to_cats_is_false() throws Exception {
+        // arrange — false (а не null): известно, что безопасно, бейдж не нужен
+        Species species = givenSpecies(100L);
+        species.setToxicToCats(false);
+        givenCardFor(species);
+
+        // act
+        cardService.showPlantCard(givenUser(1L, 555L), 10L, null, PlantCardService.BACK_TO_LIST, client);
+
+        // assert
+        assertThat(cardText()).doesNotContain(CATS_BADGE);
+    }
+
+    @Test
+    void should_not_show_cats_badge_when_toxic_to_cats_is_null() throws Exception {
+        // arrange — null: данных нет, бейдж не показываем (отдельно от false)
+        Species species = givenSpecies(100L);
+        species.setToxicToCats(null);
+        givenCardFor(species);
+
+        // act
+        cardService.showPlantCard(givenUser(1L, 555L), 10L, null, PlantCardService.BACK_TO_LIST, client);
+
+        // assert
+        assertThat(cardText()).doesNotContain(CATS_BADGE);
+    }
+
+    @Test
+    void should_hide_whole_toxicity_block_when_all_flags_are_null() throws Exception {
+        // arrange — все три null: блок отсутствует целиком
+        Species species = givenSpecies(100L);
+        species.setToxicToCats(null);
+        species.setToxicToDogs(null);
+        species.setToxicToHumans(null);
+        givenCardFor(species);
+
+        // act
+        cardService.showPlantCard(givenUser(1L, 555L), 10L, null, PlantCardService.BACK_TO_LIST, client);
+
+        // assert
+        String text = cardText();
+        assertThat(text).doesNotContain(CATS_BADGE);
+        assertThat(text).doesNotContain(DOGS_BADGE);
+        assertThat(text).doesNotContain(HUMANS_BADGE);
+        assertThat(text).doesNotContain("токсично");
+    }
+
+    @Test
+    void should_hide_whole_toxicity_block_when_all_flags_are_false() throws Exception {
+        // arrange — все три false: вид безопасен, блок отсутствует целиком
+        Species species = givenSpecies(100L);
+        species.setToxicToCats(false);
+        species.setToxicToDogs(false);
+        species.setToxicToHumans(false);
+        givenCardFor(species);
+
+        // act
+        cardService.showPlantCard(givenUser(1L, 555L), 10L, null, PlantCardService.BACK_TO_LIST, client);
+
+        // assert
+        String text = cardText();
+        assertThat(text).doesNotContain(CATS_BADGE);
+        assertThat(text).doesNotContain(DOGS_BADGE);
+        assertThat(text).doesNotContain(HUMANS_BADGE);
+        assertThat(text).doesNotContain("токсично");
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    /**
+     * Готовит карточку для растения с заданным видом: стабит загрузку растения и
+     * пустой список расписаний. {@code hasFactsForSpecies} осознанно не стабим —
+     * мок по умолчанию вернёт {@code false}, нас интересует только текст блока.
+     */
+    private void givenCardFor(Species species) {
+        Plant plant = givenPlant(10L, givenUser(1L, 555L), species);
+        when(plantRepository.findByUserIdAndIdAndArchivedAtIsNull(1L, 10L)).thenReturn(Optional.of(plant));
+        when(plantService.getActiveSchedules(10L)).thenReturn(List.of());
+    }
+
+    private String cardText() throws Exception {
+        var captor = ArgumentCaptor.forClass(SendMessage.class);
+        org.mockito.Mockito.verify(client).execute(captor.capture());
+        return captor.getValue().getText();
+    }
+
+    private User givenUser(Long id, Long chatId) {
+        var u = User.builder().telegramChatId(chatId).build();
+        setId(u, id);
+        return u;
+    }
+
+    private Species givenSpecies(Long id) {
+        var s = new Species();
+        s.setName("Монстера");
+        setId(s, id);
+        return s;
+    }
+
+    private Plant givenPlant(Long id, User user, Species species) {
+        var p = new Plant();
+        p.setName("Моя монстера");
+        p.setUser(user);
+        p.setSpecies(species);
+        setId(p, id);
+        return p;
+    }
+
+    private static void setId(Object entity, Long id) {
+        try {
+            Field f = com.plantcare.bot.domain.base.BaseEntity.class.getDeclaredField("id");
+            f.setAccessible(true);
+            f.set(entity, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Closes #130

## Что сделано
- **Машинно-читаемые флаги токсичности вида** (ADR-011) — отдельно от текстовых фактов категории `TOXICITY` из #129. Три nullable `Boolean`-поля на `Species`: `toxicToCats` / `toxicToDogs` / `toxicToHumans`. Тройное состояние значимо: `true` — токсично, `false` — безопасно, `null` — нет данных.
- **Бейдж в детальной карточке растения** (#26): «⚠️ токсично для кошек / собак / детей» рисуется только для флагов со значением `true`. При `false` и `null` соответствующая строка не показывается; если ни один флаг не `true` — блок токсичности отсутствует целиком.

## Миграции
`V26__add_species_toxicity_flags.sql` — три nullable `BOOLEAN`-колонки `toxic_to_cats` / `toxic_to_dogs` / `toxic_to_humans` на `species`, без `NOT NULL`/`DEFAULT`.

> **Номер V26, а не V23 (как в issue):** issue писался когда последней была V21. На момент PR `develop` содержит V22 (species_facts, #129), V23 (monthly_report_sent, #137) и **V24/V25 (diseases, #140 — влит в develop во время работы над этой задачей)**. V26 — следующий свободный номер; ветка перебазирована на актуальный `develop`, цепочка V24→V25→V26 применяется чисто.

## Backward-compat риски
**safe.** Добавление nullable-колонок без `DEFAULT` на существующую таблицу — метаданная-операция в PG16, без переписи строк и длинной блокировки. Старый код колонки не читает/не пишет, значение остаётся `NULL` («нет данных»). 3-шаговая процедура NOT NULL не нужна — колонки nullable по дизайну.

## Тесты
`PlantCardToxicityTest` (7 тестов, unit на `PlantCardService` с моком Telegram, по образцу `PlantCardSpeciesFactsTest` из #129):
- happy: `cats=true` → бейдж кошек; комбинация `cats=true, dogs=true, humans=null`;
- тройное состояние: `false` скрыт, `null` скрыт (раздельно);
- edge: все три `null` → блока нет; все три `false` → блока нет;
- лейбл `humans=true` → именно «для детей» (sensitivity-проверка: при мутации лейбла тест краснеет).

## Чек
- [x] `./mvnw verify` (фактически системный `mvn verify`) зелёное на чистом Testcontainers-контейнере: миграции V24→V25→V26 применяются, 0 failures
- [x] reviewer прошёл — единственный 🔴 (номер миграции) устранён перенумерованием в V26 ровно по его рекомендации; остальные пункты 🟢

## Контекст по среде
Падения `PrometheusEndpointIntegrationTest` (`/actuator/prometheus` → 401) — pre-existing на `develop`, к этой задаче не относятся. В финальном прогоне на чистом контейнере не воспроизводились.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
