### PR TITLE
feat: rate-limited async очередь отправки сообщений (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,29 @@ PII не уходит в Sentry: `SentryPiiFilter` (`BeforeSendCallback`) хеш
 |---|---|---|---|
 | `SENTRY_DSN` | пусто | prod | нет — пустой DSN = Sentry no-op |
 
+### Очередь исходящих сообщений (issue #29)
+
+Массовые отправки шедулеров (напоминания, дайджесты, годовщины, месячные отчёты,
+акклиматизация, отпуск, фото-прогресс) идут не напрямую в Telegram API, а через
+`RateLimitedTelegramSender`: in-memory bounded-очередь, которую дренирует один
+daemon-поток со скоростью ≤ `permits-per-second` (token bucket, запас под лимит
+Telegram ~30/sec). На 429 поток ждёт `retry_after` и повторяет до `max-retries`
+раз; при переполнении очереди сообщение дропается с warn (метрика
+`notifications.failed{reason=other}`), а не блокирует шедулер.
+
+Интерактивные хендлеры команд/колбэков и `AdminBroadcastService` (со своим
+троттлингом) через эту очередь намеренно НЕ ходят.
+
+Конфигурация — `telegram.rate-limit` в `application.yml`:
+
+| Переменная | Дефолт | Описание |
+|---|---|---|
+| `TELEGRAM_RATE_LIMIT_PERMITS_PER_SECOND` | `25` | Сколько отправок в секунду разрешает token bucket |
+| `TELEGRAM_RATE_LIMIT_QUEUE_CAPACITY` | `10000` | Глубина очереди; при переполнении сообщение дропается |
+| `TELEGRAM_RATE_LIMIT_MAX_RETRIES` | `3` | Сколько раз повторять отправку при 429 перед признанием неудачи |
+| `TELEGRAM_RATE_LIMIT_DEFAULT_RETRY_AFTER_SECONDS` | `1` | Fallback retry-after, если 429 не содержит распарсиваемого значения |
+| `TELEGRAM_RATE_LIMIT_MAX_RETRY_AFTER_SECONDS` | `60` | Потолок для `retry_after` из 429 — чтобы одно сообщение не заблокировало очередь на часы |
+
 ## Деплой на Railway
 
 ### Первичная настройка

--- a/src/main/java/com/plantcare/bot/PlantsCareApplication.java
+++ b/src/main/java/com/plantcare/bot/PlantsCareApplication.java
@@ -2,6 +2,7 @@ package com.plantcare.bot;
 
 import com.plantcare.bot.config.CalendarProperties;
 import com.plantcare.bot.config.SpeciesProperties;
+import com.plantcare.bot.config.TelegramRateLimitProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -9,7 +10,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
-@EnableConfigurationProperties({SpeciesProperties.class, CalendarProperties.class})
+@EnableConfigurationProperties({SpeciesProperties.class, CalendarProperties.class, TelegramRateLimitProperties.class})
 public class PlantsCareApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/plantcare/bot/config/TelegramRateLimitProperties.java
+++ b/src/main/java/com/plantcare/bot/config/TelegramRateLimitProperties.java
@@ -1,0 +1,38 @@
+package com.plantcare.bot.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Конфигурация очереди исходящих сообщений Telegram (issue #29).
+ *
+ * <p>Telegram Bot API ограничивает массовую отправку до ~30 сообщений в секунду.
+ * {@code permitsPerSecond} держим ниже лимита (запас), чтобы случайные всплески
+ * не привели к 429. Очередь ограничена {@code queueCapacity}: при переполнении
+ * сообщение дропается с warn-логом, чтобы не блокировать поток шедулера.
+ */
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "telegram.rate-limit")
+public class TelegramRateLimitProperties {
+
+    /** Сколько отправок в секунду разрешает token bucket. Запас под лимит Telegram (30/sec). */
+    private final int permitsPerSecond;
+
+    /** Максимальная глубина очереди. При переполнении сообщение дропается. */
+    private final int queueCapacity;
+
+    /** Сколько раз повторять отправку при 429 перед тем, как признать неудачу. */
+    private final int maxRetries;
+
+    /** Fallback retry-after (секунды), если 429 не содержит распарсиваемого значения. */
+    private final long defaultRetryAfterSeconds;
+
+    /**
+     * Верхняя граница (секунды) на распарсенный {@code retry-after} из 429.
+     * Один ответ с огромным значением (например, 99999) усыпил бы единственный
+     * воркер-поток на часы и застопорил всю остальную очередь — поэтому капаем.
+     */
+    private final long maxRetryAfterSeconds;
+}

--- a/src/main/java/com/plantcare/bot/service/AcclimationSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/AcclimationSchedulerService.java
@@ -1,10 +1,11 @@
 package com.plantcare.bot.service;
 
-import com.plantcare.bot.client.TelegramClientProvider;
 import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.observability.SentryTags;
 import com.plantcare.bot.observability.SentryTags.Layer;
+import com.plantcare.bot.telegram.RateLimitedTelegramSender;
+import com.plantcare.bot.telegram.SendCallbacks;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,7 +16,6 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardRow;
-import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -40,7 +40,7 @@ import java.util.List;
 public class AcclimationSchedulerService {
 
     private final PlantAcclimationService plantAcclimationService;
-    private final TelegramClientProvider telegramClientProvider;
+    private final RateLimitedTelegramSender telegramSender;
 
     @Scheduled(fixedRate = 3_600_000L)  // раз в час
     @Transactional
@@ -57,8 +57,7 @@ public class AcclimationSchedulerService {
                     if (user.isPaused() || isQuietHours(user, now)) {
                         continue;  // подождём до следующего тика
                     }
-                    sendFinishMessage(user, plant);
-                    plantAcclimationService.finish(plant);
+                    enqueueFinishMessage(user, plant);
                 } catch (Exception e) {
                     log.error("Failed to finish acclimation for plant {}: {}",
                             plant.getId(), e.getMessage(), e);
@@ -73,8 +72,7 @@ public class AcclimationSchedulerService {
                     if (user.isPaused() || isQuietHours(user, now)) {
                         continue;
                     }
-                    sendCheckinMessage(user, plant);
-                    plantAcclimationService.scheduleNextCheckin(plant);
+                    enqueueCheckinMessage(user, plant);
                 } catch (Exception e) {
                     log.error("Failed to send acclimation checkin for plant {}: {}",
                             plant.getId(), e.getMessage(), e);
@@ -84,23 +82,30 @@ public class AcclimationSchedulerService {
         });
     }
 
-    private void sendFinishMessage(User user, Plant plant) {
+    /**
+     * Issue #29: отправка ушла в rate-limited очередь. Очистка acclimation-полей
+     * ({@code finishById} — идемпотентна: повторный вызов на уже очищенном растении
+     * ничего не меняет) переехала в onSuccess-колбэк на воркер-потоке. Захватываем
+     * только plantId, чтобы перерезолвить растение в свежей транзакции.
+     */
+    private void enqueueFinishMessage(User user, Plant plant) {
         SendMessage msg = SendMessage.builder()
                 .chatId(user.getTelegramChatId().toString())
                 .text("✅ Акклиматизация для " + plant.getName() + " завершена. "
                         + "Возвращаюсь к обычному режиму уведомлений.")
                 .build();
-        try {
-            telegramClientProvider.getTelegramClient().execute(msg);
-            log.info("Acclimation finished message sent: plant={} chat={}",
-                    plant.getId(), user.getTelegramChatId());
-        } catch (TelegramApiException e) {
-            log.error("Telegram send error (acclimation finish, plant={}): {}",
-                    plant.getId(), e.getMessage(), e);
-        }
+
+        final long plantId = plant.getId();
+        final long chatId = user.getTelegramChatId();
+        telegramSender.enqueue(msg, new SendCallbacks(
+                () -> {
+                    plantAcclimationService.finishById(plantId);
+                    log.info("Acclimation finished message sent: plant={} chat={}", plantId, chatId);
+                },
+                null));
     }
 
-    private void sendCheckinMessage(User user, Plant plant) {
+    private void enqueueCheckinMessage(User user, Plant plant) {
         InlineKeyboardButton ok = InlineKeyboardButton.builder()
                 .text("👍 Ок")
                 .callbackData("v1:accl_checkin:" + plant.getId() + ":OK")
@@ -122,14 +127,16 @@ public class AcclimationSchedulerService {
                 .text("👀 Как выглядит " + plant.getName() + "?")
                 .replyMarkup(keyboard)
                 .build();
-        try {
-            telegramClientProvider.getTelegramClient().execute(msg);
-            log.info("Acclimation checkin sent: plant={} chat={}",
-                    plant.getId(), user.getTelegramChatId());
-        } catch (TelegramApiException e) {
-            log.error("Telegram send error (acclimation checkin, plant={}): {}",
-                    plant.getId(), e.getMessage(), e);
-        }
+
+        // Issue #29: планирование следующего check-in переехало в onSuccess-колбэк.
+        final long plantId = plant.getId();
+        final long chatId = user.getTelegramChatId();
+        telegramSender.enqueue(msg, new SendCallbacks(
+                () -> {
+                    plantAcclimationService.scheduleNextCheckinById(plantId);
+                    log.info("Acclimation checkin sent: plant={} chat={}", plantId, chatId);
+                },
+                null));
     }
 
     /**

--- a/src/main/java/com/plantcare/bot/service/MonthlyReportScheduler.java
+++ b/src/main/java/com/plantcare/bot/service/MonthlyReportScheduler.java
@@ -1,15 +1,15 @@
 package com.plantcare.bot.service;
 
-import com.plantcare.bot.client.TelegramClientProvider;
 import com.plantcare.bot.observability.SentryTags;
 import com.plantcare.bot.observability.SentryTags.Layer;
+import com.plantcare.bot.telegram.RateLimitedTelegramSender;
+import com.plantcare.bot.telegram.SendCallbacks;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
-import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -40,7 +40,7 @@ import java.util.List;
 public class MonthlyReportScheduler {
 
     private final MonthlyReportService monthlyReportService;
-    private final TelegramClientProvider telegramClientProvider;
+    private final RateLimitedTelegramSender telegramSender;
     private final Clock clock;
 
     /**
@@ -64,11 +64,7 @@ public class MonthlyReportScheduler {
 
             for (MonthlyReportService.MonthlyReport report : due) {
                 try {
-                    if (sendReport(report)) {
-                        monthlyReportService.markSent(report.userId(), report.yearMonth(), now);
-                        log.info("Monthly report sent: user={} yearMonth={} actions={}",
-                                report.userId(), report.yearMonth(), report.totalActions());
-                    }
+                    enqueueReport(report, now);
                 } catch (Exception e) {
                     log.error("Failed to handle monthly report for user {}: {}",
                             report.userId(), e.getMessage(), e);
@@ -78,18 +74,27 @@ public class MonthlyReportScheduler {
         });
     }
 
-    private boolean sendReport(MonthlyReportService.MonthlyReport report) {
+    /**
+     * Issue #29: отправка ушла в rate-limited очередь. Пометка «отправлено»
+     * ({@code markSent} — идемпотентный PK-based upsert) переехала в onSuccess-колбэк
+     * на воркер-потоке. Захватываем только примитивы из снимка report, чтобы не
+     * тащить состояние между потоками.
+     */
+    private void enqueueReport(MonthlyReportService.MonthlyReport report, Instant now) {
         SendMessage message = SendMessage.builder()
                 .chatId(report.telegramChatId().toString())
                 .text(report.buildText())
                 .build();
-        try {
-            telegramClientProvider.getTelegramClient().execute(message);
-            return true;
-        } catch (TelegramApiException e) {
-            log.error("Failed to send monthly report (user={}, chat={}): {}",
-                    report.userId(), report.telegramChatId(), e.getMessage());
-            return false;
-        }
+
+        final Long userId = report.userId();
+        final int yearMonth = report.yearMonth();
+        final long totalActions = report.totalActions();
+        telegramSender.enqueue(message, new SendCallbacks(
+                () -> {
+                    monthlyReportService.markSent(userId, yearMonth, now);
+                    log.info("Monthly report sent: user={} yearMonth={} actions={}",
+                            userId, yearMonth, totalActions);
+                },
+                null));
     }
 }

--- a/src/main/java/com/plantcare/bot/service/NotificationDeliveryCallbacks.java
+++ b/src/main/java/com/plantcare/bot/service/NotificationDeliveryCallbacks.java
@@ -1,0 +1,121 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.NotificationLog;
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.NotificationType;
+import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.metrics.MetricsService;
+import com.plantcare.bot.repository.NotificationLogRepository;
+import com.plantcare.bot.repository.PlantRepository;
+import com.plantcare.bot.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Колбэки доставки уведомлений (issue #29), вызываемые воркер-потоком очереди
+ * {@code RateLimitedTelegramSender} ПОСЛЕ резолва отправки.
+ *
+ * <p>Так как воркер-поток не имеет транзакции шедулера, каждый метод открывает
+ * собственную транзакцию ({@code @Transactional} через Spring-прокси: вызов идёт
+ * из другого бина — самовызова нет). Сущности перерезолвливаются по примитивным
+ * идентификаторам, которые шедулер захватил до постановки в очередь — никаких
+ * detached-entity между потоками.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationDeliveryCallbacks {
+
+    private final NotificationLogRepository notificationLogRepository;
+    private final PlantRepository plantRepository;
+    private final UserRepository userRepository;
+    private final MetricsService metricsService;
+
+    /**
+     * Зафиксировать успешную отправку одиночного уведомления: дедуп-лог +
+     * метрика sent. Дедуп-лог пишется по факту успешной отправки (как и в
+     * синхронной версии), просто теперь — на воркер-потоке очереди. На текущем
+     * масштабе очередь дренирует задолго до следующего тика (60с), так что окно
+     * дедупа не нарушается.
+     */
+    @Transactional
+    public void onSent(long plantId, TaskType taskType) {
+        plantRepository.findById(plantId).ifPresentOrElse(
+                plant -> {
+                    saveNotificationLog(plant, taskType);
+                    metricsService.recordNotificationSent(MetricsService.CHANNEL_TELEGRAM, taskType);
+                },
+                () -> log.info("Plant {} deleted before sent-callback, skipping dedup-log/metric", plantId));
+    }
+
+    /**
+     * Зафиксировать успешную отправку дайджеста: по дедуп-логу на каждую задачу +
+     * метрика sent на каждую + отдельный счётчик дайджестов. См. комментарий к
+     * {@link #onSent} про порядок записи дедупа.
+     */
+    @Transactional
+    public void onDigestSent(List<DigestLogItem> items) {
+        for (DigestLogItem item : items) {
+            plantRepository.findById(item.plantId()).ifPresentOrElse(
+                    plant -> {
+                        saveNotificationLog(plant, item.taskType());
+                        metricsService.recordNotificationSent(MetricsService.CHANNEL_TELEGRAM, item.taskType());
+                    },
+                    () -> log.info("Plant {} deleted before digest-callback, skipping dedup-log/metric",
+                            item.plantId()));
+        }
+        metricsService.recordDigestSent();
+    }
+
+    /**
+     * Обработать неудачу отправки: на 403 помечает юзера blocked, иначе пишет
+     * метрику соответствующей причины. Юзер загружается свежим по chatId —
+     * detached-entity между потоками не тащим.
+     */
+    @Transactional
+    public void onFailed(long chatId, TelegramApiException e) {
+        String errorMessage = e.getMessage();
+        MetricsService.TelegramErrorCode code = MetricsService.TelegramErrorCode.fromMessage(errorMessage);
+
+        if (errorMessage != null && errorMessage.contains("403")) {
+            userRepository.findByTelegramChatId(chatId).ifPresent(user -> {
+                if (!user.isBlocked()) {
+                    log.warn("Bot blocked by user {}, marking as blocked", chatId);
+                    user.setBlocked(true);
+                    userRepository.save(user);
+                }
+            });
+            metricsService.recordNotificationFailed(
+                    MetricsService.CHANNEL_TELEGRAM, MetricsService.FailureReason.BLOCKED);
+        } else {
+            log.error("Failed to send notification to chat {}: {}", chatId, errorMessage);
+            MetricsService.FailureReason reason = switch (code) {
+                case RATE_LIMITED -> MetricsService.FailureReason.RATE_LIMIT;
+                case BAD_REQUEST, FORBIDDEN -> MetricsService.FailureReason.API_ERROR;
+                case OTHER -> MetricsService.FailureReason.OTHER;
+            };
+            metricsService.recordNotificationFailed(MetricsService.CHANNEL_TELEGRAM, reason);
+        }
+    }
+
+    private void saveNotificationLog(Plant plant, TaskType taskType) {
+        NotificationLog logEntry = NotificationLog.builder()
+                .plant(plant)
+                .taskType(taskType)
+                .notificationType(NotificationType.DUE)
+                .sentAt(LocalDateTime.now())
+                .build();
+        notificationLogRepository.save(logEntry);
+    }
+
+    /** Идентификаторы одной задачи дайджеста для записи дедуп-лога. */
+    public record DigestLogItem(long plantId, TaskType taskType) {
+    }
+}

--- a/src/main/java/com/plantcare/bot/service/NotificationSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/NotificationSchedulerService.java
@@ -1,13 +1,10 @@
 package com.plantcare.bot.service;
 
-import com.plantcare.bot.client.TelegramClientProvider;
 import com.plantcare.bot.domain.CareSchedule;
 import com.plantcare.bot.domain.DigestTaskItem;
 import com.plantcare.bot.domain.NotificationDigest;
-import com.plantcare.bot.domain.NotificationLog;
 import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.User;
-import com.plantcare.bot.domain.enums.NotificationType;
 import com.plantcare.bot.domain.enums.TaskType;
 import com.plantcare.bot.metrics.MetricsService;
 import com.plantcare.bot.observability.SentryTags;
@@ -15,7 +12,8 @@ import com.plantcare.bot.observability.SentryTags.Layer;
 import com.plantcare.bot.repository.CareScheduleRepository;
 import com.plantcare.bot.repository.NotificationDigestRepository;
 import com.plantcare.bot.repository.NotificationLogRepository;
-import com.plantcare.bot.repository.UserRepository;
+import com.plantcare.bot.telegram.RateLimitedTelegramSender;
+import com.plantcare.bot.telegram.SendCallbacks;
 import io.micrometer.core.instrument.Timer;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
@@ -27,10 +25,8 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardRow;
-import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
 import java.time.Clock;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -47,8 +43,6 @@ public class NotificationSchedulerService {
     private final CareScheduleRepository careScheduleRepository;
     private final NotificationLogRepository notificationLogRepository;
     private final NotificationDigestRepository notificationDigestRepository;
-    private final UserRepository userRepository;
-    private final TelegramClientProvider telegramClientProvider;
     private final SchedulerHealthTracker schedulerHealthTracker;
     private final com.plantcare.bot.weather.service.WeatherService weatherService;
     private final com.plantcare.bot.seasonal.service.SeasonalIntervalService seasonalIntervalService;
@@ -56,6 +50,8 @@ public class NotificationSchedulerService {
     private final ReminderKeyboardFactory reminderKeyboardFactory;
     private final Clock clock;
     private final MetricsService metricsService;
+    private final RateLimitedTelegramSender telegramSender;
+    private final NotificationDeliveryCallbacks deliveryCallbacks;
 
     @Scheduled(fixedRate = 60_000)
     @Transactional
@@ -317,16 +313,22 @@ public class NotificationSchedulerService {
                 .replyMarkup(keyboard)
                 .build();
 
-        try {
-            telegramClientProvider.getTelegramClient().execute(message);
-            saveNotificationLog(plant, schedule.getTaskType());
-            metricsService.recordNotificationSent(MetricsService.CHANNEL_TELEGRAM, schedule.getTaskType());
-
-            log.info("Sent notification for plant '{}' id={} to user {} (acclimation={})",
-                    plant.getName(), plant.getId(), user.getTelegramChatId(), inAcclimation);
-        } catch (TelegramApiException e) {
-            handleTelegramError(user, e);
-        }
+        // Issue #29: отправка ушла в rate-limited очередь. Bookkeeping (дедуп-лог +
+        // метрики, пометка blocked на 403) выполняется в колбэках на воркер-потоке
+        // очереди вне этой транзакции. Захватываем только примитивные id, чтобы не
+        // тащить detached-entity между потоками. Дедуп-лог пишется по факту успешной
+        // отправки — как и в синхронной версии (очередь дренирует задолго до
+        // следующего 60с-тика, окно дедупа не нарушается).
+        final long plantId = plant.getId();
+        final TaskType taskType = schedule.getTaskType();
+        final long chatId = user.getTelegramChatId();
+        telegramSender.enqueue(message, new SendCallbacks(
+                () -> {
+                    deliveryCallbacks.onSent(plantId, taskType);
+                    log.info("Sent notification for plant id={} to chat {} (acclimation={})",
+                            plantId, chatId, inAcclimation);
+                },
+                e -> deliveryCallbacks.onFailed(chatId, e)));
     }
 
     private String buildAcclimationWateringText(Plant plant) {
@@ -376,37 +378,23 @@ public class NotificationSchedulerService {
                 .replyMarkup(buildDigestKeyboard(savedDigest.getId()))
                 .build();
 
-        try {
-            telegramClientProvider.getTelegramClient().execute(message);
-
-            for (CareSchedule schedule : schedules) {
-                saveNotificationLog(schedule.getPlant(), schedule.getTaskType());
-                // Каждый сгруппированный пуш считаем за отправленное уведомление —
-                // юзер получил один message, но он покрывает N задач, и срезы по
-                // task_type нужны для аналитики «сколько поливных пушей в день».
-                metricsService.recordNotificationSent(
-                        MetricsService.CHANNEL_TELEGRAM, schedule.getTaskType());
-            }
-            // Плюс отдельный счётчик именно для дайджестов — чтобы видеть, какая
-            // доля уведомлений уходит группой, а какая поштучно.
-            metricsService.recordDigestSent();
-
-            log.info("Sent digest id={} with {} tasks to user {}",
-                    savedDigest.getId(), schedules.size(), user.getTelegramChatId());
-        } catch (TelegramApiException e) {
-            handleTelegramError(user, e);
-        }
-    }
-
-    private void saveNotificationLog(Plant plant, TaskType taskType) {
-        NotificationLog logEntry = NotificationLog.builder()
-                .plant(plant)
-                .taskType(taskType)
-                .notificationType(NotificationType.DUE)
-                .sentAt(LocalDateTime.now())
-                .build();
-
-        notificationLogRepository.save(logEntry);
+        // Issue #29: см. комментарий в sendNotification. Каждый сгруппированный пуш
+        // считаем за отправленное уведомление по каждой задаче (срезы по task_type) +
+        // отдельный счётчик дайджестов. Bookkeeping — в колбэке на воркер-потоке.
+        final List<NotificationDeliveryCallbacks.DigestLogItem> logItems = schedules.stream()
+                .map(s -> new NotificationDeliveryCallbacks.DigestLogItem(
+                        s.getPlant().getId(), s.getTaskType()))
+                .toList();
+        final long chatId = user.getTelegramChatId();
+        final long digestId = savedDigest.getId();
+        final int taskCount = schedules.size();
+        telegramSender.enqueue(message, new SendCallbacks(
+                () -> {
+                    deliveryCallbacks.onDigestSent(logItems);
+                    log.info("Sent digest id={} with {} tasks to chat {}",
+                            digestId, taskCount, chatId);
+                },
+                e -> deliveryCallbacks.onFailed(chatId, e)));
     }
 
     private String buildDigestText(List<DigestTaskItem> items) {
@@ -459,29 +447,6 @@ public class NotificationSchedulerService {
             case FERTILIZING -> "удобрить";
             case SOIL_CHECK -> "проверить грунт";
         };
-    }
-
-    private void handleTelegramError(User user, TelegramApiException e) {
-        String errorMessage = e.getMessage();
-        MetricsService.TelegramErrorCode code = MetricsService.TelegramErrorCode.fromMessage(errorMessage);
-        metricsService.recordTelegramApiError(code);
-
-        if (errorMessage != null && errorMessage.contains("403")) {
-            log.warn("Bot blocked by user {}, marking as blocked", user.getTelegramChatId());
-            user.setBlocked(true);
-            userRepository.save(user);
-            metricsService.recordNotificationFailed(
-                    MetricsService.CHANNEL_TELEGRAM, MetricsService.FailureReason.BLOCKED);
-        } else {
-            log.error("Failed to send notification to user {}: {}",
-                    user.getTelegramChatId(), errorMessage, e);
-            MetricsService.FailureReason reason = switch (code) {
-                case RATE_LIMITED -> MetricsService.FailureReason.RATE_LIMIT;
-                case BAD_REQUEST, FORBIDDEN -> MetricsService.FailureReason.API_ERROR;
-                case OTHER -> MetricsService.FailureReason.OTHER;
-            };
-            metricsService.recordNotificationFailed(MetricsService.CHANNEL_TELEGRAM, reason);
-        }
     }
 
     /**

--- a/src/main/java/com/plantcare/bot/service/PhotoProgressSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/PhotoProgressSchedulerService.java
@@ -1,11 +1,12 @@
 package com.plantcare.bot.service;
 
-import com.plantcare.bot.client.TelegramClientProvider;
 import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.observability.SentryTags;
 import com.plantcare.bot.observability.SentryTags.Layer;
 import com.plantcare.bot.repository.PlantRepository;
+import com.plantcare.bot.telegram.RateLimitedTelegramSender;
+import com.plantcare.bot.telegram.SendCallbacks;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +17,6 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardRow;
-import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -55,7 +55,7 @@ public class PhotoProgressSchedulerService {
 
     private final PlantRepository plantRepository;
     private final PhotoProgressService photoProgressService;
-    private final TelegramClientProvider telegramClientProvider;
+    private final RateLimitedTelegramSender telegramSender;
 
     @Scheduled(fixedRate = INTERVAL_MS)
     public void checkPhotoPrompts() {
@@ -83,10 +83,7 @@ public class PhotoProgressSchedulerService {
                         continue;
                     }
 
-                    boolean sent = sendPhotoPrompt(user, plant);
-                    if (sent) {
-                        photoProgressService.markPromptSent(plant.getId(), LocalDateTime.now());
-                    }
+                    enqueuePhotoPrompt(user, plant);
                 } catch (Exception e) {
                     log.error("Failed to handle photo-progress prompt for plant {}: {}",
                             plant.getId(), e.getMessage(), e);
@@ -110,7 +107,13 @@ public class PhotoProgressSchedulerService {
         return plantRepository.findPhotoProgressDue(until, dedupBefore);
     }
 
-    private boolean sendPhotoPrompt(User user, Plant plant) {
+    /**
+     * Issue #29: отправка ушла в rate-limited очередь. Дедуп-пометка
+     * {@code markPromptSent} (идемпотентное обновление {@code last_photo_prompt_sent_at})
+     * переехала в onSuccess-колбэк на воркер-потоке. Захватываем только примитивы,
+     * чтобы не тащить detached Plant/User между потоками.
+     */
+    private void enqueuePhotoPrompt(User user, Plant plant) {
         SendMessage message = SendMessage.builder()
                 .chatId(user.getTelegramChatId().toString())
                 .text("📸 Пора обновить фото для *" + escapeMd(plant.getName()) + "*")
@@ -118,16 +121,14 @@ public class PhotoProgressSchedulerService {
                 .replyMarkup(buildPromptKeyboard(plant.getId()))
                 .build();
 
-        try {
-            telegramClientProvider.getTelegramClient().execute(message);
-            log.info("Photo-progress prompt sent: plant={} user={}",
-                    plant.getId(), user.getTelegramChatId());
-            return true;
-        } catch (TelegramApiException e) {
-            log.error("Failed to send photo-progress prompt (plant={}, user={}): {}",
-                    plant.getId(), user.getTelegramChatId(), e.getMessage());
-            return false;
-        }
+        final long plantId = plant.getId();
+        final long chatId = user.getTelegramChatId();
+        telegramSender.enqueue(message, new SendCallbacks(
+                () -> {
+                    photoProgressService.markPromptSent(plantId, LocalDateTime.now());
+                    log.info("Photo-progress prompt sent: plant={} chat={}", plantId, chatId);
+                },
+                null));
     }
 
     private InlineKeyboardMarkup buildPromptKeyboard(Long plantId) {

--- a/src/main/java/com/plantcare/bot/service/PlantAcclimationService.java
+++ b/src/main/java/com/plantcare/bot/service/PlantAcclimationService.java
@@ -118,6 +118,25 @@ public class PlantAcclimationService {
     }
 
     /**
+     * Id-based вариант {@link #finish(Plant)} для вызова из колбэка очереди
+     * отправки (issue #29): растение перерезолвливается в свежей транзакции
+     * воркер-потока, detached-entity между потоками не тащим.
+     */
+    @Transactional
+    public void finishById(long plantId) {
+        plantRepository.findById(plantId).ifPresent(this::finish);
+    }
+
+    /**
+     * Id-based вариант {@link #scheduleNextCheckin(Plant)} для вызова из колбэка
+     * очереди отправки (issue #29).
+     */
+    @Transactional
+    public void scheduleNextCheckinById(long plantId) {
+        plantRepository.findById(plantId).ifPresent(this::scheduleNextCheckin);
+    }
+
+    /**
      * Прочитать растение по plantId БЕЗ привязки к user (для scheduler'а).
      */
     @Transactional(readOnly = true)

--- a/src/main/java/com/plantcare/bot/service/PlantAnniversaryScheduler.java
+++ b/src/main/java/com/plantcare/bot/service/PlantAnniversaryScheduler.java
@@ -1,16 +1,16 @@
 package com.plantcare.bot.service;
 
-import com.plantcare.bot.client.TelegramClientProvider;
 import com.plantcare.bot.observability.SentryTags;
 import com.plantcare.bot.observability.SentryTags.Layer;
 import com.plantcare.bot.repository.UserRepository;
+import com.plantcare.bot.telegram.RateLimitedTelegramSender;
+import com.plantcare.bot.telegram.SendCallbacks;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
-import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -50,7 +50,7 @@ public class PlantAnniversaryScheduler {
 
     private final PlantAnniversaryService plantAnniversaryService;
     private final UserRepository userRepository;
-    private final TelegramClientProvider telegramClientProvider;
+    private final RateLimitedTelegramSender telegramSender;
     private final Clock clock;
 
     /**
@@ -77,16 +77,7 @@ public class PlantAnniversaryScheduler {
                     if (!isMorningInUserZone(anniversary.userId(), now)) {
                         continue;
                     }
-                    if (sendAnniversary(anniversary)) {
-                        plantAnniversaryService.markSent(
-                                anniversary.plantId(),
-                                anniversary.anniversaryYear(),
-                                now);
-                        log.info("Anniversary sent: plant={} years={} user={}",
-                                anniversary.plantId(),
-                                anniversary.yearsOld(),
-                                anniversary.telegramChatId());
-                    }
+                    enqueueAnniversary(anniversary, now);
                 } catch (Exception e) {
                     log.error("Failed to handle anniversary for plant {}: {}",
                             anniversary.plantId(), e.getMessage(), e);
@@ -111,19 +102,28 @@ public class PlantAnniversaryScheduler {
                 .orElse(false);
     }
 
-    private boolean sendAnniversary(PlantAnniversaryService.Anniversary anniversary) {
+    /**
+     * Issue #29: отправка ушла в rate-limited очередь. Пометка «отправлено»
+     * ({@code markSent} — идемпотентный PK-based upsert) переехала в onSuccess-колбэк
+     * на воркер-потоке. Захватываем только примитивы из снимка anniversary.
+     */
+    private void enqueueAnniversary(PlantAnniversaryService.Anniversary anniversary, Instant now) {
         SendMessage message = SendMessage.builder()
                 .chatId(anniversary.telegramChatId().toString())
                 .text(anniversary.buildText())
                 .build();
-        try {
-            telegramClientProvider.getTelegramClient().execute(message);
-            return true;
-        } catch (TelegramApiException e) {
-            log.error("Failed to send anniversary push (plant={}, chat={}): {}",
-                    anniversary.plantId(), anniversary.telegramChatId(), e.getMessage());
-            return false;
-        }
+
+        final Long plantId = anniversary.plantId();
+        final int anniversaryYear = anniversary.anniversaryYear();
+        final int yearsOld = anniversary.yearsOld();
+        final Long chatId = anniversary.telegramChatId();
+        telegramSender.enqueue(message, new SendCallbacks(
+                () -> {
+                    plantAnniversaryService.markSent(plantId, anniversaryYear, now);
+                    log.info("Anniversary sent: plant={} years={} chat={}",
+                            plantId, yearsOld, chatId);
+                },
+                null));
     }
 
     private static ZoneId safeZone(String tz) {

--- a/src/main/java/com/plantcare/bot/service/VacationSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/VacationSchedulerService.java
@@ -1,6 +1,5 @@
 package com.plantcare.bot.service;
 
-import com.plantcare.bot.client.TelegramClientProvider;
 import com.plantcare.bot.domain.CareSchedule;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.TaskType;
@@ -8,6 +7,7 @@ import com.plantcare.bot.observability.SentryTags;
 import com.plantcare.bot.observability.SentryTags.Layer;
 import com.plantcare.bot.repository.CareScheduleRepository;
 import com.plantcare.bot.repository.UserRepository;
+import com.plantcare.bot.telegram.RateLimitedTelegramSender;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +19,6 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardRow;
-import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -55,7 +54,7 @@ public class VacationSchedulerService {
 
     private final UserRepository userRepository;
     private final CareScheduleRepository careScheduleRepository;
-    private final TelegramClientProvider telegramClientProvider;
+    private final RateLimitedTelegramSender telegramSender;
     private final Clock clock;
     /**
      * Берём self из контекста, чтобы @Transactional-методы внутри одного бина
@@ -177,13 +176,10 @@ public class VacationSchedulerService {
                 .replyMarkup(keyboard)
                 .build();
 
-        try {
-            telegramClientProvider.getTelegramClient().execute(message);
-            log.info("Tomorrow-back vacation reminder sent to chat {}", chatId);
-        } catch (TelegramApiException e) {
-            log.error("Failed to send tomorrow-back reminder to {}: {}",
-                    chatId, e.getMessage(), e);
-        }
+        // Issue #29: fire-and-forget через rate-limited очередь. Bookkeeping тут нет —
+        // ошибки логируются и метрятся внутри очереди.
+        telegramSender.enqueue(message);
+        log.info("Tomorrow-back vacation reminder enqueued for chat {}", chatId);
     }
 
     private void sendWelcomeBackMessage(WelcomeBackPayload payload) {
@@ -192,14 +188,10 @@ public class VacationSchedulerService {
                 .text(buildWelcomeBackText(payload.overdue()))
                 .build();
 
-        try {
-            telegramClientProvider.getTelegramClient().execute(message);
-            log.info("Welcome-back sent to chat {} (overdue={})",
-                    payload.chatId(), payload.overdue().size());
-        } catch (TelegramApiException e) {
-            log.error("Failed to send welcome-back to {}: {}",
-                    payload.chatId(), e.getMessage(), e);
-        }
+        // Issue #29: fire-and-forget через rate-limited очередь.
+        telegramSender.enqueue(message);
+        log.info("Welcome-back enqueued for chat {} (overdue={})",
+                payload.chatId(), payload.overdue().size());
     }
 
     private String buildWelcomeBackText(List<OverdueItem> overdue) {

--- a/src/main/java/com/plantcare/bot/telegram/RateLimitedTelegramSender.java
+++ b/src/main/java/com/plantcare/bot/telegram/RateLimitedTelegramSender.java
@@ -1,0 +1,192 @@
+package com.plantcare.bot.telegram;
+
+import com.plantcare.bot.client.TelegramClientProvider;
+import com.plantcare.bot.config.TelegramRateLimitProperties;
+import com.plantcare.bot.metrics.MetricsService;
+import com.plantcare.bot.metrics.MetricsService.TelegramErrorCode;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Медиатор отправки сообщений Telegram с rate-limiting (issue #29).
+ *
+ * <p>Используется только массовыми путями (шедулеры). Интерактивные хендлеры
+ * команд/колбэков, а также {@code AdminBroadcastService} (со своим троттлингом
+ * и синхронными результатами) сюда НЕ переводятся.
+ *
+ * <p>Модель: {@link #enqueue} кладёт сообщение в ограниченную очередь и сразу
+ * возвращает управление. Один выделенный daemon-поток дренирует очередь со
+ * скоростью ≤ {@code permitsPerSecond} (через {@link TokenBucketRateLimiter}),
+ * а на 429 ждёт {@code retry-after} и повторяет до {@code maxRetries} раз.
+ *
+ * <p>Колбэки {@link SendCallbacks} выполняются НА ВОРКЕР-ПОТОКЕ после резолва
+ * отправки — вне транзакции вызывающего шедулера. См. doc к {@link SendCallbacks}.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RateLimitedTelegramSender {
+
+    /**
+     * Парсер retry-after из текста {@code TelegramApiException}. Совпадает с
+     * подходом {@code AdminBroadcastService.extractRetryAfter}: библиотека
+     * форматирует ошибку строкой, тянем число после «retry after».
+     */
+    private static final Pattern RETRY_AFTER_PATTERN =
+            Pattern.compile("retry\\s*after\\s*(\\d+)", Pattern.CASE_INSENSITIVE);
+
+    private final TelegramClientProvider telegramClientProvider;
+    private final TokenBucketRateLimiter rateLimiter;
+    private final Sleeper sleeper;
+    private final TelegramRateLimitProperties properties;
+    private final MetricsService metricsService;
+
+    private LinkedBlockingQueue<QueuedMessage> queue;
+    private Thread worker;
+    private volatile boolean running;
+
+    @PostConstruct
+    void start() {
+        this.queue = new LinkedBlockingQueue<>(Math.max(1, properties.getQueueCapacity()));
+        this.running = true;
+        this.worker = new Thread(this::drainLoop, "tg-send-queue");
+        this.worker.setDaemon(true);
+        this.worker.start();
+        log.info("Telegram send queue started: permitsPerSecond={}, queueCapacity={}, maxRetries={}",
+                properties.getPermitsPerSecond(), properties.getQueueCapacity(), properties.getMaxRetries());
+    }
+
+    @PreDestroy
+    void stop() {
+        running = false;
+        if (worker != null) {
+            worker.interrupt();
+        }
+        log.info("Telegram send queue stopping");
+    }
+
+    /** Fire-and-forget: ошибки только логируются + метрика, без колбэков. */
+    public void enqueue(SendMessage message) {
+        enqueue(message, SendCallbacks.none());
+    }
+
+    /**
+     * Поставить сообщение в очередь с колбэками. Колбэки выполнятся на воркер-потоке
+     * после резолва отправки. При переполнении очереди сообщение дропается с warn.
+     */
+    public void enqueue(SendMessage message, SendCallbacks callbacks) {
+        SendCallbacks effective = callbacks != null ? callbacks : SendCallbacks.none();
+        boolean accepted = queue.offer(new QueuedMessage(message, effective));
+        if (!accepted) {
+            log.warn("Telegram send queue is full (capacity={}), dropping message to chat {}",
+                    properties.getQueueCapacity(), message.getChatId());
+            metricsService.recordNotificationFailed(
+                    MetricsService.CHANNEL_TELEGRAM, MetricsService.FailureReason.OTHER);
+        }
+    }
+
+    private void drainLoop() {
+        while (running) {
+            QueuedMessage queued;
+            try {
+                queued = queue.poll(1, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+            if (queued == null) {
+                continue;
+            }
+            try {
+                long waitMillis = rateLimiter.reserveNextPermitMillis();
+                if (waitMillis > 0) {
+                    sleeper.sleep(waitMillis);
+                }
+                sendWithRetry(queued.message(), queued.callbacks());
+            } catch (InterruptedException e) {
+                // Прерывание = graceful shutdown: восстанавливаем флаг и выходим.
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Throwable t) {
+                // Любая иная ошибка (rate limiter, send, или колбэк с DB-транзакцией:
+                // DataAccessException / FK-нарушение из-за удалённой сущности и т.п.)
+                // НЕ должна убить единственный воркер-поток — иначе вся очередь
+                // навсегда встаёт. Логируем, метрика, идём к следующему сообщению.
+                log.error("send-queue worker swallowed error for chatId={}",
+                        queued.message().getChatId(), t);
+                metricsService.recordNotificationFailed(
+                        MetricsService.CHANNEL_TELEGRAM, MetricsService.FailureReason.OTHER);
+            }
+        }
+        log.info("Telegram send queue worker exited (drained={} remaining)", queue.size());
+    }
+
+    /**
+     * Отправка с обработкой 429. Package-private, чтобы юнит-тест мог дёргать
+     * напрямую с замоканным {@link TelegramClientProvider} и стаб-{@link Sleeper}.
+     */
+    void sendWithRetry(SendMessage message, SendCallbacks callbacks) throws InterruptedException {
+        int maxRetries = Math.max(0, properties.getMaxRetries());
+        int attempt = 0;
+        while (true) {
+            try {
+                telegramClientProvider.getTelegramClient().execute(message);
+                callbacks.runSuccess();
+                return;
+            } catch (TelegramApiException e) {
+                String msg = e.getMessage();
+                boolean rateLimited = TelegramErrorCode.fromMessage(msg) == TelegramErrorCode.RATE_LIMITED;
+                if (rateLimited && attempt < maxRetries) {
+                    attempt++;
+                    long retryAfter = extractRetryAfterSeconds(msg);
+                    log.warn("Rate-limited (429) sending to chat {}: retry {}/{} after {}s",
+                            message.getChatId(), attempt, maxRetries, retryAfter);
+                    metricsService.recordTelegramApiError(TelegramErrorCode.RATE_LIMITED);
+                    sleeper.sleep(retryAfter * 1000L);
+                    continue;
+                }
+                // Либо неретраябельная ошибка (403/400/...), либо исчерпали ретраи 429.
+                metricsService.recordTelegramApiError(TelegramErrorCode.fromMessage(msg));
+                log.warn("Send failed for chat {} (attempts={}, rateLimited={}): {}",
+                        message.getChatId(), attempt + 1, rateLimited, msg);
+                callbacks.runFailure(e);
+                return;
+            }
+        }
+    }
+
+    /**
+     * Достаёт {@code retry_after} из текста исключения. Если число не нашлось —
+     * fallback {@code defaultRetryAfterSeconds} из конфигурации.
+     */
+    private long extractRetryAfterSeconds(String errorMessage) {
+        if (errorMessage != null) {
+            Matcher m = RETRY_AFTER_PATTERN.matcher(errorMessage);
+            if (m.find()) {
+                try {
+                    long parsed = Long.parseLong(m.group(1));
+                    // Капаем, чтобы один 429 с огромным retry-after не усыпил
+                    // единственный воркер на часы и не застопорил всю очередь.
+                    return Math.min(parsed, properties.getMaxRetryAfterSeconds());
+                } catch (NumberFormatException ignored) {
+                    // упадём в fallback ниже
+                }
+            }
+        }
+        return Math.max(0, properties.getDefaultRetryAfterSeconds());
+    }
+
+    /** Элемент очереди: сообщение + его колбэки. */
+    private record QueuedMessage(SendMessage message, SendCallbacks callbacks) {
+    }
+}

--- a/src/main/java/com/plantcare/bot/telegram/SendCallbacks.java
+++ b/src/main/java/com/plantcare/bot/telegram/SendCallbacks.java
@@ -1,0 +1,39 @@
+package com.plantcare.bot.telegram;
+
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+import java.util.function.Consumer;
+
+/**
+ * Колбэки, которые воркер очереди вызывает ПОСЛЕ резолва отправки (issue #29).
+ *
+ * <p>Выполняются на воркер-потоке очереди, ВНЕ Spring-управляемой транзакции
+ * шедулера. Поэтому в них нельзя протаскивать detached JPA-entity — захватывайте
+ * только примитивные идентификаторы и перерезолвливайте сущности в собственной
+ * транзакции коллаборатора.
+ *
+ * @param onSuccess вызывается после успешной отправки (может быть {@code null})
+ * @param onFailure вызывается после неретраябельной ошибки или исчерпания ретраев
+ *                  (может быть {@code null})
+ */
+public record SendCallbacks(Runnable onSuccess, Consumer<TelegramApiException> onFailure) {
+
+    private static final SendCallbacks NONE = new SendCallbacks(null, null);
+
+    /** Колбэки-заглушки: ничего не делают. */
+    public static SendCallbacks none() {
+        return NONE;
+    }
+
+    void runSuccess() {
+        if (onSuccess != null) {
+            onSuccess.run();
+        }
+    }
+
+    void runFailure(TelegramApiException e) {
+        if (onFailure != null) {
+            onFailure.accept(e);
+        }
+    }
+}

--- a/src/main/java/com/plantcare/bot/telegram/Sleeper.java
+++ b/src/main/java/com/plantcare/bot/telegram/Sleeper.java
@@ -1,0 +1,26 @@
+package com.plantcare.bot.telegram;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Тонкая абстракция над {@link Thread#sleep(long)} (issue #29).
+ *
+ * <p>Нужна исключительно для тестируемости: путь отправки с ретраями на 429 и
+ * пауза token bucket'а должны проверяться юнит-тестом без реальных задержек в
+ * десятки секунд. В проде работает дефолтный бин {@link Default}.
+ */
+public interface Sleeper {
+
+    void sleep(long millis) throws InterruptedException;
+
+    /** Боевая реализация — обычный {@link Thread#sleep(long)}. */
+    @Component
+    class Default implements Sleeper {
+        @Override
+        public void sleep(long millis) throws InterruptedException {
+            if (millis > 0) {
+                Thread.sleep(millis);
+            }
+        }
+    }
+}

--- a/src/main/java/com/plantcare/bot/telegram/TokenBucketRateLimiter.java
+++ b/src/main/java/com/plantcare/bot/telegram/TokenBucketRateLimiter.java
@@ -1,0 +1,85 @@
+package com.plantcare.bot.telegram;
+
+import com.plantcare.bot.config.TelegramRateLimitProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+
+/**
+ * Token bucket для соблюдения лимита Telegram на массовую отправку (issue #29).
+ *
+ * <p>Ёмкость ведра = {@code permitsPerSecond}, пополняется с той же скоростью
+ * ({@code permitsPerSecond} токенов в секунду). Метод {@link #reserveNextPermitMillis()}
+ * резервирует один токен и возвращает, сколько миллисекунд вызывающему нужно
+ * подождать перед его использованием (0 — токен доступен немедленно).
+ *
+ * <p>Время берётся только из инжектируемого {@link Clock} — никаких прямых
+ * {@code Instant.now()}, чтобы тест мог детерминированно прогнать пополнение
+ * через мутабельный тест-clock.
+ *
+ * <p>Потокобезопасность через {@code synchronized}: очередь дренирует один
+ * воркер-поток, конкуренции почти нет, простота важнее микро-оптимизации.
+ */
+@Component
+@RequiredArgsConstructor
+public class TokenBucketRateLimiter {
+
+    private final TelegramRateLimitProperties properties;
+    private final Clock clock;
+
+    /**
+     * Доступные токены (дробные — накапливаются между вызовами). Изначально ведро
+     * полное, чтобы первый всплеск до {@code permitsPerSecond} ушёл без задержки.
+     */
+    private double availableTokens;
+
+    /** Время последнего пополнения, мс эпохи (из {@code clock}). */
+    private long lastRefillMillis = Long.MIN_VALUE;
+
+    /**
+     * Зарезервировать следующий токен. Возвращает сколько миллисекунд подождать
+     * до момента, когда зарезервированный токен станет доступен (0 — сейчас).
+     *
+     * <p><b>Инвариант единственного потребителя:</b> метод рассчитан на ОДНОГО
+     * потребителя (воркер-поток очереди), который ОБЯЗАТЕЛЬНО проспит возвращённую
+     * паузу перед следующим вызовом. {@code lastRefillMillis} не двигается на
+     * зарезервированный «будущий» слот — баланс лишь уходит в минус «в долг».
+     * Если бы вызовов было несколько подряд без ожидания (или из нескольких
+     * потоков), пополнение посчиталось бы заново от того же момента и реальная
+     * скорость превысила бы {@code permitsPerSecond}.
+     */
+    public synchronized long reserveNextPermitMillis() {
+        long permitsPerSecond = Math.max(1, properties.getPermitsPerSecond());
+        long nowMillis = clock.millis();
+
+        if (lastRefillMillis == Long.MIN_VALUE) {
+            // Первый вызов: ведро полное.
+            lastRefillMillis = nowMillis;
+            availableTokens = permitsPerSecond;
+        } else {
+            double elapsedSeconds = (nowMillis - lastRefillMillis) / 1000.0;
+            if (elapsedSeconds > 0) {
+                availableTokens = Math.min(
+                        permitsPerSecond,
+                        availableTokens + elapsedSeconds * permitsPerSecond);
+                lastRefillMillis = nowMillis;
+            }
+        }
+
+        if (availableTokens >= 1.0) {
+            availableTokens -= 1.0;
+            return 0L;
+        }
+
+        // Не хватает целого токена — сколько мс до накопления недостающей доли.
+        double missing = 1.0 - availableTokens;
+        double secondsToWait = missing / permitsPerSecond;
+        long waitMillis = (long) Math.ceil(secondsToWait * 1000.0);
+
+        // Резервируем токен «в долг»: уводим баланс в минус, чтобы следующий
+        // вызов считал паузу от уже зарезервированного момента, а не повторно.
+        availableTokens -= 1.0;
+        return waitMillis;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,6 +107,13 @@ telegram:
     token: ${TELEGRAM_BOT_TOKEN:}
     username: ${TELEGRAM_BOT_USERNAME:}
     enabled: ${TELEGRAM_BOT_ENABLED:true}
+  # Issue #29: очередь исходящих сообщений с rate-limiting под лимит Telegram (~30/sec).
+  rate-limit:
+    permits-per-second: ${TELEGRAM_RATE_LIMIT_PERMITS_PER_SECOND:25}
+    queue-capacity: ${TELEGRAM_RATE_LIMIT_QUEUE_CAPACITY:10000}
+    max-retries: ${TELEGRAM_RATE_LIMIT_MAX_RETRIES:3}
+    default-retry-after-seconds: ${TELEGRAM_RATE_LIMIT_DEFAULT_RETRY_AFTER_SECONDS:1}
+    max-retry-after-seconds: ${TELEGRAM_RATE_LIMIT_MAX_RETRY_AFTER_SECONDS:60}
 
 logging:
   level:

--- a/src/test/java/com/plantcare/bot/service/MonthlyReportSchedulerTest.java
+++ b/src/test/java/com/plantcare/bot/service/MonthlyReportSchedulerTest.java
@@ -1,18 +1,18 @@
 package com.plantcare.bot.service;
 
-import com.plantcare.bot.client.TelegramClientProvider;
 import com.plantcare.bot.service.MonthlyReportService.MonthlyReport;
 import com.plantcare.bot.service.MonthlyReportService.OldestPlant;
+import com.plantcare.bot.telegram.RateLimitedTelegramSender;
+import com.plantcare.bot.telegram.SendCallbacks;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
-import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
-import org.telegram.telegrambots.meta.generics.TelegramClient;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -20,6 +20,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -27,36 +28,34 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit-тесты {@link MonthlyReportScheduler} (issue #137) с фиксированным {@link Clock}.
- * Внешний мир (Telegram) замокан; сервис — мок, чтобы изолировать оркестрацию
- * шедулера: отправку отобранных кандидатов и порядок «send → markSent».
+ * Unit-тесты {@link MonthlyReportScheduler} (issue #137) после перевода на
+ * rate-limited очередь (issue #29). Шедулер кладёт отчёт в
+ * {@link RateLimitedTelegramSender#enqueue}; пометка {@code markSent} переехала
+ * в onSuccess-колбэк. Тесты проверяют постановку в очередь и маршрутизацию
+ * пометки через захваченные {@link SendCallbacks}.
  *
- * <p>Окно «1-е число + утро 09:00–10:00 в TZ юзера» здесь НЕ проверяется — оно
- * переехало внутрь {@link MonthlyReportService#findDueReports} (перед агрегатами),
- * и покрывается {@code MonthlyReportServiceTest} на Testcontainers. Шедулер
- * отправляет всё, что вернул {@code findDueReports}, и сам окно не считает.
+ * <p>Окно «1-е число + утро» считается внутри {@link MonthlyReportService#findDueReports}
+ * и покрывается отдельным Testcontainers-тестом — шедулер отправляет всё, что вернул сервис.
  */
-@DisplayName("MonthlyReportScheduler — оркестрация отправки (issue #137)")
+@DisplayName("MonthlyReportScheduler — оркестрация отправки (issue #137 / #29)")
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class MonthlyReportSchedulerTest {
 
     @Mock private MonthlyReportService monthlyReportService;
-    @Mock private TelegramClientProvider telegramClientProvider;
-    @Mock private TelegramClient telegramClient;
+    @Mock private RateLimitedTelegramSender telegramSender;
 
     private MonthlyReportScheduler newScheduler(Clock clock) {
-        when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
-        return new MonthlyReportScheduler(
-                monthlyReportService, telegramClientProvider, clock);
+        return new MonthlyReportScheduler(monthlyReportService, telegramSender, clock);
     }
 
     @Test
-    @DisplayName("should_send_and_mark_when_report_is_due")
-    void should_send_and_mark_when_report_is_due() throws TelegramApiException {
+    @DisplayName("should_enqueue_and_mark_on_success_when_report_is_due")
+    void should_enqueue_and_mark_on_success_when_report_is_due() {
         // arrange: сервис уже отобрал кандидата (окно посчитано внутри сервиса).
         Instant now = Instant.parse("2026-05-01T06:30:00Z");
         MonthlyReportScheduler scheduler = newScheduler(fixed(now));
@@ -67,34 +66,42 @@ class MonthlyReportSchedulerTest {
         // act
         scheduler.tick();
 
-        // assert
-        verify(telegramClient, times(1)).execute(any(SendMessage.class));
+        // assert: сообщение поставлено в очередь, markSent ещё НЕ вызван (только в колбэке).
+        ArgumentCaptor<SendMessage> messageCaptor = ArgumentCaptor.forClass(SendMessage.class);
+        ArgumentCaptor<SendCallbacks> callbacksCaptor = ArgumentCaptor.forClass(SendCallbacks.class);
+        verify(telegramSender, times(1)).enqueue(messageCaptor.capture(), callbacksCaptor.capture());
+        assertThat(messageCaptor.getValue().getChatId()).isEqualTo("555");
+        verify(monthlyReportService, never()).markSent(anyLong(), anyInt(), any(Instant.class));
+
+        runSuccess(callbacksCaptor.getValue());
+
         verify(monthlyReportService).markSent(eq(1L), eq(202604), eq(now));
     }
 
     @Test
-    @DisplayName("should_not_mark_when_telegram_send_fails")
-    void should_not_mark_when_telegram_send_fails() throws TelegramApiException {
-        // arrange: кандидат есть, но Telegram падает → markSent НЕ зовём.
+    @DisplayName("should_not_mark_when_send_fails_callback")
+    void should_not_mark_when_send_fails_callback() {
+        // arrange: кандидат есть; отправка проваливается → markSent НЕ зовём.
         Instant now = Instant.parse("2026-05-01T06:30:00Z");
         MonthlyReportScheduler scheduler = newScheduler(fixed(now));
-
         when(monthlyReportService.findDueReports(now))
                 .thenReturn(List.of(report(1L, 555L, 202604)));
-        when(telegramClient.execute(any(SendMessage.class)))
-                .thenThrow(new TelegramApiException("boom"));
 
-        // act
         scheduler.tick();
 
-        // assert
-        verify(telegramClient, times(1)).execute(any(SendMessage.class));
+        ArgumentCaptor<SendCallbacks> callbacksCaptor = ArgumentCaptor.forClass(SendCallbacks.class);
+        verify(telegramSender).enqueue(any(SendMessage.class), callbacksCaptor.capture());
+
+        // onFailure=null для месячного отчёта — провал не должен ни ронять, ни помечать.
+        runFailure(callbacksCaptor.getValue(),
+                new org.telegram.telegrambots.meta.exceptions.TelegramApiException("boom"));
+
         verify(monthlyReportService, never()).markSent(anyLong(), anyInt(), any(Instant.class));
     }
 
     @Test
     @DisplayName("should_do_nothing_when_no_due_reports")
-    void should_do_nothing_when_no_due_reports() throws TelegramApiException {
+    void should_do_nothing_when_no_due_reports() {
         // arrange
         Instant now = Instant.parse("2026-05-01T06:30:00Z");
         MonthlyReportScheduler scheduler = newScheduler(fixed(now));
@@ -104,35 +111,51 @@ class MonthlyReportSchedulerTest {
         scheduler.tick();
 
         // assert
-        verify(telegramClient, never()).execute(any(SendMessage.class));
+        verifyNoInteractions(telegramSender);
         verify(monthlyReportService, never()).markSent(anyLong(), anyInt(), any(Instant.class));
     }
 
     @Test
-    @DisplayName("should_continue_when_telegram_fails_for_one_user")
-    void should_continue_when_telegram_fails_for_one_user() throws TelegramApiException {
-        // arrange: два кандидата, у первого Telegram падает — второй всё равно
-        // обрабатывается и помечается.
+    @DisplayName("should_enqueue_every_candidate_and_mark_each_independently")
+    void should_enqueue_every_candidate_and_mark_each_independently() {
+        // arrange: два кандидата — каждый ставится в очередь, каждый помечается своим колбэком.
         Instant now = Instant.parse("2026-05-01T06:30:00Z");
         MonthlyReportScheduler scheduler = newScheduler(fixed(now));
-
         when(monthlyReportService.findDueReports(now)).thenReturn(List.of(
                 report(1L, 555L, 202604),
                 report(2L, 666L, 202604)));
-        when(telegramClient.execute(any(SendMessage.class)))
-                .thenThrow(new TelegramApiException("boom"))
-                .thenReturn(null);
 
         // act
         scheduler.tick();
 
         // assert
-        verify(telegramClient, times(2)).execute(any(SendMessage.class));
-        verify(monthlyReportService, never()).markSent(eq(1L), anyInt(), any(Instant.class));
+        ArgumentCaptor<SendCallbacks> callbacksCaptor = ArgumentCaptor.forClass(SendCallbacks.class);
+        verify(telegramSender, times(2)).enqueue(any(SendMessage.class), callbacksCaptor.capture());
+
+        List<SendCallbacks> allCallbacks = callbacksCaptor.getAllValues();
+        runSuccess(allCallbacks.get(0));
+        runSuccess(allCallbacks.get(1));
+
+        verify(monthlyReportService).markSent(eq(1L), eq(202604), eq(now));
         verify(monthlyReportService).markSent(eq(2L), eq(202604), eq(now));
     }
 
     // ===================== helpers =====================
+
+    /** Эмулирует вызов onSuccess воркером очереди (с null-guard, как в проде). */
+    private static void runSuccess(SendCallbacks callbacks) {
+        if (callbacks.onSuccess() != null) {
+            callbacks.onSuccess().run();
+        }
+    }
+
+    /** Эмулирует вызов onFailure воркером очереди (с null-guard, как в проде). */
+    private static void runFailure(SendCallbacks callbacks,
+                                   org.telegram.telegrambots.meta.exceptions.TelegramApiException e) {
+        if (callbacks.onFailure() != null) {
+            callbacks.onFailure().accept(e);
+        }
+    }
 
     private static Clock fixed(Instant instant) {
         return Clock.fixed(instant, ZoneOffset.UTC);

--- a/src/test/java/com/plantcare/bot/service/NotificationDeliveryCallbacksTest.java
+++ b/src/test/java/com/plantcare/bot/service/NotificationDeliveryCallbacksTest.java
@@ -1,0 +1,167 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.Location;
+import com.plantcare.bot.domain.NotificationLog;
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.NotificationType;
+import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.metrics.MetricsService;
+import com.plantcare.bot.repository.LocationRepository;
+import com.plantcare.bot.repository.NotificationLogRepository;
+import com.plantcare.bot.repository.PlantRepository;
+import com.plantcare.bot.repository.UserRepository;
+import com.plantcare.bot.support.IntegrationTestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Интеграционные тесты {@link NotificationDeliveryCallbacks} (issue #29) на реальном
+ * Postgres через Testcontainers. Колбэки доставки пишут дедуп-лог и помечают юзера
+ * blocked — это касается БД, поэтому репозитории НЕ мокаются (CLAUDE.md). Замокан
+ * только {@link MetricsService} (внешний счётчик, не БД).
+ */
+@DisplayName("NotificationDeliveryCallbacks — bookkeeping доставки (issue #29)")
+class NotificationDeliveryCallbacksTest extends IntegrationTestBase {
+
+    @Autowired private NotificationDeliveryCallbacks callbacks;
+    @Autowired private UserRepository userRepository;
+    @Autowired private LocationRepository locationRepository;
+    @Autowired private PlantRepository plantRepository;
+    @Autowired private NotificationLogRepository notificationLogRepository;
+
+    @MockitoBean private MetricsService metricsService;
+
+    @AfterEach
+    void cleanup() {
+        notificationLogRepository.deleteAll();
+        plantRepository.deleteAll();
+        locationRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("should_write_dedup_log_and_record_metric_when_on_sent")
+    void should_write_dedup_log_and_record_metric_when_on_sent() {
+        // arrange
+        Plant plant = savedPlant(savedUser(100L));
+
+        // act
+        callbacks.onSent(plant.getId(), TaskType.WATERING);
+
+        // assert
+        List<NotificationLog> logs = notificationLogRepository.findAll();
+        assertThat(logs).hasSize(1);
+        NotificationLog log = logs.get(0);
+        assertThat(log.getPlant().getId()).isEqualTo(plant.getId());
+        assertThat(log.getTaskType()).isEqualTo(TaskType.WATERING);
+        assertThat(log.getNotificationType()).isEqualTo(NotificationType.DUE);
+
+        verify(metricsService).recordNotificationSent(MetricsService.CHANNEL_TELEGRAM, TaskType.WATERING);
+    }
+
+    @Test
+    @DisplayName("should_write_one_log_per_task_and_record_digest_when_on_digest_sent")
+    void should_write_one_log_per_task_and_record_digest_when_on_digest_sent() {
+        // arrange
+        Plant plant = savedPlant(savedUser(101L));
+        List<NotificationDeliveryCallbacks.DigestLogItem> items = List.of(
+                new NotificationDeliveryCallbacks.DigestLogItem(plant.getId(), TaskType.WATERING),
+                new NotificationDeliveryCallbacks.DigestLogItem(plant.getId(), TaskType.MISTING));
+
+        // act
+        callbacks.onDigestSent(items);
+
+        // assert
+        assertThat(notificationLogRepository.findAll())
+                .extracting(NotificationLog::getTaskType)
+                .containsExactlyInAnyOrder(TaskType.WATERING, TaskType.MISTING);
+
+        verify(metricsService).recordNotificationSent(MetricsService.CHANNEL_TELEGRAM, TaskType.WATERING);
+        verify(metricsService).recordNotificationSent(MetricsService.CHANNEL_TELEGRAM, TaskType.MISTING);
+        verify(metricsService).recordDigestSent();
+    }
+
+    @Test
+    @DisplayName("should_mark_user_blocked_and_record_blocked_when_on_failed_with_403")
+    void should_mark_user_blocked_and_record_blocked_when_on_failed_with_403() {
+        // arrange
+        User user = savedUser(102L);
+        assertThat(user.isBlocked()).isFalse();
+
+        // act
+        callbacks.onFailed(user.getTelegramChatId(),
+                new TelegramApiException("Forbidden: bot was blocked by the user [403]"));
+
+        // assert
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(reloaded.isBlocked()).isTrue();
+        verify(metricsService).recordNotificationFailed(
+                MetricsService.CHANNEL_TELEGRAM, MetricsService.FailureReason.BLOCKED);
+    }
+
+    @Test
+    @DisplayName("should_not_block_user_and_record_other_when_on_failed_with_non_403")
+    void should_not_block_user_and_record_other_when_on_failed_with_non_403() {
+        // arrange
+        User user = savedUser(103L);
+
+        // act
+        callbacks.onFailed(user.getTelegramChatId(), new TelegramApiException("Network timeout"));
+
+        // assert
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(reloaded.isBlocked()).isFalse();
+        verify(metricsService).recordNotificationFailed(
+                MetricsService.CHANNEL_TELEGRAM, MetricsService.FailureReason.OTHER);
+    }
+
+    @Test
+    @DisplayName("should_not_throw_when_on_failed_and_user_not_found_by_chat_id")
+    void should_not_throw_when_on_failed_and_user_not_found_by_chat_id() {
+        // arrange: ни одного юзера с таким chatId нет.
+        long unknownChatId = 999_999L;
+
+        // act + assert: отсутствие записи не должно ронять колбэк, метрика всё равно пишется.
+        assertThatNoException().isThrownBy(() ->
+                callbacks.onFailed(unknownChatId,
+                        new TelegramApiException("Forbidden: bot was blocked by the user [403]")));
+
+        verify(metricsService).recordNotificationFailed(
+                MetricsService.CHANNEL_TELEGRAM, MetricsService.FailureReason.BLOCKED);
+    }
+
+    // ===== helpers =====
+
+    private User savedUser(long chatId) {
+        return userRepository.save(User.builder()
+                .telegramChatId(chatId)
+                .timezone("UTC")
+                .blocked(false)
+                .build());
+    }
+
+    private Plant savedPlant(User user) {
+        Location location = locationRepository.save(Location.builder()
+                .user(user)
+                .name(Location.DEFAULT_NAME)
+                .emoji(Location.DEFAULT_EMOJI)
+                .defaultLocation(true)
+                .build());
+        return plantRepository.save(Plant.builder()
+                .user(user)
+                .location(location)
+                .name("Монстера")
+                .build());
+    }
+}

--- a/src/test/java/com/plantcare/bot/service/NotificationSchedulerServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/NotificationSchedulerServiceTest.java
@@ -1,18 +1,17 @@
 package com.plantcare.bot.service;
 
-import com.plantcare.bot.client.TelegramClientProvider;
 import com.plantcare.bot.domain.CareSchedule;
 import com.plantcare.bot.domain.NotificationDigest;
-import com.plantcare.bot.domain.NotificationLog;
 import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.User;
-import com.plantcare.bot.domain.enums.NotificationType;
 import com.plantcare.bot.domain.enums.TaskType;
 import com.plantcare.bot.metrics.MetricsService;
 import com.plantcare.bot.repository.CareScheduleRepository;
 import com.plantcare.bot.repository.NotificationDigestRepository;
 import com.plantcare.bot.repository.NotificationLogRepository;
 import com.plantcare.bot.repository.UserRepository;
+import com.plantcare.bot.telegram.RateLimitedTelegramSender;
+import com.plantcare.bot.telegram.SendCallbacks;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -29,7 +28,6 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
-import org.telegram.telegrambots.meta.generics.TelegramClient;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -41,11 +39,30 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
+/**
+ * Unit-тесты {@link NotificationSchedulerService} после перевода отправки на
+ * rate-limited очередь (issue #29). Шедулер больше не зовёт Telegram напрямую —
+ * он кладёт {@link SendMessage} в {@link RateLimitedTelegramSender#enqueue}, а
+ * bookkeeping (дедуп-лог, метрики, пометка blocked) выполняется в колбэках
+ * {@link SendCallbacks}, делегирующих в {@link NotificationDeliveryCallbacks}.
+ *
+ * <p>Тесты ловят: (1) что именно ставится в очередь (текст/кнопки/получатель),
+ * (2) фильтры shouldSend (pause / quiet-hours / дедуп) до постановки в очередь,
+ * (3) маршрутизацию колбэков — onSuccess → onSent/onDigestSent, onFailure → onFailed.
+ *
+ * <p>Дедуп-проверка считает quiet-hours в TZ юзера (Europe/Minsk) — таймзонный
+ * кейс сохранён через QuietHoursPolicy-перегрузку на Instant из фиксированного Clock.
+ */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-@DisplayName("Unit-тесты для NotificationSchedulerService")
+@DisplayName("Unit-тесты для NotificationSchedulerService (issue #29)")
 class NotificationSchedulerServiceTest {
 
     @Mock
@@ -61,18 +78,8 @@ class NotificationSchedulerServiceTest {
     private UserRepository userRepository;
 
     @Mock
-    private TelegramClientProvider telegramClientProvider;
-
-    @Mock
-    private TelegramClient telegramClient;
-
-    @Mock
     private SchedulerHealthTracker schedulerHealthTracker;
 
-    // Зависимости, добавленные после рефакторинга (issue #69 weather, #67 seasonal,
-    // #118 quiet-hours/keyboard вынесены в отдельные компоненты). Моки нужны
-    // потому что без них @InjectMocks вернёт null и тик упадёт в NPE на первом
-    // же вызове isWeatherUsable/isQuiet/buildReminderKeyboard.
     @Mock
     private com.plantcare.bot.weather.service.WeatherService weatherService;
 
@@ -85,6 +92,12 @@ class NotificationSchedulerServiceTest {
     @Mock
     private MetricsService metricsService;
 
+    @Mock
+    private RateLimitedTelegramSender telegramSender;
+
+    @Mock
+    private NotificationDeliveryCallbacks deliveryCallbacks;
+
     /**
      * Реальный экземпляр, не мок: проверки в тестах смотрят на содержимое
      * клавиатуры (число кнопок, callback_data). Фабрика — pure-функция без
@@ -94,9 +107,8 @@ class NotificationSchedulerServiceTest {
     private ReminderKeyboardFactory reminderKeyboardFactory = new ReminderKeyboardFactory();
 
     /**
-     * Реальный Clock с фиксированным моментом — quiet-hours проверка теперь
-     * читает {@code clock.instant()} вместо передаваемого LocalDateTime
-     * (фикс регрессии после #118, см. NotificationSchedulerService.shouldSend).
+     * Реальный Clock с фиксированным моментом — quiet-hours проверка читает
+     * {@code clock.instant()} (фикс регрессии после #118).
      */
     @org.mockito.Spy
     private Clock clock = Clock.fixed(Instant.parse("2026-05-24T12:00:00Z"), ZoneOffset.UTC);
@@ -135,15 +147,33 @@ class NotificationSchedulerServiceTest {
         ReflectionTestUtils.setField(plant, "id", 10L);
         ReflectionTestUtils.setField(schedule, "id", 100L);
 
-        // По умолчанию quiet-hours не активны (любой момент проходит фильтр).
-        // Конкретные тесты QuietHours переопределяют через свой when(...).
-        // Шедулер с #118-фикса вызывает Instant-перегрузку (см. shouldSend).
+        // По умолчанию quiet-hours не активны. Шедулер с #118-фикса вызывает
+        // Instant-перегрузку (см. shouldSend).
         when(quietHoursPolicy.isQuiet(any(User.class), any(Instant.class)))
                 .thenReturn(false);
-        // По умолчанию сезонная корректировка возвращает базовый интервал —
-        // тесты, проверяющие сезонную логику, есть отдельно от этого набора.
         when(seasonalIntervalService.effectiveIntervalDays(any(), any(), any(Integer.class)))
                 .thenAnswer(inv -> inv.getArgument(2, Integer.class));
+    }
+
+    /** Захватывает SendCallbacks из единственного enqueue с колбэками. */
+    private SendCallbacks captureCallbacks() {
+        ArgumentCaptor<SendCallbacks> captor = ArgumentCaptor.forClass(SendCallbacks.class);
+        verify(telegramSender).enqueue(any(SendMessage.class), captor.capture());
+        return captor.getValue();
+    }
+
+    /** Эмулирует вызов onSuccess воркером очереди (с null-guard, как в проде). */
+    private static void runSuccess(SendCallbacks callbacks) {
+        if (callbacks.onSuccess() != null) {
+            callbacks.onSuccess().run();
+        }
+    }
+
+    /** Эмулирует вызов onFailure воркером очереди (с null-guard, как в проде). */
+    private static void runFailure(SendCallbacks callbacks, TelegramApiException e) {
+        if (callbacks.onFailure() != null) {
+            callbacks.onFailure().accept(e);
+        }
     }
 
     @Nested
@@ -151,29 +181,62 @@ class NotificationSchedulerServiceTest {
     class SingleNotification {
 
         @Test
-        @DisplayName("Если due-задача одна, отправляется обычное уведомление")
-        void shouldSendSingleNotificationWhenOnlyOneDueSchedule() throws TelegramApiException {
+        @DisplayName("Если due-задача одна, в очередь ставится обычное уведомление")
+        void shouldEnqueueSingleNotificationWhenOnlyOneDueSchedule() {
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(false);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
 
             service.checkAndSendNotifications();
 
             ArgumentCaptor<SendMessage> messageCaptor = ArgumentCaptor.forClass(SendMessage.class);
-            verify(telegramClient).execute(messageCaptor.capture());
+            verify(telegramSender).enqueue(messageCaptor.capture(), any(SendCallbacks.class));
 
             SendMessage sent = messageCaptor.getValue();
-
             assertThat(sent.getChatId()).isEqualTo("100");
             assertThat(sent.getText()).contains("Пора полить");
             assertThat(sent.getText()).contains("Монстера");
             assertThat(sent.getText()).doesNotContain("На сегодня:");
 
             verify(notificationDigestRepository, never()).save(any());
-            verify(notificationLogRepository).save(any(NotificationLog.class));
             // Тик зафиксирован после успешной итерации (issue #28).
             verify(schedulerHealthTracker).recordTick();
+        }
+
+        @Test
+        @DisplayName("onSuccess колбэк пишет дедуп-лог через NotificationDeliveryCallbacks.onSent")
+        void shouldRouteSuccessCallbackToOnSent() {
+            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
+            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
+                    .thenReturn(false);
+
+            service.checkAndSendNotifications();
+
+            SendCallbacks callbacks = captureCallbacks();
+            // До выполнения колбэка bookkeeping не трогается.
+            verify(deliveryCallbacks, never()).onSent(anyLong(), any());
+
+            runSuccess(callbacks);
+
+            verify(deliveryCallbacks).onSent(plant.getId(), TaskType.WATERING);
+        }
+
+        @Test
+        @DisplayName("onFailure колбэк делегирует в NotificationDeliveryCallbacks.onFailed с chatId")
+        void shouldRouteFailureCallbackToOnFailed() {
+            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
+            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
+                    .thenReturn(false);
+
+            service.checkAndSendNotifications();
+
+            SendCallbacks callbacks = captureCallbacks();
+            TelegramApiException error =
+                    new TelegramApiException("Forbidden: bot was blocked by the user [403]");
+
+            runFailure(callbacks, error);
+
+            verify(deliveryCallbacks).onFailed(user.getTelegramChatId(), error);
         }
 
         @Test
@@ -198,23 +261,22 @@ class NotificationSchedulerServiceTest {
                 // ожидаемо, тик не завершился успешно
             }
 
-            verify(schedulerHealthTracker, org.mockito.Mockito.never()).recordTick();
+            verify(schedulerHealthTracker, never()).recordTick();
         }
 
         @Test
         @DisplayName("Текст уведомления зависит от типа задачи")
-        void shouldUseCorrectTextForDifferentTaskTypes() throws TelegramApiException {
+        void shouldUseCorrectTextForDifferentTaskTypes() {
             schedule.setTaskType(TaskType.MISTING);
 
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(false);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
 
             service.checkAndSendNotifications();
 
             ArgumentCaptor<SendMessage> messageCaptor = ArgumentCaptor.forClass(SendMessage.class);
-            verify(telegramClient).execute(messageCaptor.capture());
+            verify(telegramSender).enqueue(messageCaptor.capture(), any(SendCallbacks.class));
 
             assertThat(messageCaptor.getValue().getText()).contains("Пора опрыскать");
             assertThat(messageCaptor.getValue().getText()).contains("Монстера");
@@ -222,120 +284,75 @@ class NotificationSchedulerServiceTest {
 
         @Test
         @DisplayName("Кнопка done содержит правильный глагол для WATERING")
-        void shouldUseWateringDoneButtonLabel() throws TelegramApiException {
+        void shouldUseWateringDoneButtonLabel() {
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(false);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
 
             service.checkAndSendNotifications();
 
-            ArgumentCaptor<SendMessage> messageCaptor = ArgumentCaptor.forClass(SendMessage.class);
-            verify(telegramClient).execute(messageCaptor.capture());
-
-            InlineKeyboardMarkup keyboard = (InlineKeyboardMarkup) messageCaptor.getValue().getReplyMarkup();
-
-            List<String> buttonLabels = keyboard.getKeyboard().stream()
-                    .flatMap(Collection::stream)
-                    .map(InlineKeyboardButton::getText)
-                    .toList();
-
-            assertThat(buttonLabels).contains("✅ Полил");
+            assertThat(buttonLabels()).contains("✅ Полил");
         }
 
         @Test
         @DisplayName("Кнопка done содержит правильный глагол для MISTING")
-        void shouldUseMistingDoneButtonLabel() throws TelegramApiException {
+        void shouldUseMistingDoneButtonLabel() {
             schedule.setTaskType(TaskType.MISTING);
 
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(false);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
 
             service.checkAndSendNotifications();
 
-            ArgumentCaptor<SendMessage> messageCaptor = ArgumentCaptor.forClass(SendMessage.class);
-            verify(telegramClient).execute(messageCaptor.capture());
-
-            InlineKeyboardMarkup keyboard = (InlineKeyboardMarkup) messageCaptor.getValue().getReplyMarkup();
-
-            List<String> buttonLabels = keyboard.getKeyboard().stream()
-                    .flatMap(Collection::stream)
-                    .map(InlineKeyboardButton::getText)
-                    .toList();
-
-            assertThat(buttonLabels).contains("✅ Опрыскал");
+            assertThat(buttonLabels()).contains("✅ Опрыскал");
         }
 
         @Test
         @DisplayName("Кнопка done содержит правильный глагол для FERTILIZING")
-        void shouldUseFertilizingDoneButtonLabel() throws TelegramApiException {
+        void shouldUseFertilizingDoneButtonLabel() {
             schedule.setTaskType(TaskType.FERTILIZING);
 
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(false);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
 
             service.checkAndSendNotifications();
 
-            ArgumentCaptor<SendMessage> messageCaptor = ArgumentCaptor.forClass(SendMessage.class);
-            verify(telegramClient).execute(messageCaptor.capture());
-
-            InlineKeyboardMarkup keyboard = (InlineKeyboardMarkup) messageCaptor.getValue().getReplyMarkup();
-
-            List<String> buttonLabels = keyboard.getKeyboard().stream()
-                    .flatMap(Collection::stream)
-                    .map(InlineKeyboardButton::getText)
-                    .toList();
-
-            assertThat(buttonLabels).contains("✅ Удобрил");
+            assertThat(buttonLabels()).contains("✅ Удобрил");
         }
 
         @Test
         @DisplayName("Обычное уведомление содержит кнопки done, snooze, skip")
-        void shouldContainThreeInlineButtons() throws TelegramApiException {
+        void shouldContainThreeInlineButtons() {
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(false);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
 
             service.checkAndSendNotifications();
 
+            assertThat(callbackData())
+                    .contains("v1:done:100", "v1:snooze:100", "v1:skip:100");
+        }
+
+        private List<String> buttonLabels() {
             ArgumentCaptor<SendMessage> messageCaptor = ArgumentCaptor.forClass(SendMessage.class);
-            verify(telegramClient).execute(messageCaptor.capture());
-
+            verify(telegramSender).enqueue(messageCaptor.capture(), any(SendCallbacks.class));
             InlineKeyboardMarkup keyboard = (InlineKeyboardMarkup) messageCaptor.getValue().getReplyMarkup();
+            return keyboard.getKeyboard().stream()
+                    .flatMap(Collection::stream)
+                    .map(InlineKeyboardButton::getText)
+                    .toList();
+        }
 
-            List<String> callbackData = keyboard.getKeyboard().stream()
+        private List<String> callbackData() {
+            ArgumentCaptor<SendMessage> messageCaptor = ArgumentCaptor.forClass(SendMessage.class);
+            verify(telegramSender).enqueue(messageCaptor.capture(), any(SendCallbacks.class));
+            InlineKeyboardMarkup keyboard = (InlineKeyboardMarkup) messageCaptor.getValue().getReplyMarkup();
+            return keyboard.getKeyboard().stream()
                     .flatMap(Collection::stream)
                     .map(InlineKeyboardButton::getCallbackData)
                     .toList();
-
-            assertThat(callbackData).contains("v1:done:100");
-            assertThat(callbackData).contains("v1:snooze:100");
-            assertThat(callbackData).contains("v1:skip:100");
-        }
-
-        @Test
-        @DisplayName("После отправки обычного уведомления создаётся запись в notifications_log")
-        void shouldSaveNotificationLog() throws TelegramApiException {
-            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
-            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
-                    .thenReturn(false);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
-
-            service.checkAndSendNotifications();
-
-            ArgumentCaptor<NotificationLog> logCaptor = ArgumentCaptor.forClass(NotificationLog.class);
-            verify(notificationLogRepository).save(logCaptor.capture());
-
-            NotificationLog saved = logCaptor.getValue();
-
-            assertThat(saved.getPlant()).isEqualTo(plant);
-            assertThat(saved.getTaskType()).isEqualTo(TaskType.WATERING);
-            assertThat(saved.getNotificationType()).isEqualTo(NotificationType.DUE);
         }
     }
 
@@ -344,33 +361,12 @@ class NotificationSchedulerServiceTest {
     class DigestNotifications {
 
         @Test
-        @DisplayName("Если у одного пользователя 3 due-задачи, отправляется один digest")
-        void shouldSendDigestWhenUserHasSeveralDueSchedules() throws TelegramApiException {
-            CareSchedule schedule2 = CareSchedule.builder()
-                    .plant(plant)
-                    .taskType(TaskType.MISTING)
-                    .intervalDays(3)
-                    .nextDueAt(LocalDateTime.now().minusHours(1))
-                    .active(true)
-                    .build();
+        @DisplayName("Если у одного пользователя 3 due-задачи, в очередь ставится один digest")
+        void shouldEnqueueDigestWhenUserHasSeveralDueSchedules() {
+            CareSchedule schedule2 = dueSchedule(plant, TaskType.MISTING, 101L);
+            CareSchedule schedule3 = dueSchedule(plant, TaskType.FERTILIZING, 102L);
 
-            CareSchedule schedule3 = CareSchedule.builder()
-                    .plant(plant)
-                    .taskType(TaskType.FERTILIZING)
-                    .intervalDays(30)
-                    .nextDueAt(LocalDateTime.now().minusHours(1))
-                    .active(true)
-                    .build();
-
-            ReflectionTestUtils.setField(schedule2, "id", 101L);
-            ReflectionTestUtils.setField(schedule3, "id", 102L);
-
-            NotificationDigest savedDigest = NotificationDigest.builder()
-                    .userId(user.getId())
-                    .plantTaskIds(List.of())
-                    .build();
-
-            ReflectionTestUtils.setField(savedDigest, "id", 500L);
+            NotificationDigest savedDigest = savedDigest(500L);
 
             when(careScheduleRepository.findDueSchedules(any()))
                     .thenReturn(List.of(schedule, schedule2, schedule3));
@@ -378,15 +374,13 @@ class NotificationSchedulerServiceTest {
                     .thenReturn(false);
             when(notificationDigestRepository.save(any(NotificationDigest.class)))
                     .thenReturn(savedDigest);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
 
             service.checkAndSendNotifications();
 
             ArgumentCaptor<SendMessage> messageCaptor = ArgumentCaptor.forClass(SendMessage.class);
-            verify(telegramClient).execute(messageCaptor.capture());
+            verify(telegramSender).enqueue(messageCaptor.capture(), any(SendCallbacks.class));
 
             SendMessage sent = messageCaptor.getValue();
-
             assertThat(sent.getChatId()).isEqualTo("100");
             assertThat(sent.getText()).contains("На сегодня:");
             assertThat(sent.getText()).contains("Монстера — полить");
@@ -394,46 +388,50 @@ class NotificationSchedulerServiceTest {
             assertThat(sent.getText()).contains("Монстера — удобрить");
 
             InlineKeyboardMarkup keyboard = (InlineKeyboardMarkup) sent.getReplyMarkup();
-
             List<String> callbacks = keyboard.getKeyboard().stream()
                     .flatMap(Collection::stream)
                     .map(InlineKeyboardButton::getCallbackData)
                     .toList();
 
-            assertThat(callbacks).contains("digest:done_all:500");
-            assertThat(callbacks).contains("digest:expand:500");
+            assertThat(callbacks).contains("digest:done_all:500", "digest:expand:500");
 
             verify(notificationDigestRepository).save(any(NotificationDigest.class));
-            verify(notificationLogRepository, times(3)).save(any(NotificationLog.class));
+        }
+
+        @Test
+        @DisplayName("onSuccess дайджеста пишет дедуп-лог по каждой задаче через onDigestSent")
+        void shouldRouteDigestSuccessToOnDigestSent() {
+            CareSchedule schedule2 = dueSchedule(plant, TaskType.MISTING, 101L);
+            when(careScheduleRepository.findDueSchedules(any()))
+                    .thenReturn(List.of(schedule, schedule2));
+            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
+                    .thenReturn(false);
+            when(notificationDigestRepository.save(any(NotificationDigest.class)))
+                    .thenReturn(savedDigest(500L));
+
+            service.checkAndSendNotifications();
+
+            runSuccess(captureCallbacks());
+
+            ArgumentCaptor<List<NotificationDeliveryCallbacks.DigestLogItem>> itemsCaptor =
+                    ArgumentCaptor.forClass(List.class);
+            verify(deliveryCallbacks).onDigestSent(itemsCaptor.capture());
+            assertThat(itemsCaptor.getValue())
+                    .extracting(NotificationDeliveryCallbacks.DigestLogItem::taskType)
+                    .containsExactlyInAnyOrder(TaskType.WATERING, TaskType.MISTING);
         }
 
         @Test
         @DisplayName("В NotificationDigest сохраняются все задачи пользователя")
-        void shouldSaveDigestWithAllTasks() throws TelegramApiException {
-            CareSchedule schedule2 = CareSchedule.builder()
-                    .plant(plant)
-                    .taskType(TaskType.MISTING)
-                    .intervalDays(3)
-                    .nextDueAt(LocalDateTime.now().minusHours(1))
-                    .active(true)
-                    .build();
-
-            ReflectionTestUtils.setField(schedule2, "id", 101L);
-
-            NotificationDigest savedDigest = NotificationDigest.builder()
-                    .userId(user.getId())
-                    .plantTaskIds(List.of())
-                    .build();
-
-            ReflectionTestUtils.setField(savedDigest, "id", 500L);
+        void shouldSaveDigestWithAllTasks() {
+            CareSchedule schedule2 = dueSchedule(plant, TaskType.MISTING, 101L);
 
             when(careScheduleRepository.findDueSchedules(any()))
                     .thenReturn(List.of(schedule, schedule2));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(false);
             when(notificationDigestRepository.save(any(NotificationDigest.class)))
-                    .thenReturn(savedDigest);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
+                    .thenReturn(savedDigest(500L));
 
             service.checkAndSendNotifications();
 
@@ -441,7 +439,6 @@ class NotificationSchedulerServiceTest {
             verify(notificationDigestRepository).save(digestCaptor.capture());
 
             NotificationDigest digest = digestCaptor.getValue();
-
             assertThat(digest.getUserId()).isEqualTo(1L);
             assertThat(digest.getPlantTaskIds()).hasSize(2);
             assertThat(digest.getPlantTaskIds().get(0).scheduleId()).isEqualTo(100L);
@@ -454,115 +451,52 @@ class NotificationSchedulerServiceTest {
 
         @Test
         @DisplayName("Если у разных пользователей по одной задаче, digest не создаётся")
-        void shouldNotCreateDigestForDifferentUsersWithSingleTaskEach() throws TelegramApiException {
-            User secondUser = User.builder()
-                    .telegramChatId(200L)
-                    .timezone("Europe/Minsk")
-                    .quietHoursStart(LocalTime.of(0, 0))
-                    .quietHoursEnd(LocalTime.of(0, 0))
-                    .blocked(false)
-                    .build();
-
-            Plant secondPlant = Plant.builder()
-                    .user(secondUser)
-                    .name("Фикус")
-                    .build();
-
-            CareSchedule secondSchedule = CareSchedule.builder()
-                    .plant(secondPlant)
-                    .taskType(TaskType.MISTING)
-                    .intervalDays(3)
-                    .nextDueAt(LocalDateTime.now().minusHours(1))
-                    .active(true)
-                    .build();
-
-            ReflectionTestUtils.setField(secondUser, "id", 2L);
-            ReflectionTestUtils.setField(secondPlant, "id", 20L);
-            ReflectionTestUtils.setField(secondSchedule, "id", 200L);
+        void shouldNotCreateDigestForDifferentUsersWithSingleTaskEach() {
+            User secondUser = secondUser();
+            Plant secondPlant = secondPlant(secondUser);
+            CareSchedule secondSchedule = dueSchedule(secondPlant, TaskType.MISTING, 200L);
 
             when(careScheduleRepository.findDueSchedules(any()))
                     .thenReturn(List.of(schedule, secondSchedule));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(false);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
 
             service.checkAndSendNotifications();
 
-            verify(telegramClient, times(2)).execute(any(SendMessage.class));
+            verify(telegramSender, times(2)).enqueue(any(SendMessage.class), any(SendCallbacks.class));
             verify(notificationDigestRepository, never()).save(any());
-            verify(notificationLogRepository, times(2)).save(any(NotificationLog.class));
         }
 
         @Test
-        @DisplayName("Если у первого пользователя 2 задачи, а у второго 1, первый получает digest, второй обычное уведомление")
-        void shouldSendDigestForOneUserAndSingleNotificationForAnother() throws TelegramApiException {
-            CareSchedule schedule2 = CareSchedule.builder()
-                    .plant(plant)
-                    .taskType(TaskType.MISTING)
-                    .intervalDays(3)
-                    .nextDueAt(LocalDateTime.now().minusHours(1))
-                    .active(true)
-                    .build();
+        @DisplayName("Первый пользователь получает digest, второй — обычное уведомление")
+        void shouldSendDigestForOneUserAndSingleNotificationForAnother() {
+            CareSchedule schedule2 = dueSchedule(plant, TaskType.MISTING, 101L);
 
-            User secondUser = User.builder()
-                    .telegramChatId(200L)
-                    .timezone("Europe/Minsk")
-                    .quietHoursStart(LocalTime.of(0, 0))
-                    .quietHoursEnd(LocalTime.of(0, 0))
-                    .blocked(false)
-                    .build();
-
-            Plant secondPlant = Plant.builder()
-                    .user(secondUser)
-                    .name("Фикус")
-                    .build();
-
-            CareSchedule secondUserSchedule = CareSchedule.builder()
-                    .plant(secondPlant)
-                    .taskType(TaskType.WATERING)
-                    .intervalDays(5)
-                    .nextDueAt(LocalDateTime.now().minusHours(1))
-                    .active(true)
-                    .build();
-
-            ReflectionTestUtils.setField(schedule2, "id", 101L);
-            ReflectionTestUtils.setField(secondUser, "id", 2L);
-            ReflectionTestUtils.setField(secondPlant, "id", 20L);
-            ReflectionTestUtils.setField(secondUserSchedule, "id", 200L);
-
-            NotificationDigest savedDigest = NotificationDigest.builder()
-                    .userId(user.getId())
-                    .plantTaskIds(List.of())
-                    .build();
-
-            ReflectionTestUtils.setField(savedDigest, "id", 500L);
+            User secondUser = secondUser();
+            Plant secondPlant = secondPlant(secondUser);
+            CareSchedule secondUserSchedule = dueSchedule(secondPlant, TaskType.WATERING, 200L);
 
             when(careScheduleRepository.findDueSchedules(any()))
                     .thenReturn(List.of(schedule, schedule2, secondUserSchedule));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(false);
             when(notificationDigestRepository.save(any(NotificationDigest.class)))
-                    .thenReturn(savedDigest);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
+                    .thenReturn(savedDigest(500L));
 
             service.checkAndSendNotifications();
 
             ArgumentCaptor<SendMessage> messageCaptor = ArgumentCaptor.forClass(SendMessage.class);
-            verify(telegramClient, times(2)).execute(messageCaptor.capture());
+            verify(telegramSender, times(2)).enqueue(messageCaptor.capture(), any(SendCallbacks.class));
 
             List<SendMessage> sentMessages = messageCaptor.getAllValues();
-
             assertThat(sentMessages)
-                    .anyMatch(message -> message.getChatId().equals("100")
-                            && message.getText().contains("На сегодня:"));
-
+                    .anyMatch(m -> m.getChatId().equals("100") && m.getText().contains("На сегодня:"));
             assertThat(sentMessages)
-                    .anyMatch(message -> message.getChatId().equals("200")
-                            && message.getText().contains("Пора полить")
-                            && message.getText().contains("Фикус"));
+                    .anyMatch(m -> m.getChatId().equals("200")
+                            && m.getText().contains("Пора полить")
+                            && m.getText().contains("Фикус"));
 
             verify(notificationDigestRepository).save(any(NotificationDigest.class));
-            verify(notificationLogRepository, times(3)).save(any(NotificationLog.class));
         }
     }
 
@@ -571,32 +505,30 @@ class NotificationSchedulerServiceTest {
     class PausedUser {
 
         @Test
-        @DisplayName("Не отправляет уведомление, если pausedUntil > now")
-        void shouldSkipPausedUser() throws TelegramApiException {
+        @DisplayName("Не ставит в очередь, если pausedUntil > now")
+        void shouldSkipPausedUser() {
             user.setPausedUntil(LocalDateTime.now().plusHours(1));
 
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
 
             service.checkAndSendNotifications();
 
-            verify(telegramClient, never()).execute(any(SendMessage.class));
+            verifyNoInteractions(telegramSender);
             verify(notificationDigestRepository, never()).save(any());
-            verify(notificationLogRepository, never()).save(any());
         }
 
         @Test
-        @DisplayName("Отправляет уведомление, если pausedUntil уже прошло")
-        void shouldSendIfPauseExpired() throws TelegramApiException {
+        @DisplayName("Ставит в очередь, если pausedUntil уже прошло")
+        void shouldSendIfPauseExpired() {
             user.setPausedUntil(LocalDateTime.now().minusHours(1));
 
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(false);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
 
             service.checkAndSendNotifications();
 
-            verify(telegramClient).execute(any(SendMessage.class));
+            verify(telegramSender).enqueue(any(SendMessage.class), any(SendCallbacks.class));
         }
     }
 
@@ -605,8 +537,8 @@ class NotificationSchedulerServiceTest {
     class QuietHours {
 
         @Test
-        @DisplayName("Не отправляет уведомление во время тихих часов")
-        void shouldSkipDuringQuietHours() throws TelegramApiException {
+        @DisplayName("Не ставит в очередь во время тихих часов")
+        void shouldSkipDuringQuietHours() {
             user.setQuietHoursStart(LocalTime.of(0, 0));
             user.setQuietHoursEnd(LocalTime.of(23, 59));
 
@@ -617,25 +549,23 @@ class NotificationSchedulerServiceTest {
 
             service.checkAndSendNotifications();
 
-            verify(telegramClient, never()).execute(any(SendMessage.class));
+            verifyNoInteractions(telegramSender);
             verify(notificationDigestRepository, never()).save(any());
-            verify(notificationLogRepository, never()).save(any());
         }
 
         @Test
-        @DisplayName("Отправляет уведомление, если quiet_hours_start == quiet_hours_end")
-        void shouldSendWhenQuietHoursDisabled() throws TelegramApiException {
+        @DisplayName("Ставит в очередь, если quiet_hours_start == quiet_hours_end")
+        void shouldSendWhenQuietHoursDisabled() {
             user.setQuietHoursStart(LocalTime.of(0, 0));
             user.setQuietHoursEnd(LocalTime.of(0, 0));
 
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(false);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
 
             service.checkAndSendNotifications();
 
-            verify(telegramClient).execute(any(SendMessage.class));
+            verify(telegramSender).enqueue(any(SendMessage.class), any(SendCallbacks.class));
         }
     }
 
@@ -644,100 +574,52 @@ class NotificationSchedulerServiceTest {
     class Deduplication {
 
         @Test
-        @DisplayName("Не отправляет уведомление, если за последние 12 часов уже отправляли")
-        void shouldSkipIfAlreadyNotifiedRecently() throws TelegramApiException {
+        @DisplayName("Не ставит в очередь, если за последние 12 часов уже отправляли")
+        void shouldSkipIfAlreadyNotifiedRecently() {
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(true);
 
             service.checkAndSendNotifications();
 
-            verify(telegramClient, never()).execute(any(SendMessage.class));
+            verifyNoInteractions(telegramSender);
             verify(notificationDigestRepository, never()).save(any());
-            verify(notificationLogRepository, never()).save(any());
         }
     }
 
     @Nested
-    @DisplayName("Ошибки Telegram")
-    class TelegramErrors {
+    @DisplayName("Ошибки доставки маршрутизируются в onFailed")
+    class FailureRouting {
 
         @Test
-        @DisplayName("При 403 помечает пользователя как заблокированного")
-        void shouldMarkUserAsBlockedOn403() throws TelegramApiException {
+        @DisplayName("403-колбэк делегирует в onFailed (пометка blocked живёт там)")
+        void shouldRouteForbiddenToOnFailed() {
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(false);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
-            when(telegramClient.execute(any(SendMessage.class)))
-                    .thenThrow(new TelegramApiException("Forbidden: bot was blocked by the user [403]"));
 
             service.checkAndSendNotifications();
 
-            assertThat(user.isBlocked()).isTrue();
+            TelegramApiException error =
+                    new TelegramApiException("Forbidden: bot was blocked by the user [403]");
+            runFailure(captureCallbacks(), error);
 
-            verify(userRepository).save(user);
-            verify(notificationLogRepository, never()).save(any());
+            verify(deliveryCallbacks).onFailed(100L, error);
         }
 
         @Test
-        @DisplayName("При прочих ошибках пользователь не блокируется")
-        void shouldNotBlockUserOnOtherErrors() throws TelegramApiException {
+        @DisplayName("Прочая ошибка тоже делегирует в onFailed с тем же chatId/исключением")
+        void shouldRouteOtherErrorToOnFailed() {
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(false);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
-            when(telegramClient.execute(any(SendMessage.class)))
-                    .thenThrow(new TelegramApiException("Network timeout"));
 
             service.checkAndSendNotifications();
 
-            assertThat(user.isBlocked()).isFalse();
+            TelegramApiException error = new TelegramApiException("Network timeout");
+            runFailure(captureCallbacks(), error);
 
-            verify(userRepository, never()).save(any());
-            verify(notificationLogRepository, never()).save(any());
-        }
-
-        @Test
-        @DisplayName("Ошибка у одного пользователя не останавливает обработку другого")
-        void shouldContinueProcessingAfterError() throws TelegramApiException {
-            User secondUser = User.builder()
-                    .telegramChatId(200L)
-                    .timezone("Europe/Minsk")
-                    .quietHoursStart(LocalTime.of(0, 0))
-                    .quietHoursEnd(LocalTime.of(0, 0))
-                    .blocked(false)
-                    .build();
-
-            Plant secondPlant = Plant.builder()
-                    .user(secondUser)
-                    .name("Фикус")
-                    .build();
-
-            CareSchedule secondSchedule = CareSchedule.builder()
-                    .plant(secondPlant)
-                    .taskType(TaskType.MISTING)
-                    .intervalDays(3)
-                    .nextDueAt(LocalDateTime.now().minusHours(1))
-                    .active(true)
-                    .build();
-
-            ReflectionTestUtils.setField(secondUser, "id", 2L);
-            ReflectionTestUtils.setField(secondPlant, "id", 20L);
-            ReflectionTestUtils.setField(secondSchedule, "id", 200L);
-
-            when(careScheduleRepository.findDueSchedules(any()))
-                    .thenReturn(List.of(schedule, secondSchedule));
-            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
-                    .thenReturn(false);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
-            when(telegramClient.execute(any(SendMessage.class)))
-                    .thenThrow(new TelegramApiException("error"))
-                    .thenReturn(null);
-
-            service.checkAndSendNotifications();
-
-            verify(telegramClient, times(2)).execute(any(SendMessage.class));
+            verify(deliveryCallbacks).onFailed(100L, error);
         }
     }
 
@@ -746,20 +628,19 @@ class NotificationSchedulerServiceTest {
     class NoDueSchedules {
 
         @Test
-        @DisplayName("Не отправляет ничего, если нет просроченных расписаний")
-        void shouldDoNothingWhenNoDueSchedules() throws TelegramApiException {
+        @DisplayName("Не ставит ничего в очередь, если нет просроченных расписаний")
+        void shouldDoNothingWhenNoDueSchedules() {
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of());
 
             service.checkAndSendNotifications();
 
-            verify(telegramClient, never()).execute(any(SendMessage.class));
+            verifyNoInteractions(telegramSender);
             verify(notificationDigestRepository, never()).save(any());
-            verify(notificationLogRepository, never()).save(any());
         }
     }
 
     @Nested
-    @DisplayName("Метрики (#115)")
+    @DisplayName("Метрики тика (#115)")
     class Metrics {
 
         @Test
@@ -767,7 +648,7 @@ class NotificationSchedulerServiceTest {
         void should_wrap_each_tick_in_timer_sample_when_called() {
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of());
             io.micrometer.core.instrument.Timer.Sample sample =
-                    mock(io.micrometer.core.instrument.Timer.Sample.class);
+                    org.mockito.Mockito.mock(io.micrometer.core.instrument.Timer.Sample.class);
             when(metricsService.startSchedulerTickTimer()).thenReturn(sample);
 
             service.checkAndSendNotifications();
@@ -780,7 +661,7 @@ class NotificationSchedulerServiceTest {
         @DisplayName("Timer.stop вызывается даже если tick упал с исключением (finally)")
         void should_stop_timer_when_tick_fails_with_exception() {
             io.micrometer.core.instrument.Timer.Sample sample =
-                    mock(io.micrometer.core.instrument.Timer.Sample.class);
+                    org.mockito.Mockito.mock(io.micrometer.core.instrument.Timer.Sample.class);
             when(metricsService.startSchedulerTickTimer()).thenReturn(sample);
             when(careScheduleRepository.findDueSchedules(any()))
                     .thenThrow(new RuntimeException("DB down"));
@@ -794,104 +675,49 @@ class NotificationSchedulerServiceTest {
             verify(metricsService).startSchedulerTickTimer();
             verify(metricsService).stopSchedulerTickTimer(sample);
         }
+    }
 
-        @Test
-        @DisplayName("После успешной отправки одиночного уведомления увеличивается notifications.sent")
-        void should_record_notification_sent_when_single_push_succeeds() throws TelegramApiException {
-            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
-            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
-                    .thenReturn(false);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
+    // ===== helpers =====
 
-            service.checkAndSendNotifications();
+    private CareSchedule dueSchedule(Plant ownerPlant, TaskType type, long id) {
+        CareSchedule s = CareSchedule.builder()
+                .plant(ownerPlant)
+                .taskType(type)
+                .intervalDays(3)
+                .nextDueAt(LocalDateTime.now().minusHours(1))
+                .active(true)
+                .build();
+        ReflectionTestUtils.setField(s, "id", id);
+        return s;
+    }
 
-            verify(metricsService).recordNotificationSent(MetricsService.CHANNEL_TELEGRAM, TaskType.WATERING);
-            verify(metricsService, never()).recordNotificationFailed(any(), any());
-        }
+    private NotificationDigest savedDigest(long id) {
+        NotificationDigest d = NotificationDigest.builder()
+                .userId(user.getId())
+                .plantTaskIds(List.of())
+                .build();
+        ReflectionTestUtils.setField(d, "id", id);
+        return d;
+    }
 
-        @Test
-        @DisplayName("При 429 от Telegram пишутся telegram.api.errors[429] и notifications.failed[rate_limit]")
-        void should_record_rate_limit_failure_when_telegram_returns_429() throws TelegramApiException {
-            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
-            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
-                    .thenReturn(false);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
-            when(telegramClient.execute(any(SendMessage.class)))
-                    .thenThrow(new TelegramApiException("[429] Too Many Requests: retry after 30"));
+    private User secondUser() {
+        User secondUser = User.builder()
+                .telegramChatId(200L)
+                .timezone("Europe/Minsk")
+                .quietHoursStart(LocalTime.of(0, 0))
+                .quietHoursEnd(LocalTime.of(0, 0))
+                .blocked(false)
+                .build();
+        ReflectionTestUtils.setField(secondUser, "id", 2L);
+        return secondUser;
+    }
 
-            service.checkAndSendNotifications();
-
-            verify(metricsService).recordTelegramApiError(MetricsService.TelegramErrorCode.RATE_LIMITED);
-            verify(metricsService).recordNotificationFailed(
-                    MetricsService.CHANNEL_TELEGRAM, MetricsService.FailureReason.RATE_LIMIT);
-            verify(metricsService, never()).recordNotificationSent(any(), any());
-        }
-
-        @Test
-        @DisplayName("При 403 от Telegram пишутся telegram.api.errors[403] и notifications.failed[blocked]")
-        void should_record_blocked_failure_when_telegram_returns_403() throws TelegramApiException {
-            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
-            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
-                    .thenReturn(false);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
-            when(telegramClient.execute(any(SendMessage.class)))
-                    .thenThrow(new TelegramApiException("Forbidden: bot was blocked by the user [403]"));
-
-            service.checkAndSendNotifications();
-
-            verify(metricsService).recordTelegramApiError(MetricsService.TelegramErrorCode.FORBIDDEN);
-            verify(metricsService).recordNotificationFailed(
-                    MetricsService.CHANNEL_TELEGRAM, MetricsService.FailureReason.BLOCKED);
-        }
-
-        @Test
-        @DisplayName("При прочей ошибке Telegram пишется failed[other]")
-        void should_record_other_failure_when_telegram_throws_unknown_error() throws TelegramApiException {
-            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
-            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
-                    .thenReturn(false);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
-            when(telegramClient.execute(any(SendMessage.class)))
-                    .thenThrow(new TelegramApiException("Network timeout"));
-
-            service.checkAndSendNotifications();
-
-            verify(metricsService).recordTelegramApiError(MetricsService.TelegramErrorCode.OTHER);
-            verify(metricsService).recordNotificationFailed(
-                    MetricsService.CHANNEL_TELEGRAM, MetricsService.FailureReason.OTHER);
-        }
-
-        @Test
-        @DisplayName("Дайджест из 2 задач: 2x recordNotificationSent + 1x recordDigestSent")
-        void should_record_digest_sent_and_per_task_sent_when_digest_pushed() throws TelegramApiException {
-            CareSchedule schedule2 = CareSchedule.builder()
-                    .plant(plant)
-                    .taskType(TaskType.MISTING)
-                    .intervalDays(3)
-                    .nextDueAt(LocalDateTime.now().minusHours(1))
-                    .active(true)
-                    .build();
-            ReflectionTestUtils.setField(schedule2, "id", 101L);
-
-            NotificationDigest savedDigest = NotificationDigest.builder()
-                    .userId(user.getId())
-                    .plantTaskIds(List.of())
-                    .build();
-            ReflectionTestUtils.setField(savedDigest, "id", 500L);
-
-            when(careScheduleRepository.findDueSchedules(any()))
-                    .thenReturn(List.of(schedule, schedule2));
-            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
-                    .thenReturn(false);
-            when(notificationDigestRepository.save(any(NotificationDigest.class)))
-                    .thenReturn(savedDigest);
-            when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
-
-            service.checkAndSendNotifications();
-
-            verify(metricsService).recordNotificationSent(MetricsService.CHANNEL_TELEGRAM, TaskType.WATERING);
-            verify(metricsService).recordNotificationSent(MetricsService.CHANNEL_TELEGRAM, TaskType.MISTING);
-            verify(metricsService).recordDigestSent();
-        }
+    private Plant secondPlant(User owner) {
+        Plant secondPlant = Plant.builder()
+                .user(owner)
+                .name("Фикус")
+                .build();
+        ReflectionTestUtils.setField(secondPlant, "id", 20L);
+        return secondPlant;
     }
 }

--- a/src/test/java/com/plantcare/bot/service/PhotoProgressSchedulerServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/PhotoProgressSchedulerServiceTest.java
@@ -1,14 +1,15 @@
 package com.plantcare.bot.service;
 
-import com.plantcare.bot.client.TelegramClientProvider;
 import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.PhotoProgressFrequency;
 import com.plantcare.bot.repository.PlantRepository;
-import org.junit.jupiter.api.BeforeEach;
+import com.plantcare.bot.telegram.RateLimitedTelegramSender;
+import com.plantcare.bot.telegram.SendCallbacks;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -16,27 +17,29 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
-import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
-import org.telegram.telegrambots.meta.generics.TelegramClient;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit-тесты {@link PhotoProgressSchedulerService} (issue #72) — проверяют
- * базовое поведение: счастливый путь, фильтр paused/blocked, корректная
- * обработка падения Telegram-API для одного из растений.
+ * Unit-тесты {@link PhotoProgressSchedulerService} (issue #72) после перевода на
+ * rate-limited очередь (issue #29). Шедулер теперь не зовёт Telegram напрямую, а
+ * кладёт сообщение в {@link RateLimitedTelegramSender#enqueue}; дедуп-пометка
+ * {@code markPromptSent} переехала в onSuccess-колбэк. Тесты проверяют постановку
+ * в очередь и маршрутизацию колбэков через захваченные {@link SendCallbacks}.
  */
-@DisplayName("Unit-тесты PhotoProgressSchedulerService (issue #72)")
+@DisplayName("Unit-тесты PhotoProgressSchedulerService (issue #72 / #29)")
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class PhotoProgressSchedulerServiceTest {
@@ -48,33 +51,53 @@ class PhotoProgressSchedulerServiceTest {
     private PhotoProgressService photoProgressService;
 
     @Mock
-    private TelegramClientProvider telegramClientProvider;
-
-    @Mock
-    private TelegramClient telegramClient;
+    private RateLimitedTelegramSender telegramSender;
 
     @InjectMocks
     private PhotoProgressSchedulerService service;
 
-    @BeforeEach
-    void setUp() {
-        when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
-    }
-
     @Test
-    void should_send_prompt_and_mark_when_plant_due_and_user_active() throws TelegramApiException {
+    void should_enqueue_prompt_and_mark_on_success_when_plant_due_and_user_active() {
         User user = activeUser(100L);
         Plant plant = duePlant(10L, "Монстера", user);
         when(plantRepository.findPhotoProgressDue(any(), any())).thenReturn(List.of(plant));
 
         service.checkPhotoPrompts();
 
-        verify(telegramClient, times(1)).execute(any(SendMessage.class));
+        ArgumentCaptor<SendMessage> messageCaptor = ArgumentCaptor.forClass(SendMessage.class);
+        ArgumentCaptor<SendCallbacks> callbacksCaptor = ArgumentCaptor.forClass(SendCallbacks.class);
+        verify(telegramSender, times(1)).enqueue(messageCaptor.capture(), callbacksCaptor.capture());
+
+        assertThat(messageCaptor.getValue().getChatId()).isEqualTo("100");
+        // Пометка происходит ТОЛЬКО после успешной отправки (колбэк), не при enqueue.
+        verify(photoProgressService, never()).markPromptSent(anyLong(), any(LocalDateTime.class));
+
+        runSuccess(callbacksCaptor.getValue());
+
         verify(photoProgressService).markPromptSent(eq(plant.getId()), any(LocalDateTime.class));
     }
 
     @Test
-    void should_skip_when_user_is_paused() throws TelegramApiException {
+    void should_not_mark_when_send_fails_callback_invoked() {
+        User user = activeUser(100L);
+        Plant plant = duePlant(10L, "Монстера", user);
+        when(plantRepository.findPhotoProgressDue(any(), any())).thenReturn(List.of(plant));
+
+        service.checkPhotoPrompts();
+
+        ArgumentCaptor<SendCallbacks> callbacksCaptor = ArgumentCaptor.forClass(SendCallbacks.class);
+        verify(telegramSender).enqueue(any(SendMessage.class), callbacksCaptor.capture());
+
+        // Photo-progress использует fire-and-forget onFailure=null — провал не должен
+        // ни ронять, ни помечать растение отправленным.
+        runFailure(callbacksCaptor.getValue(),
+                new org.telegram.telegrambots.meta.exceptions.TelegramApiException("boom"));
+
+        verify(photoProgressService, never()).markPromptSent(anyLong(), any(LocalDateTime.class));
+    }
+
+    @Test
+    void should_skip_when_user_is_paused() {
         User user = activeUser(100L);
         user.setPausedUntil(LocalDateTime.now().plusHours(2));
         Plant plant = duePlant(10L, "Монстера", user);
@@ -82,12 +105,12 @@ class PhotoProgressSchedulerServiceTest {
 
         service.checkPhotoPrompts();
 
-        verify(telegramClient, never()).execute(any(SendMessage.class));
+        verifyNoInteractions(telegramSender);
         verify(photoProgressService, never()).markPromptSent(anyLong(), any(LocalDateTime.class));
     }
 
     @Test
-    void should_skip_when_user_is_blocked() throws TelegramApiException {
+    void should_skip_when_user_is_blocked() {
         User user = activeUser(100L);
         user.setBlocked(true);
         Plant plant = duePlant(10L, "Монстера", user);
@@ -95,28 +118,44 @@ class PhotoProgressSchedulerServiceTest {
 
         service.checkPhotoPrompts();
 
-        verify(telegramClient, never()).execute(any(SendMessage.class));
+        verifyNoInteractions(telegramSender);
         verify(photoProgressService, never()).markPromptSent(anyLong(), any(LocalDateTime.class));
     }
 
     @Test
-    void should_continue_processing_when_telegram_fails_for_one_plant() throws TelegramApiException {
+    void should_enqueue_each_due_plant_independently() {
         User user = activeUser(100L);
-        Plant failing = duePlant(10L, "Монстера", user);
-        Plant ok = duePlant(11L, "Фикус", user);
-        when(plantRepository.findPhotoProgressDue(any(), any())).thenReturn(List.of(failing, ok));
-
-        // Первый вызов execute падает, второй проходит. Шедулер должен пометить
-        // отправленным только второе растение, первое — пропустить.
-        when(telegramClient.execute(any(SendMessage.class)))
-                .thenThrow(new TelegramApiException("boom"))
-                .thenReturn(null);
+        Plant first = duePlant(10L, "Монстера", user);
+        Plant second = duePlant(11L, "Фикус", user);
+        when(plantRepository.findPhotoProgressDue(any(), any())).thenReturn(List.of(first, second));
 
         service.checkPhotoPrompts();
 
-        verify(telegramClient, times(2)).execute(any(SendMessage.class));
-        verify(photoProgressService, never()).markPromptSent(eq(failing.getId()), any(LocalDateTime.class));
-        verify(photoProgressService).markPromptSent(eq(ok.getId()), any(LocalDateTime.class));
+        ArgumentCaptor<SendCallbacks> callbacksCaptor = ArgumentCaptor.forClass(SendCallbacks.class);
+        verify(telegramSender, times(2)).enqueue(any(SendMessage.class), callbacksCaptor.capture());
+
+        // Каждый колбэк помечает своё растение — проверяем независимую маршрутизацию.
+        List<SendCallbacks> allCallbacks = callbacksCaptor.getAllValues();
+        runSuccess(allCallbacks.get(0));
+        runSuccess(allCallbacks.get(1));
+
+        verify(photoProgressService).markPromptSent(eq(first.getId()), any(LocalDateTime.class));
+        verify(photoProgressService).markPromptSent(eq(second.getId()), any(LocalDateTime.class));
+    }
+
+    /** Эмулирует вызов onSuccess воркером очереди (с null-guard, как в проде). */
+    private static void runSuccess(SendCallbacks callbacks) {
+        if (callbacks.onSuccess() != null) {
+            callbacks.onSuccess().run();
+        }
+    }
+
+    /** Эмулирует вызов onFailure воркером очереди (с null-guard, как в проде). */
+    private static void runFailure(SendCallbacks callbacks,
+                                   org.telegram.telegrambots.meta.exceptions.TelegramApiException e) {
+        if (callbacks.onFailure() != null) {
+            callbacks.onFailure().accept(e);
+        }
     }
 
     private static User activeUser(Long chatId) {

--- a/src/test/java/com/plantcare/bot/service/VacationSchedulerServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/VacationSchedulerServiceTest.java
@@ -11,6 +11,7 @@ import com.plantcare.bot.repository.LocationRepository;
 import com.plantcare.bot.repository.PlantRepository;
 import com.plantcare.bot.repository.UserRepository;
 import com.plantcare.bot.support.IntegrationTestBase;
+import com.plantcare.bot.telegram.RateLimitedTelegramSender;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,10 +23,10 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
-import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import org.telegram.telegrambots.meta.generics.TelegramClient;
 
 import java.time.Clock;
@@ -43,15 +44,19 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
- * Интеграционные тесты hourly-тика отпуска (issue #53):
- * tomorrow-back за ~24 часа до конца + welcome-back при окончании.
+ * Интеграционные тесты hourly-тика отпуска (issue #53) после перевода на
+ * rate-limited очередь (issue #29): tomorrow-back за ~24 часа до конца +
+ * welcome-back при окончании.
  *
  * <p>Clock зафиксирован на 2026-05-23T10:00:00Z, поэтому окно поиска
  * tomorrow-back = [11:00; 12:00) того же дня (now+23h..now+24h).
- * Telegram-вызовы перехватываем через мок {@link TelegramClientProvider}.
+ *
+ * <p>Отправка теперь идёт fire-and-forget через {@link RateLimitedTelegramSender}
+ * (без колбэков), поэтому проверяем вызовы {@code enqueue(SendMessage)} вместо
+ * прямого {@code TelegramClient.execute}.
  */
 @Import(VacationSchedulerServiceTest.FixedClockConfig.class)
-@DisplayName("VacationSchedulerService (issue #53)")
+@DisplayName("VacationSchedulerService (issue #53 / #29)")
 class VacationSchedulerServiceTest extends IntegrationTestBase {
 
     static final Instant FIXED_NOW = Instant.parse("2026-05-23T10:00:00Z");
@@ -63,11 +68,12 @@ class VacationSchedulerServiceTest extends IntegrationTestBase {
     @Autowired private LocationRepository locationRepository;
     @Autowired private CareScheduleRepository careScheduleRepository;
     @Autowired private UserService userService;
-    @Autowired private TelegramClient telegramClient;
+
+    @MockitoBean private RateLimitedTelegramSender telegramSender;
 
     @BeforeEach
-    void resetClientMock() {
-        Mockito.reset(telegramClient);
+    void resetSenderMock() {
+        Mockito.reset(telegramSender);
     }
 
     @AfterEach
@@ -80,13 +86,13 @@ class VacationSchedulerServiceTest extends IntegrationTestBase {
 
     @Test
     @DisplayName("Tomorrow-back push идёт юзеру, у кого до конца отпуска ~23.5 часа")
-    void should_send_tomorrow_back_push_when_vacation_ends_in_24h() throws TelegramApiException {
+    void should_send_tomorrow_back_push_when_vacation_ends_in_24h() {
         User user = saveUserWithVacation(1000L, NOW_LDT.plusHours(23).plusMinutes(30));
 
         scheduler.tick();
 
         ArgumentCaptor<SendMessage> cap = ArgumentCaptor.forClass(SendMessage.class);
-        verify(telegramClient, times(1)).execute(cap.capture());
+        verify(telegramSender, times(1)).enqueue(cap.capture());
 
         SendMessage sent = cap.getValue();
         assertThat(sent.getChatId()).isEqualTo(user.getTelegramChatId().toString());
@@ -105,48 +111,44 @@ class VacationSchedulerServiceTest extends IntegrationTestBase {
 
     @Test
     @DisplayName("Нет tomorrow-back, если до конца отпуска ещё > 24 часов")
-    void should_not_send_tomorrow_back_when_outside_window() throws TelegramApiException {
+    void should_not_send_tomorrow_back_when_outside_window() {
         saveUserWithVacation(1001L, NOW_LDT.plusHours(30));
 
         scheduler.tick();
 
-        // execute мог быть вызван 0 раз для tomorrow-back и 0 раз для welcome-back.
-        verify(telegramClient, never()).execute(any(SendMessage.class));
+        verify(telegramSender, never()).enqueue(any(SendMessage.class));
     }
 
     @Test
     @DisplayName("Граница окна: pausedUntil ровно в now+24h НЕ попадает (right-exclusive)")
-    void should_not_send_tomorrow_back_when_paused_until_equals_upper_bound()
-            throws TelegramApiException {
+    void should_not_send_tomorrow_back_when_paused_until_equals_upper_bound() {
         // pausedUntil == now + 24h. Окно [now+23h; now+24h) — правая граница исключена.
         saveUserWithVacation(1002L, NOW_LDT.plusHours(24));
 
         scheduler.tick();
 
-        verify(telegramClient, never()).execute(any(SendMessage.class));
+        verify(telegramSender, never()).enqueue(any(SendMessage.class));
     }
 
     @Test
     @DisplayName("Граница окна: pausedUntil ровно в now+23h попадает (left-inclusive)")
-    void should_send_tomorrow_back_when_paused_until_equals_lower_bound()
-            throws TelegramApiException {
+    void should_send_tomorrow_back_when_paused_until_equals_lower_bound() {
         // pausedUntil == now + 23h. Окно [now+23h; now+24h) — левая граница включена.
         saveUserWithVacation(1011L, NOW_LDT.plusHours(23));
 
         scheduler.tick();
 
-        verify(telegramClient, times(1)).execute(any(SendMessage.class));
+        verify(telegramSender, times(1)).enqueue(any(SendMessage.class));
     }
 
     @Test
     @DisplayName("Welcome-back: отпуск закончился → push + paused_until=null")
-    void should_send_welcome_back_and_clear_paused_until_when_vacation_ended()
-            throws TelegramApiException {
+    void should_send_welcome_back_and_clear_paused_until_when_vacation_ended() {
         User user = saveUserWithVacation(1003L, NOW_LDT.minusHours(1));
 
         scheduler.tick();
 
-        verify(telegramClient, times(1)).execute(any(SendMessage.class));
+        verify(telegramSender, times(1)).enqueue(any(SendMessage.class));
 
         User reloaded = userRepository.findById(user.getId()).orElseThrow();
         assertThat(reloaded.getPausedUntil())
@@ -156,7 +158,7 @@ class VacationSchedulerServiceTest extends IntegrationTestBase {
 
     @Test
     @DisplayName("Welcome-back с просрочкой содержит список «За время отпуска накопилось» + растение")
-    void should_include_overdue_tasks_in_welcome_back_message() throws TelegramApiException {
+    void should_include_overdue_tasks_in_welcome_back_message() {
         User user = saveUserWithVacation(1004L, NOW_LDT.minusHours(1));
         Plant plant = savePlant(user, "Монстера");
         saveSchedule(plant, TaskType.WATERING, NOW_LDT.minusDays(5));
@@ -164,7 +166,7 @@ class VacationSchedulerServiceTest extends IntegrationTestBase {
         scheduler.tick();
 
         ArgumentCaptor<SendMessage> cap = ArgumentCaptor.forClass(SendMessage.class);
-        verify(telegramClient).execute(cap.capture());
+        verify(telegramSender).enqueue(cap.capture());
 
         String text = cap.getValue().getText();
         assertThat(text).contains("С возвращением");
@@ -192,13 +194,13 @@ class VacationSchedulerServiceTest extends IntegrationTestBase {
 
     @Test
     @DisplayName("Welcome-back без просрочки — короткое сообщение без блока «накопилось»")
-    void should_send_clean_welcome_back_when_no_overdue() throws TelegramApiException {
+    void should_send_clean_welcome_back_when_no_overdue() {
         saveUserWithVacation(1006L, NOW_LDT.minusHours(1));
 
         scheduler.tick();
 
         ArgumentCaptor<SendMessage> cap = ArgumentCaptor.forClass(SendMessage.class);
-        verify(telegramClient).execute(cap.capture());
+        verify(telegramSender).enqueue(cap.capture());
 
         String text = cap.getValue().getText();
         assertThat(text).contains("С возвращением");
@@ -207,39 +209,39 @@ class VacationSchedulerServiceTest extends IntegrationTestBase {
 
     @Test
     @DisplayName("Welcome-back idempotent: второй тик после очистки paused_until не шлёт повтор")
-    void should_send_welcome_back_only_once_when_tick_runs_twice() throws TelegramApiException {
+    void should_send_welcome_back_only_once_when_tick_runs_twice() {
         saveUserWithVacation(1007L, NOW_LDT.minusHours(1));
 
         scheduler.tick();
         scheduler.tick();
 
         // После первого тика paused_until = null, во втором тике findVacationEnded
-        // его не подберёт. Итого ровно один send.
-        verify(telegramClient, times(1)).execute(any(SendMessage.class));
+        // его не подберёт. Итого ровно один enqueue.
+        verify(telegramSender, times(1)).enqueue(any(SendMessage.class));
     }
 
     @Test
     @DisplayName("Заблокированному юзеру tomorrow-back не уходит")
-    void should_skip_blocked_users_in_tomorrow_back() throws TelegramApiException {
+    void should_skip_blocked_users_in_tomorrow_back() {
         User user = saveUserWithVacation(1008L, NOW_LDT.plusHours(23).plusMinutes(30));
         user.setBlocked(true);
         userRepository.save(user);
 
         scheduler.tick();
 
-        verify(telegramClient, never()).execute(any(SendMessage.class));
+        verify(telegramSender, never()).enqueue(any(SendMessage.class));
     }
 
     @Test
     @DisplayName("Заблокированному юзеру welcome-back не уходит")
-    void should_skip_blocked_users_in_welcome_back() throws TelegramApiException {
+    void should_skip_blocked_users_in_welcome_back() {
         User user = saveUserWithVacation(1009L, NOW_LDT.minusHours(1));
         user.setBlocked(true);
         userRepository.save(user);
 
         scheduler.tick();
 
-        verify(telegramClient, never()).execute(any(SendMessage.class));
+        verify(telegramSender, never()).enqueue(any(SendMessage.class));
         // paused_until НЕ должен очищаться для заблокированных — иначе при разблокировке
         // юзер пропустит welcome-back и попадёт сразу в обычный поток уведомлений.
         User reloaded = userRepository.findById(user.getId()).orElseThrow();
@@ -315,9 +317,9 @@ class VacationSchedulerServiceTest extends IntegrationTestBase {
     /**
      * Подменяет:
      * - Clock — на фиксированный, чтобы расчёты «сейчас + N часов» были детерминированы;
-     * - TelegramClientProvider — на стаб, возвращающий мок TelegramClient. Это удобнее
-     *   чем @MockitoBean, потому что мок должен возвращать ненулевой клиент уже на
-     *   ApplicationReadyEvent (BotCommandsRegistrar дёргает execute() ещё до тестов).
+     * - TelegramClientProvider — на стаб, возвращающий мок TelegramClient. Нужен ещё на
+     *   ApplicationReadyEvent (BotCommandsRegistrar дёргает execute() до тестов), хотя
+     *   сам шедулер отправляет через RateLimitedTelegramSender (замокан отдельно).
      */
     @TestConfiguration
     static class FixedClockConfig {

--- a/src/test/java/com/plantcare/bot/telegram/RateLimitedTelegramSenderTest.java
+++ b/src/test/java/com/plantcare/bot/telegram/RateLimitedTelegramSenderTest.java
@@ -1,0 +1,212 @@
+package com.plantcare.bot.telegram;
+
+import com.plantcare.bot.client.TelegramClientProvider;
+import com.plantcare.bot.config.TelegramRateLimitProperties;
+import com.plantcare.bot.metrics.MetricsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit-тесты пути отправки {@link RateLimitedTelegramSender#sendWithRetry} (issue #29).
+ *
+ * <p>Метод дёргается напрямую (он package-private, тест в том же пакете), очередь
+ * и воркер-поток не поднимаются. {@link Sleeper} застаблен записывающей реализацией —
+ * никакого реального сна на ретраях 429. Внешний Telegram замокан через
+ * {@link TelegramClientProvider}.
+ */
+@DisplayName("RateLimitedTelegramSender.sendWithRetry — отправка с ретраями 429 (issue #29)")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RateLimitedTelegramSenderTest {
+
+    private static final int MAX_RETRIES = 3;
+    private static final long DEFAULT_RETRY_AFTER = 2L;
+
+    @Mock
+    private TelegramClientProvider telegramClientProvider;
+
+    @Mock
+    private TelegramClient telegramClient;
+
+    @Mock
+    private TokenBucketRateLimiter rateLimiter;
+
+    @Mock
+    private MetricsService metricsService;
+
+    private RecordingSleeper sleeper;
+    private RateLimitedTelegramSender sender;
+
+    @BeforeEach
+    void setUp() {
+        sleeper = new RecordingSleeper();
+        TelegramRateLimitProperties properties = new TelegramRateLimitProperties(
+                25, 100, MAX_RETRIES, DEFAULT_RETRY_AFTER, 60L);
+        sender = new RateLimitedTelegramSender(
+                telegramClientProvider, rateLimiter, sleeper, properties, metricsService);
+        when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
+    }
+
+    @Test
+    @DisplayName("should_call_execute_once_and_run_success_when_send_succeeds")
+    void should_call_execute_once_and_run_success_when_send_succeeds() throws Exception {
+        // arrange
+        AtomicBoolean successRan = new AtomicBoolean(false);
+        AtomicBoolean failureRan = new AtomicBoolean(false);
+        SendCallbacks callbacks = new SendCallbacks(
+                () -> successRan.set(true),
+                e -> failureRan.set(true));
+
+        // act
+        sender.sendWithRetry(message("100"), callbacks);
+
+        // assert
+        verify(telegramClient, times(1)).execute(any(SendMessage.class));
+        assertThat(successRan).isTrue();
+        assertThat(failureRan).isFalse();
+        assertThat(sleeper.sleeps).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_retry_once_with_parsed_retry_after_when_429_then_succeeds")
+    void should_retry_once_with_parsed_retry_after_when_429_then_succeeds() throws Exception {
+        // arrange: первая попытка — 429 с «retry after 30», вторая — успех.
+        when(telegramClient.execute(any(SendMessage.class)))
+                .thenThrow(new TelegramApiException("[429] Too Many Requests: retry after 30"))
+                .thenReturn(null);
+
+        AtomicBoolean successRan = new AtomicBoolean(false);
+        SendCallbacks callbacks = new SendCallbacks(() -> successRan.set(true), null);
+
+        // act
+        sender.sendWithRetry(message("100"), callbacks);
+
+        // assert: ровно 2 вызова execute, пауза = распарсенные 30s в миллисекундах.
+        verify(telegramClient, times(2)).execute(any(SendMessage.class));
+        assertThat(sleeper.sleeps).containsExactly(30_000L);
+        assertThat(successRan).isTrue();
+        verify(metricsService).recordTelegramApiError(MetricsService.TelegramErrorCode.RATE_LIMITED);
+    }
+
+    @Test
+    @DisplayName("should_fall_back_to_default_retry_after_when_429_has_no_parsable_value")
+    void should_fall_back_to_default_retry_after_when_429_has_no_parsable_value() throws Exception {
+        // arrange: 429 без числа retry-after → fallback из конфигурации.
+        when(telegramClient.execute(any(SendMessage.class)))
+                .thenThrow(new TelegramApiException("[429] Too Many Requests"))
+                .thenReturn(null);
+
+        // act
+        sender.sendWithRetry(message("100"), SendCallbacks.none());
+
+        // assert
+        assertThat(sleeper.sleeps).containsExactly(DEFAULT_RETRY_AFTER * 1000L);
+    }
+
+    @Test
+    @DisplayName("should_retry_exactly_max_retries_then_fail_when_429_persists")
+    void should_retry_exactly_max_retries_then_fail_when_429_persists() throws Exception {
+        // arrange: 429 на каждой попытке — ретраи ограничены, без бесконечного цикла.
+        when(telegramClient.execute(any(SendMessage.class)))
+                .thenThrow(new TelegramApiException("[429] Too Many Requests: retry after 5"));
+
+        AtomicBoolean successRan = new AtomicBoolean(false);
+        AtomicReference<TelegramApiException> failure = new AtomicReference<>();
+        SendCallbacks callbacks = new SendCallbacks(
+                () -> successRan.set(true),
+                failure::set);
+
+        // act
+        sender.sendWithRetry(message("100"), callbacks);
+
+        // assert: 1 первичная попытка + MAX_RETRIES ретраев = MAX_RETRIES + 1 вызовов.
+        verify(telegramClient, times(MAX_RETRIES + 1)).execute(any(SendMessage.class));
+        assertThat(sleeper.sleeps).hasSize(MAX_RETRIES);
+        assertThat(successRan).isFalse();
+        assertThat(failure.get())
+                .isNotNull()
+                .hasMessageContaining("429");
+    }
+
+    @Test
+    @DisplayName("should_not_retry_and_fail_immediately_when_error_is_403")
+    void should_not_retry_and_fail_immediately_when_error_is_403() throws Exception {
+        // arrange: 403 — неретраябельная ошибка.
+        TelegramApiException forbidden =
+                new TelegramApiException("Forbidden: bot was blocked by the user [403]");
+        when(telegramClient.execute(any(SendMessage.class))).thenThrow(forbidden);
+
+        AtomicReference<TelegramApiException> failure = new AtomicReference<>();
+        SendCallbacks callbacks = new SendCallbacks(null, failure::set);
+
+        // act
+        sender.sendWithRetry(message("100"), callbacks);
+
+        // assert: ровно один вызов, никакого сна, onFailure получил то же исключение.
+        verify(telegramClient, times(1)).execute(any(SendMessage.class));
+        assertThat(sleeper.sleeps).isEmpty();
+        assertThat(failure.get()).isSameAs(forbidden);
+        verify(metricsService).recordTelegramApiError(MetricsService.TelegramErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("should_not_throw_when_callbacks_are_none_on_success")
+    void should_not_throw_when_callbacks_are_none_on_success() {
+        // arrange: успех с заглушечными колбэками не должен бросать NPE.
+
+        // act + assert
+        assertThatNoException().isThrownBy(() ->
+                sender.sendWithRetry(message("100"), SendCallbacks.none()));
+    }
+
+    @Test
+    @DisplayName("should_not_throw_when_callbacks_are_none_on_failure")
+    void should_not_throw_when_callbacks_are_none_on_failure() throws Exception {
+        // arrange: неретраябельная ошибка с заглушечными колбэками — без NPE.
+        when(telegramClient.execute(any(SendMessage.class)))
+                .thenThrow(new TelegramApiException("Bad Request: chat not found [400]"));
+
+        // act + assert
+        assertThatNoException().isThrownBy(() ->
+                sender.sendWithRetry(message("100"), SendCallbacks.none()));
+        verify(telegramClient, times(1)).execute(any(SendMessage.class));
+    }
+
+    private static SendMessage message(String chatId) {
+        return SendMessage.builder()
+                .chatId(chatId)
+                .text("hi")
+                .build();
+    }
+
+    /** Стаб-{@link Sleeper}: ничего не ждёт, лишь запоминает запрошенные паузы. */
+    private static final class RecordingSleeper implements Sleeper {
+        private final List<Long> sleeps = new ArrayList<>();
+
+        @Override
+        public void sleep(long millis) {
+            sleeps.add(millis);
+        }
+    }
+}

--- a/src/test/java/com/plantcare/bot/telegram/RateLimitedTelegramSenderWorkerTest.java
+++ b/src/test/java/com/plantcare/bot/telegram/RateLimitedTelegramSenderWorkerTest.java
@@ -1,0 +1,230 @@
+package com.plantcare.bot.telegram;
+
+import com.plantcare.bot.client.TelegramClientProvider;
+import com.plantcare.bot.config.TelegramRateLimitProperties;
+import com.plantcare.bot.metrics.MetricsService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Тесты РЕАЛЬНОГО воркер-потока очереди {@link RateLimitedTelegramSender} (issue #29).
+ *
+ * <p>В отличие от {@link RateLimitedTelegramSenderTest}, который дёргает
+ * {@code sendWithRetry} синхронно, здесь поднимается настоящий daemon-поток через
+ * {@code @PostConstruct start()} (вызываем вручную — Spring-контекста нет), и
+ * сообщения проходят весь путь {@code enqueue → drainLoop → sendWithRetry → callbacks}.
+ *
+ * <p>Ключевой регрессионный кейс: исключение из колбэка НЕ должно убивать
+ * единственный воркер-поток (иначе очередь встаёт навсегда). Воркер обязан
+ * изолировать сбой и продолжить дренаж.
+ *
+ * <p>Ожидания синхронизируются через {@link CountDownLatch} (Awaitility в проекте
+ * не подключён) — без unbounded {@code Thread.sleep}. {@link Sleeper} застаблен,
+ * rate limiter не тормозит (0 мс ожидания).
+ */
+@DisplayName("RateLimitedTelegramSender — воркер очереди и изоляция сбоев (issue #29)")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RateLimitedTelegramSenderWorkerTest {
+
+    private static final long AWAIT_TIMEOUT_SECONDS = 5L;
+
+    @Mock
+    private TelegramClientProvider telegramClientProvider;
+
+    @Mock
+    private TelegramClient telegramClient;
+
+    @Mock
+    private TokenBucketRateLimiter rateLimiter;
+
+    @Mock
+    private MetricsService metricsService;
+
+    private RateLimitedTelegramSender sender;
+
+    @AfterEach
+    void tearDown() {
+        if (sender != null) {
+            sender.stop();
+        }
+    }
+
+    private void startSender(int queueCapacity, Sleeper sleeper) {
+        startSender(queueCapacity, sleeper, 0L);
+    }
+
+    private void startSender(int queueCapacity, Sleeper sleeper, long reservedMillis) {
+        TelegramRateLimitProperties properties = new TelegramRateLimitProperties(
+                1000, queueCapacity, 3, 2L, 60L);
+        sender = new RateLimitedTelegramSender(
+                telegramClientProvider, rateLimiter, sleeper, properties, metricsService);
+        when(telegramClientProvider.getTelegramClient()).thenReturn(telegramClient);
+        when(rateLimiter.reserveNextPermitMillis()).thenReturn(reservedMillis);
+        sender.start();
+    }
+
+    @Test
+    @DisplayName("should_execute_message_on_worker_thread_when_enqueued")
+    void should_execute_message_on_worker_thread_when_enqueued() throws Exception {
+        // arrange
+        CountDownLatch executed = new CountDownLatch(1);
+        doAnswer(inv -> {
+            executed.countDown();
+            return null;
+        }).when(telegramClient).execute(any(SendMessage.class));
+        startSender(100, noOpSleeper());
+
+        // act
+        sender.enqueue(message("100"));
+
+        // assert
+        assertThat(executed.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                .as("worker thread should have executed the enqueued message")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("should_keep_draining_when_a_success_callback_throws")
+    void should_keep_draining_when_a_success_callback_throws() throws Exception {
+        // arrange: A and B both succeed at the Telegram layer; A's onSuccess throws.
+        // The worker must NOT die after A — B must still be delivered and its onSuccess run.
+        List<String> executedChatIds = new CopyOnWriteArrayList<>();
+        doAnswer(inv -> {
+            SendMessage sent = inv.getArgument(0);
+            executedChatIds.add(sent.getChatId());
+            return null;
+        }).when(telegramClient).execute(any(SendMessage.class));
+        startSender(100, noOpSleeper());
+
+        AtomicBoolean aSuccessRan = new AtomicBoolean(false);
+        CountDownLatch bSuccess = new CountDownLatch(1);
+
+        SendCallbacks throwingOnSuccess = new SendCallbacks(
+                () -> {
+                    aSuccessRan.set(true);
+                    throw new RuntimeException("boom from A's onSuccess");
+                },
+                null);
+        SendCallbacks normalCallbacks = new SendCallbacks(bSuccess::countDown, null);
+
+        // act
+        sender.enqueue(message("A"), throwingOnSuccess);
+        sender.enqueue(message("B"), normalCallbacks);
+
+        // assert: B was delivered AND its success callback ran — worker survived A's throw.
+        assertThat(bSuccess.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                .as("B's onSuccess must run — worker must survive A's throwing callback")
+                .isTrue();
+        assertThat(aSuccessRan)
+                .as("A's onSuccess must have been invoked (and thrown)")
+                .isTrue();
+        assertThat(executedChatIds).containsExactly("A", "B");
+    }
+
+    @Test
+    @DisplayName("should_keep_draining_when_send_fails_and_failure_callback_throws")
+    void should_keep_draining_when_send_fails_and_failure_callback_throws() throws Exception {
+        // arrange: A's execute throws a non-429 error AND A's onFailure throws (DB-style).
+        // B then succeeds normally and must still be delivered.
+        List<String> executedChatIds = new CopyOnWriteArrayList<>();
+        TelegramApiException nonRetryable =
+                new TelegramApiException("Forbidden: bot was blocked by the user [403]");
+        doAnswer(inv -> {
+            SendMessage sent = inv.getArgument(0);
+            executedChatIds.add(sent.getChatId());
+            if ("A".equals(sent.getChatId())) {
+                throw nonRetryable;
+            }
+            return null;
+        }).when(telegramClient).execute(any(SendMessage.class));
+        startSender(100, noOpSleeper());
+
+        CountDownLatch bSuccess = new CountDownLatch(1);
+        SendCallbacks throwingOnFailure = new SendCallbacks(
+                null,
+                e -> {
+                    throw new RuntimeException("boom from A's onFailure", e);
+                });
+        SendCallbacks normalCallbacks = new SendCallbacks(bSuccess::countDown, null);
+
+        // act
+        sender.enqueue(message("A"), throwingOnFailure);
+        sender.enqueue(message("B"), normalCallbacks);
+
+        // assert: B delivered and acked despite A's failure callback throwing.
+        assertThat(bSuccess.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                .as("B must be delivered — worker must survive A's throwing failure callback")
+                .isTrue();
+        assertThat(executedChatIds).containsExactly("A", "B");
+    }
+
+    @Test
+    @DisplayName("should_drop_overflow_messages_without_blocking_caller_when_queue_full")
+    void should_drop_overflow_messages_without_blocking_caller_when_queue_full() throws Exception {
+        // arrange: worker is parked inside the rate-limiter sleep on the first message,
+        // so it cannot drain the queue. Capacity is 1, so beyond that messages are dropped.
+        CountDownLatch workerParked = new CountDownLatch(1);
+        CountDownLatch releaseWorker = new CountDownLatch(1);
+        Sleeper blockingSleeper = millis -> {
+            workerParked.countDown();
+            try {
+                releaseWorker.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw e;
+            }
+        };
+        startSender(1, blockingSleeper, 50L);
+
+        // First message: worker pulls it and parks in the sleeper before executing.
+        sender.enqueue(message("first"));
+        assertThat(workerParked.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                .as("worker should have pulled the first message and parked in the sleeper")
+                .isTrue();
+
+        // act: queue (capacity 1) takes "queued"; "dropped" overflows. enqueue must not block.
+        sender.enqueue(message("queued"));
+        sender.enqueue(message("dropped"));
+
+        // assert: the overflowing message was dropped → one OTHER-failure metric recorded.
+        verify(metricsService).recordNotificationFailed(
+                MetricsService.CHANNEL_TELEGRAM, MetricsService.FailureReason.OTHER);
+
+        // release the worker so @AfterEach shutdown is clean.
+        releaseWorker.countDown();
+    }
+
+    private static SendMessage message(String chatId) {
+        return SendMessage.builder()
+                .chatId(chatId)
+                .text("hi")
+                .build();
+    }
+
+    private static Sleeper noOpSleeper() {
+        return millis -> { /* no real sleep — tests must be fast */ };
+    }
+}

--- a/src/test/java/com/plantcare/bot/telegram/TokenBucketRateLimiterTest.java
+++ b/src/test/java/com/plantcare/bot/telegram/TokenBucketRateLimiterTest.java
@@ -1,0 +1,157 @@
+package com.plantcare.bot.telegram;
+
+import com.plantcare.bot.config.TelegramRateLimitProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit-тесты {@link TokenBucketRateLimiter} (issue #29) на детерминированном,
+ * вручную сдвигаемом {@link Clock}. Никаких реальных пауз и реального времени —
+ * счётчик токенов проверяется по математике пополнения.
+ */
+@DisplayName("TokenBucketRateLimiter — детерминированный token bucket (issue #29)")
+class TokenBucketRateLimiterTest {
+
+    private static final int PERMITS_PER_SECOND = 5;
+
+    private MutableClock clock;
+    private TokenBucketRateLimiter limiter;
+
+    @BeforeEach
+    void setUp() {
+        clock = new MutableClock(Instant.parse("2026-05-25T10:00:00Z"));
+        TelegramRateLimitProperties properties = new TelegramRateLimitProperties(
+                PERMITS_PER_SECOND, 100, 3, 1L, 60L);
+        limiter = new TokenBucketRateLimiter(properties, clock);
+    }
+
+    @Test
+    @DisplayName("should_return_zero_wait_for_first_burst_within_one_second")
+    void should_return_zero_wait_for_first_burst_within_one_second() {
+        // arrange: ведро стартует полным (= permitsPerSecond), время не двигаем.
+
+        // act + assert: первые N permit'ов уходят мгновенно.
+        for (int i = 0; i < PERMITS_PER_SECOND; i++) {
+            assertThat(limiter.reserveNextPermitMillis())
+                    .as("permit #%d должен быть доступен немедленно", i + 1)
+                    .isZero();
+        }
+    }
+
+    @Test
+    @DisplayName("should_return_positive_wait_when_bucket_exhausted_in_same_second")
+    void should_return_positive_wait_when_bucket_exhausted_in_same_second() {
+        // arrange: исчерпываем весь стартовый запас в тот же момент времени.
+        for (int i = 0; i < PERMITS_PER_SECOND; i++) {
+            limiter.reserveNextPermitMillis();
+        }
+
+        // act: (N+1)-й permit в ту же секунду.
+        long wait = limiter.reserveNextPermitMillis();
+
+        // assert: ждать придётся ~ до накопления одного токена = 1000/permitsPerSecond.
+        assertThat(wait)
+                .isPositive()
+                .isLessThanOrEqualTo(1000L / PERMITS_PER_SECOND);
+    }
+
+    @Test
+    @DisplayName("should_return_zero_wait_again_after_clock_advanced_past_refill_window")
+    void should_return_zero_wait_again_after_clock_advanced_past_refill_window() {
+        // arrange: исчерпали стартовый запас.
+        for (int i = 0; i < PERMITS_PER_SECOND; i++) {
+            limiter.reserveNextPermitMillis();
+        }
+        assertThat(limiter.reserveNextPermitMillis())
+                .as("сразу после исчерпания запаса ждём положительную паузу")
+                .isPositive();
+
+        // act: сдвигаем часы на секунду вперёд — ведро успело пополниться.
+        clock.advanceMillis(1_000);
+
+        // assert: токен снова доступен немедленно.
+        assertThat(limiter.reserveNextPermitMillis())
+                .as("после пополнения за 1с permit снова мгновенный")
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("should_cap_refill_at_capacity_when_idle_for_long")
+    void should_cap_refill_at_capacity_when_idle_for_long() {
+        // arrange: один permit, затем долгий простой (10 секунд).
+        limiter.reserveNextPermitMillis();
+        clock.advanceMillis(10_000);
+
+        // act + assert: ведро не накопит больше capacity=permitsPerSecond токенов,
+        // значит мгновенных permit'ов будет ровно permitsPerSecond, не больше.
+        for (int i = 0; i < PERMITS_PER_SECOND; i++) {
+            assertThat(limiter.reserveNextPermitMillis())
+                    .as("permit #%d после простоя должен быть мгновенным (в пределах capacity)", i + 1)
+                    .isZero();
+        }
+
+        assertThat(limiter.reserveNextPermitMillis())
+                .as("permit сверх capacity уже требует ожидания — накопление не безгранично")
+                .isPositive();
+    }
+
+    @Test
+    @DisplayName("should_treat_permits_per_second_below_one_as_one")
+    void should_treat_permits_per_second_below_one_as_one() {
+        // arrange: некорректная конфигурация (0) не должна ронять делением/циклом.
+        TelegramRateLimitProperties zeroProps = new TelegramRateLimitProperties(0, 100, 3, 1L, 60L);
+        TokenBucketRateLimiter zeroLimiter = new TokenBucketRateLimiter(zeroProps, clock);
+
+        // act: один permit уходит сразу (capacity подтянут к минимуму 1).
+        long first = zeroLimiter.reserveNextPermitMillis();
+        long second = zeroLimiter.reserveNextPermitMillis();
+
+        // assert: первый мгновенно, второй ждёт ~секунду (1 permit/sec).
+        assertThat(first).isZero();
+        assertThat(second).isPositive().isLessThanOrEqualTo(1000L);
+    }
+
+    /**
+     * Сдвигаемый Clock: лимитер читает только {@link #millis()}/{@link #instant()},
+     * поэтому достаточно подменять текущий момент между вызовами.
+     */
+    private static final class MutableClock extends Clock {
+        private Instant now;
+
+        private MutableClock(Instant start) {
+            this.now = start;
+        }
+
+        void advanceMillis(long millis) {
+            now = now.plusMillis(millis);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return now;
+        }
+
+        @Override
+        public long millis() {
+            return now.toEpochMilli();
+        }
+    }
+}


### PR DESCRIPTION
Closes #29

## Что сделано
- Новый `RateLimitedTelegramSender` (@Service, `com.plantcare.bot.telegram`): in-memory bounded-очередь + один daemon-воркер, дренящий со скоростью ≤ `permits-per-second` (token bucket с запасом под лимит Telegram ~30/sec). На `429` воркер ждёт `retry_after` (с потолком `max-retry-after-seconds`) и повторяет до `max-retries` раз; при переполнении очереди сообщение дропается с метрикой, не блокируя шедулер. Любой `Throwable` из воркера/коллбэка изолируется — один сбой не убивает поток.
- `TokenBucketRateLimiter` — Clock-driven, потокобезопасный.
- `TelegramRateLimitProperties` (`telegram.rate-limit`) + блок в `application.yml` (`permits-per-second=25`, `queue-capacity=10000`, `max-retries=3`, `default-retry-after-seconds=1`, `max-retry-after-seconds=60`).
- `NotificationDeliveryCallbacks` — post-send bookkeeping (dedup-log, метрики, пометка `blocked` на 403) выполняется в отдельных транзакциях на воркер-потоке, сущности резолвятся по id (без detached-сущностей между потоками).
- Шедулеры Notification / MonthlyReport / PlantAnniversary / Vacation / PhotoProgress / Acclimation шлют через очередь.

## Охват / решения
- Скоуп — только mass-send пути (шедулеры). Интерактивные command/state/callback хендлеры (1 сообщение на действие юзера) и `AdminBroadcastService` (свой троттлинг + синхронный результат для пометки blocked) намеренно НЕ трогаем.
- Использована простая внутренняя очередь, **не Bucket4j** — по AC и чтобы не добавлять зависимость.
- Отправка стала fire-and-forget (`enqueue` не бросает); dedup `NotificationLog` теперь пишется по async-успеху через коллбэк. На текущем масштабе (один юзер, очередь дренит сильно быстрее 60-сек тика) — безопасно.

## Миграции
Нет (in-memory очередь + конфиг-проперти, схема БД не меняется).

## Backward-compat риски
Safe. Новые env-переменные `TELEGRAM_RATE_LIMIT_*` имеют дефолты; без них поведение корректное. Schema не трогается. Один релиз.

## Тесты
- `TokenBucketRateLimiterTest` — token bucket на mutable Clock (burst/исчерпание/refill/cap).
- `RateLimitedTelegramSenderTest` — `sendWithRetry`: happy, 429-retry с парсингом `retry_after`, fallback, исчерпание `max-retries`→onFailure, 403 без ретрая, null-коллбэки.
- `RateLimitedTelegramSenderWorkerTest` — реальный воркер: happy, **изоляция падений** (бросающий success/failure-коллбэк не убивает воркер — регресс на BLOCKING из ревью), queue-full drop без блокировки caller.
- `NotificationDeliveryCallbacksTest` — Testcontainers Postgres: dedup-log, digest, 403→blocked, неизвестный chatId без падения.
- Мигрированы существующие scheduler-тесты на async-модель; кейсы с не-UTC таймзонами (Asia/Almaty, Europe/Minsk) сохранены.

Изолированный прогон затронутых классов: **BUILD SUCCESS, 67/67**.

## Чек
- [x] `./mvnw verify` зелёное по затронутым классам (67/67 в изоляции). В полном прогоне `verify` падают только pre-existing flaky DB/Testcontainers тесты (Species*/PlantService popularity, UserRepository/CareSchedule contention) — не относятся к диффу (species/admin-файлов в диффе нет).
- [x] reviewer прошёл: 1 BLOCKING (воркер умирал на unchecked-исключении коллбэка) + 3 SHOULD-FIX (нет теста воркер-пути; unbounded retry-after; `getReferenceById` на удалённом растении) — все исправлены. Принятые NIT: метрика 429 теперь считается по попытке ретрая; at-least-once для acclimation/anniversary при сбое отправки.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
