### PR TITLE
feat: смена таймзоны и тихих часов в меню «Настройки» (#116)

### DIFF
--- a/src/main/java/com/plantcare/bot/beans/PlantsCareBot.java
+++ b/src/main/java/com/plantcare/bot/beans/PlantsCareBot.java
@@ -40,6 +40,7 @@ public class PlantsCareBot implements LongPollingSingleThreadUpdateConsumer, Tel
     private static final String PHOTO_PROGRESS_CALLBACK_PREFIX = "PHOTO_PROGRESS:";
     private static final String SHOPPING_CALLBACK_PREFIX = "SHOPPING:";
     private static final String DISEASE_CALLBACK_PREFIX = "DISEASE:";
+    private static final String SET_TZ_CALLBACK_PREFIX = "SET_TZ";
 
     private final TelegramClient telegramClient;
     private final CommandContainer commandContainer;
@@ -129,6 +130,18 @@ public class PlantsCareBot implements LongPollingSingleThreadUpdateConsumer, Tel
                     User user = userService.findOrCreate(chatId, userName);
 
                     menuCallbackService.handleCallback(update.getCallbackQuery(), telegramClient, user);
+                    return;
+                }
+
+                // Issue #116: SET_TZ:<zone> и SET_TZ_CUSTOM из inline-пикера ручного
+                // ввода таймзоны обслуживает не MenuCallbackService, а машина состояний
+                // (AwaitingTimezoneManualStateHandler, состояние AWAITING_TIMEZONE_MANUAL).
+                // startsWith("SET_TZ") покрывает оба варианта — маршрутизируем в stateResolver.
+                if (data != null && data.startsWith(SET_TZ_CALLBACK_PREFIX)) {
+                    String userName = getUserName(update);
+                    User user = userService.findOrCreate(chatId, userName);
+
+                    stateResolver.resolve(user, update, telegramClient);
                     return;
                 }
 

--- a/src/main/java/com/plantcare/bot/domain/enums/ConversationState.java
+++ b/src/main/java/com/plantcare/bot/domain/enums/ConversationState.java
@@ -6,6 +6,11 @@ public enum ConversationState {
     // Онбординг
     AWAITING_TIMEZONE,
     AWAITING_TIMEZONE_MANUAL,
+    AWAITING_TIMEZONE_CUSTOM,          // issue #116: ручной ввод ZoneId текстом
+
+    // Настройки: тихие часы (issue #116)
+    AWAITING_QUIET_START,
+    AWAITING_QUIET_END,
 
     // Создание растения
     AWAITING_PLANT_SPECIES_CHOICE,

--- a/src/main/java/com/plantcare/bot/service/MenuCallbackService.java
+++ b/src/main/java/com/plantcare/bot/service/MenuCallbackService.java
@@ -44,6 +44,7 @@ import java.util.List;
 public class MenuCallbackService {
 
     private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("dd.MM");
+    private static final DateTimeFormatter QUIET_TIME_FMT = DateTimeFormatter.ofPattern("HH:mm");
 
     private static final EnumSet<ConversationState> EDIT_MODE_STATES = EnumSet.of(
             ConversationState.AWAITING_PLANT_RENAME,
@@ -76,6 +77,7 @@ public class MenuCallbackService {
     private final ShoppingListMenuService shoppingListMenuService;
     private final DiseaseMenuService diseaseMenuService;
     private final SeasonalMenuService seasonalMenuService;
+    private final UserSettingsService userSettingsService;
 
     private record LocationPreset(String name, String emoji) {
     }
@@ -341,6 +343,28 @@ public class MenuCallbackService {
             case "CHANGE_TZ" -> {
                 userService.updateState(user, ConversationState.AWAITING_TIMEZONE);
                 sendTimezonePrompt(user, client);
+                answerCallback(client, callbackId, "");
+            }
+
+            // ===== Тихие часы (issue #116) =====
+            case "QUIET_HOURS" -> {
+                sendQuietHoursMenu(user, client);
+                answerCallback(client, callbackId, "");
+            }
+            case "QUIET_START" -> {
+                userService.updateState(user, ConversationState.AWAITING_QUIET_START);
+                sendText(user, client, "Введи время начала тихих часов в формате ЧЧ:ММ (например 22:00):");
+                answerCallback(client, callbackId, "");
+            }
+            case "QUIET_END" -> {
+                userService.updateState(user, ConversationState.AWAITING_QUIET_END);
+                sendText(user, client, "Введи время конца тихих часов в формате ЧЧ:ММ (например 09:00):");
+                answerCallback(client, callbackId, "");
+            }
+            case "QUIET_RESET" -> {
+                userSettingsService.resetQuietHours(user);
+                sendText(user, client, "🌙 Тихие часы сброшены: 22:00–09:00.");
+                sendQuietHoursMenu(user, client);
                 answerCallback(client, callbackId, "");
             }
 
@@ -1627,8 +1651,16 @@ public class MenuCallbackService {
                 )))
                 .keyboardRow(new InlineKeyboardRow(List.of(
                         InlineKeyboardButton.builder()
-                                .text("🌍 Изменить регион")
+                                .text("🌐 Таймзона: " + user.getTimezone())
                                 .callbackData("MENU:CHANGE_TZ")
+                                .build()
+                )))
+                .keyboardRow(new InlineKeyboardRow(List.of(
+                        InlineKeyboardButton.builder()
+                                .text("🌙 Тихие часы: "
+                                        + user.getQuietHoursStart().format(QUIET_TIME_FMT) + "–"
+                                        + user.getQuietHoursEnd().format(QUIET_TIME_FMT))
+                                .callbackData("MENU:QUIET_HOURS")
                                 .build()
                 )))
                 .keyboardRow(new InlineKeyboardRow(List.of(
@@ -1679,6 +1711,59 @@ public class MenuCallbackService {
             client.execute(message);
         } catch (TelegramApiException e) {
             log.error("Failed to send settings menu", e);
+        }
+    }
+
+    /**
+     * Экран редактирования тихих часов (issue #116).
+     */
+    private void sendQuietHoursMenu(User user, TelegramClient client) {
+        String start = user.getQuietHoursStart().format(QUIET_TIME_FMT);
+        String end = user.getQuietHoursEnd().format(QUIET_TIME_FMT);
+
+        InlineKeyboardMarkup keyboard = InlineKeyboardMarkup.builder()
+                .keyboardRow(new InlineKeyboardRow(List.of(
+                        InlineKeyboardButton.builder()
+                                .text("Изменить начало")
+                                .callbackData("MENU:QUIET_START")
+                                .build()
+                )))
+                .keyboardRow(new InlineKeyboardRow(List.of(
+                        InlineKeyboardButton.builder()
+                                .text("Изменить конец")
+                                .callbackData("MENU:QUIET_END")
+                                .build()
+                )))
+                .keyboardRow(new InlineKeyboardRow(List.of(
+                        InlineKeyboardButton.builder()
+                                .text("Сбросить (22:00–09:00)")
+                                .callbackData("MENU:QUIET_RESET")
+                                .build()
+                )))
+                .keyboardRow(new InlineKeyboardRow(List.of(
+                        InlineKeyboardButton.builder()
+                                .text("⬅️ Назад")
+                                .callbackData("MENU:SETTINGS")
+                                .build()
+                )))
+                .build();
+
+        SendMessage message = SendMessage.builder()
+                .chatId(user.getTelegramChatId().toString())
+                .text("""
+                        🌙 Тихие часы
+
+                        Сейчас: %s–%s
+
+                        В это время бот не присылает напоминания.
+                        """.formatted(start, end))
+                .replyMarkup(keyboard)
+                .build();
+
+        try {
+            client.execute(message);
+        } catch (TelegramApiException e) {
+            log.error("Failed to send quiet hours menu", e);
         }
     }
 

--- a/src/main/java/com/plantcare/bot/service/UserSettingsService.java
+++ b/src/main/java/com/plantcare/bot/service/UserSettingsService.java
@@ -1,0 +1,158 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.CareSchedule;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.repository.CareScheduleRepository;
+import com.plantcare.bot.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * Настройки пользователя из меню «⚙️ Настройки» (issue #116): смена таймзоны
+ * и редактирование тихих часов.
+ *
+ * <p>Ключевой момент — смена таймзоны пересчитывает {@code nextDueAt} активных
+ * расписаний так, чтобы «локальное время дня» сохранилось (полить в 9:00 в Минске
+ * остаётся 9:00 в Алматы). {@code nextDueAt} хранится как UTC wall-clock
+ * {@link LocalDateTime} (так же пишет {@link UserService#startVacation}), поэтому
+ * конвертация проходит через {@link ZoneOffset#UTC}.
+ *
+ * <p>Telegram-вызовов внутри транзакции нет (см. CLAUDE.md). Все методы только
+ * меняют состояние БД и возвращают данные для последующей отправки наружу.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserSettingsService {
+
+    private static final DateTimeFormatter TIME_FMT = DateTimeFormatter.ofPattern("HH:mm");
+
+    private final UserRepository userRepository;
+    private final CareScheduleRepository careScheduleRepository;
+    private final QuietHoursPolicy quietHoursPolicy;
+
+    /**
+     * Результат смены таймзоны для построения подтверждающего сообщения.
+     *
+     * @param newZoneId          новый ZoneId юзера (например {@code Asia/Almaty})
+     * @param rescheduledCount   сколько активных расписаний пересчитано
+     * @param quietHoursConflict есть ли среди пересчитанных хотя бы одно, чей новый
+     *                           момент попадает в тихие часы юзера
+     */
+    public record TimezoneChangeResult(String newZoneId, int rescheduledCount, boolean quietHoursConflict) {
+    }
+
+    /**
+     * Меняет таймзону юзера и пересчитывает {@code nextDueAt} активных расписаний,
+     * сохраняя локальное время дня в новой зоне.
+     */
+    @Transactional
+    public TimezoneChangeResult changeTimezone(User user, ZoneId newZone) {
+        ZoneId oldZone = resolveZone(user.getTimezone());
+
+        user.setTimezone(newZone.getId());
+
+        List<CareSchedule> schedules = careScheduleRepository.findActiveSchedulesByUserId(user.getId());
+
+        boolean quietHoursConflict = false;
+
+        for (CareSchedule schedule : schedules) {
+            LocalDateTime oldNext = schedule.getNextDueAt();
+            if (oldNext == null) {
+                continue;
+            }
+
+            Instant oldInstant = oldNext.toInstant(ZoneOffset.UTC);
+            ZonedDateTime oldLocal = oldInstant.atZone(oldZone);
+            Instant newInstant = ZonedDateTime.of(oldLocal.toLocalDate(), oldLocal.toLocalTime(), newZone)
+                    .toInstant();
+
+            schedule.setNextDueAt(LocalDateTime.ofInstant(newInstant, ZoneOffset.UTC));
+
+            // user.timezone уже = newZone, поэтому isQuiet считает в новой зоне.
+            if (quietHoursPolicy.isQuiet(user, newInstant)) {
+                quietHoursConflict = true;
+            }
+        }
+
+        userRepository.save(user);
+        careScheduleRepository.saveAll(schedules);
+
+        log.info("Timezone changed to {} for user {}, rescheduled {} schedules (quietConflict={})",
+                newZone.getId(), user.getTelegramChatId(), schedules.size(), quietHoursConflict);
+
+        return new TimezoneChangeResult(newZone.getId(), schedules.size(), quietHoursConflict);
+    }
+
+    /**
+     * Устанавливает начало тихих часов. Пересчёта расписаний не делаем — тихие часы
+     * применяются на этапе отправки, не хранения.
+     */
+    @Transactional
+    public void setQuietHoursStart(User user, LocalTime start) {
+        user.setQuietHoursStart(start);
+        userRepository.save(user);
+        log.info("Quiet hours start set to {} for user {}", start, user.getTelegramChatId());
+    }
+
+    @Transactional
+    public void setQuietHoursEnd(User user, LocalTime end) {
+        user.setQuietHoursEnd(end);
+        userRepository.save(user);
+        log.info("Quiet hours end set to {} for user {}", end, user.getTelegramChatId());
+    }
+
+    @Transactional
+    public void resetQuietHours(User user) {
+        user.setQuietHoursStart(LocalTime.of(22, 0));
+        user.setQuietHoursEnd(LocalTime.of(9, 0));
+        userRepository.save(user);
+        log.info("Quiet hours reset to 22:00-09:00 for user {}", user.getTelegramChatId());
+    }
+
+    /**
+     * Строит текст подтверждения смены таймзоны для отправки наружу (после транзакции).
+     * Учитывает наличие пересчитанных расписаний и конфликт с тихими часами.
+     */
+    public static String buildTimezoneConfirmation(TimezoneChangeResult result, LocalTime quietHoursEnd) {
+        StringBuilder sb = new StringBuilder();
+
+        if (result.rescheduledCount() > 0) {
+            sb.append("🌐 Таймзона: ").append(result.newZoneId()).append(". Расписания пересчитаны.");
+        } else {
+            sb.append("✅ Часовой пояс обновлён: ").append(result.newZoneId());
+        }
+
+        if (result.quietHoursConflict() && quietHoursEnd != null) {
+            sb.append("\n⚠️ У тебя есть напоминания в тихие часы — они приедут в ")
+                    .append(quietHoursEnd.format(TIME_FMT))
+                    .append(".");
+        }
+
+        return sb.toString();
+    }
+
+    private ZoneId resolveZone(String tz) {
+        if (tz == null || tz.isBlank()) {
+            return ZoneOffset.UTC;
+        }
+        try {
+            return ZoneId.of(tz);
+        } catch (DateTimeException e) {
+            log.warn("Invalid timezone '{}', defaulting to UTC", tz);
+            return ZoneOffset.UTC;
+        }
+    }
+}

--- a/src/main/java/com/plantcare/bot/state/impl/AwaitingQuietEndStateHandler.java
+++ b/src/main/java/com/plantcare/bot/state/impl/AwaitingQuietEndStateHandler.java
@@ -1,0 +1,71 @@
+package com.plantcare.bot.state.impl;
+
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.ConversationState;
+import com.plantcare.bot.service.UserService;
+import com.plantcare.bot.service.UserSettingsService;
+import com.plantcare.bot.state.interfaces.StateHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Ввод времени конца тихих часов (issue #116). Формат {@code HH:mm}; парсер сам
+ * валидирует диапазон 0–23 ч / 0–59 мин. На невалидном вводе остаёмся в состоянии.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AwaitingQuietEndStateHandler implements StateHandler {
+
+    private static final DateTimeFormatter TIME_FMT = DateTimeFormatter.ofPattern("HH:mm");
+
+    private final UserService userService;
+    private final UserSettingsService userSettingsService;
+
+    @Override
+    public ConversationState getSupportedState() {
+        return ConversationState.AWAITING_QUIET_END;
+    }
+
+    @Override
+    public void handle(User user, Update update, TelegramClient client) {
+        if (!update.hasMessage() || !update.getMessage().hasText()) {
+            return;
+        }
+
+        LocalTime time;
+        try {
+            time = LocalTime.parse(update.getMessage().getText().trim(), TIME_FMT);
+        } catch (DateTimeParseException e) {
+            sendText(user, client, "❌ Не понял время. Введи в формате ЧЧ:ММ, например 22:00.");
+            return;
+        }
+
+        userSettingsService.setQuietHoursEnd(user, time);
+        userService.updateState(user, ConversationState.IDLE);
+
+        sendText(user, client, "🌙 Конец тихих часов: " + time.format(TIME_FMT) + ".");
+    }
+
+    private void sendText(User user, TelegramClient client, String text) {
+        SendMessage message = SendMessage.builder()
+                .chatId(user.getTelegramChatId().toString())
+                .text(text)
+                .build();
+
+        try {
+            client.execute(message);
+        } catch (TelegramApiException e) {
+            log.error("Failed to send quiet end message", e);
+        }
+    }
+}

--- a/src/main/java/com/plantcare/bot/state/impl/AwaitingQuietStartStateHandler.java
+++ b/src/main/java/com/plantcare/bot/state/impl/AwaitingQuietStartStateHandler.java
@@ -1,0 +1,71 @@
+package com.plantcare.bot.state.impl;
+
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.ConversationState;
+import com.plantcare.bot.service.UserService;
+import com.plantcare.bot.service.UserSettingsService;
+import com.plantcare.bot.state.interfaces.StateHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Ввод времени начала тихих часов (issue #116). Формат {@code HH:mm}; парсер сам
+ * валидирует диапазон 0–23 ч / 0–59 мин. На невалидном вводе остаёмся в состоянии.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AwaitingQuietStartStateHandler implements StateHandler {
+
+    private static final DateTimeFormatter TIME_FMT = DateTimeFormatter.ofPattern("HH:mm");
+
+    private final UserService userService;
+    private final UserSettingsService userSettingsService;
+
+    @Override
+    public ConversationState getSupportedState() {
+        return ConversationState.AWAITING_QUIET_START;
+    }
+
+    @Override
+    public void handle(User user, Update update, TelegramClient client) {
+        if (!update.hasMessage() || !update.getMessage().hasText()) {
+            return;
+        }
+
+        LocalTime time;
+        try {
+            time = LocalTime.parse(update.getMessage().getText().trim(), TIME_FMT);
+        } catch (DateTimeParseException e) {
+            sendText(user, client, "❌ Не понял время. Введи в формате ЧЧ:ММ, например 22:00.");
+            return;
+        }
+
+        userSettingsService.setQuietHoursStart(user, time);
+        userService.updateState(user, ConversationState.IDLE);
+
+        sendText(user, client, "🌙 Начало тихих часов: " + time.format(TIME_FMT) + ".");
+    }
+
+    private void sendText(User user, TelegramClient client, String text) {
+        SendMessage message = SendMessage.builder()
+                .chatId(user.getTelegramChatId().toString())
+                .text(text)
+                .build();
+
+        try {
+            client.execute(message);
+        } catch (TelegramApiException e) {
+            log.error("Failed to send quiet start message", e);
+        }
+    }
+}

--- a/src/main/java/com/plantcare/bot/state/impl/AwaitingTimezoneCustomStateHandler.java
+++ b/src/main/java/com/plantcare/bot/state/impl/AwaitingTimezoneCustomStateHandler.java
@@ -1,0 +1,89 @@
+package com.plantcare.bot.state.impl;
+
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.ConversationState;
+import com.plantcare.bot.service.UserService;
+import com.plantcare.bot.service.UserSettingsService;
+import com.plantcare.bot.service.UserSettingsService.TimezoneChangeResult;
+import com.plantcare.bot.state.interfaces.StateHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboardRemove;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.time.DateTimeException;
+import java.time.ZoneId;
+
+/**
+ * Ручной ввод таймзоны текстом (issue #116). Юзер пишет {@code Region/City},
+ * валидируем через {@link ZoneId#of(String)}. На невалидном вводе остаёмся
+ * в состоянии и переспрашиваем; на валидном — меняем таймзону и пересчитываем
+ * расписания через {@link UserSettingsService#changeTimezone}.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AwaitingTimezoneCustomStateHandler implements StateHandler {
+
+    private final UserService userService;
+    private final UserSettingsService userSettingsService;
+
+    @Override
+    public ConversationState getSupportedState() {
+        return ConversationState.AWAITING_TIMEZONE_CUSTOM;
+    }
+
+    @Override
+    public void handle(User user, Update update, TelegramClient client) {
+        if (!update.hasMessage() || !update.getMessage().hasText()) {
+            return;
+        }
+
+        String text = update.getMessage().getText().trim();
+
+        ZoneId zone;
+        try {
+            zone = ZoneId.of(text);
+        } catch (DateTimeException e) {
+            sendText(user, client,
+                    "❌ Не знаю такую таймзону. Попробуй ещё раз, например `Europe/Warsaw`.");
+            return;
+        }
+
+        TimezoneChangeResult result = userSettingsService.changeTimezone(user, zone);
+        userService.updateState(user, ConversationState.IDLE);
+
+        String confirmation = UserSettingsService.buildTimezoneConfirmation(result, user.getQuietHoursEnd())
+                + "\n\nНапиши /menu, чтобы открыть главное меню.";
+
+        SendMessage message = SendMessage.builder()
+                .chatId(user.getTelegramChatId().toString())
+                .text(confirmation)
+                .replyMarkup(new ReplyKeyboardRemove(true))
+                .build();
+
+        try {
+            client.execute(message);
+        } catch (TelegramApiException e) {
+            log.error("Failed to send custom timezone success message", e);
+        }
+    }
+
+    private void sendText(User user, TelegramClient client, String text) {
+        SendMessage message = SendMessage.builder()
+                .chatId(user.getTelegramChatId().toString())
+                .text(text)
+                .parseMode("Markdown")
+                .build();
+
+        try {
+            client.execute(message);
+        } catch (TelegramApiException e) {
+            log.error("Failed to send custom timezone error message", e);
+        }
+    }
+}

--- a/src/main/java/com/plantcare/bot/state/impl/AwaitingTimezoneManualStateHandler.java
+++ b/src/main/java/com/plantcare/bot/state/impl/AwaitingTimezoneManualStateHandler.java
@@ -3,6 +3,8 @@ package com.plantcare.bot.state.impl;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.ConversationState;
 import com.plantcare.bot.service.UserService;
+import com.plantcare.bot.service.UserSettingsService;
+import com.plantcare.bot.service.UserSettingsService.TimezoneChangeResult;
 import com.plantcare.bot.state.interfaces.StateHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,14 +16,18 @@ import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboardRem
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import org.telegram.telegrambots.meta.generics.TelegramClient;
 
+import java.time.ZoneId;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class AwaitingTimezoneManualStateHandler implements StateHandler {
 
     private static final String SET_TZ_PREFIX = "SET_TZ:";
+    private static final String SET_TZ_CUSTOM = "SET_TZ_CUSTOM";
 
     private final UserService userService;
+    private final UserSettingsService userSettingsService;
 
     @Override
     public ConversationState getSupportedState() {
@@ -42,6 +48,12 @@ public class AwaitingTimezoneManualStateHandler implements StateHandler {
 
     private void handleCallback(User user, Update update, TelegramClient client) {
         String callbackData = update.getCallbackQuery().getData();
+
+        if (SET_TZ_CUSTOM.equals(callbackData)) {
+            promptForCustomTimezone(user, client);
+            answerCallback(update.getCallbackQuery().getId(), client);
+            return;
+        }
 
         if (callbackData == null || !callbackData.startsWith(SET_TZ_PREFIX)) {
             answerCallback(update.getCallbackQuery().getId(), client);
@@ -78,21 +90,32 @@ public class AwaitingTimezoneManualStateHandler implements StateHandler {
         }
     }
 
-    private void saveAndFinish(User user, String timezoneId, TelegramClient client) {
-        user.setTimezone(timezoneId);
-        userService.updateState(user, ConversationState.IDLE);
-
-        log.info("Timezone set to {} for user {}", timezoneId, user.getTelegramChatId());
+    private void promptForCustomTimezone(User user, TelegramClient client) {
+        userService.updateState(user, ConversationState.AWAITING_TIMEZONE_CUSTOM);
 
         SendMessage message = SendMessage.builder()
                 .chatId(user.getTelegramChatId().toString())
-                .text("""
-                        ✅ Часовой пояс обновлён: %s
-                        
-                        Теперь напоминания будут приходить по выбранному времени.
-                        
-                        Напиши /menu, чтобы открыть главное меню.
-                        """.formatted(timezoneId))
+                .text("Введи название таймзоны в формате Region/City, например `Asia/Tbilisi`:")
+                .parseMode("Markdown")
+                .build();
+
+        try {
+            client.execute(message);
+        } catch (TelegramApiException e) {
+            log.error("Failed to send custom timezone prompt", e);
+        }
+    }
+
+    private void saveAndFinish(User user, String timezoneId, TelegramClient client) {
+        TimezoneChangeResult result = userSettingsService.changeTimezone(user, ZoneId.of(timezoneId));
+        userService.updateState(user, ConversationState.IDLE);
+
+        String text = UserSettingsService.buildTimezoneConfirmation(result, user.getQuietHoursEnd())
+                + "\n\nНапиши /menu, чтобы открыть главное меню.";
+
+        SendMessage message = SendMessage.builder()
+                .chatId(user.getTelegramChatId().toString())
+                .text(text)
                 .replyMarkup(new ReplyKeyboardRemove(true))
                 .build();
 

--- a/src/main/java/com/plantcare/bot/state/impl/AwaitingTimezoneStateHandler.java
+++ b/src/main/java/com/plantcare/bot/state/impl/AwaitingTimezoneStateHandler.java
@@ -3,6 +3,8 @@ package com.plantcare.bot.state.impl;
 import com.plantcare.bot.domain.User;
 import com.plantcare.bot.domain.enums.ConversationState;
 import com.plantcare.bot.service.UserService;
+import com.plantcare.bot.service.UserSettingsService;
+import com.plantcare.bot.service.UserSettingsService.TimezoneChangeResult;
 import com.plantcare.bot.state.interfaces.StateHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +20,7 @@ import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKe
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import org.telegram.telegrambots.meta.generics.TelegramClient;
 
+import java.time.ZoneId;
 import java.util.List;
 
 @Slf4j
@@ -26,6 +29,7 @@ import java.util.List;
 public class AwaitingTimezoneStateHandler implements StateHandler {
 
     private final UserService userService;
+    private final UserSettingsService userSettingsService;
     private final TimeZoneEngine engine;
 
     @Override
@@ -83,16 +87,15 @@ public class AwaitingTimezoneStateHandler implements StateHandler {
     }
 
     private void saveAndFinish(User user, String timezoneId, TelegramClient client) {
-        user.setTimezone(timezoneId);
+        TimezoneChangeResult result = userSettingsService.changeTimezone(user, ZoneId.of(timezoneId));
         userService.updateState(user, ConversationState.IDLE);
 
-        log.info("Timezone set to {} for user {}", timezoneId, user.getTelegramChatId());
+        String text = UserSettingsService.buildTimezoneConfirmation(result, user.getQuietHoursEnd())
+                + "\n\nОткрой /menu, чтобы продолжить.";
 
         SendMessage message = SendMessage.builder()
                 .chatId(user.getTelegramChatId().toString())
-                .text("✅ Часовой пояс обновлён: *" + timezoneId + "*.\n\n" +
-                        "Открой /menu, чтобы продолжить.")
-                .parseMode("Markdown")
+                .text(text)
                 .replyMarkup(new ReplyKeyboardRemove(true))
                 .build();
 
@@ -109,9 +112,9 @@ public class AwaitingTimezoneStateHandler implements StateHandler {
                 "Europe/Moscow",
                 "Europe/Kyiv",
                 "Asia/Almaty",
-                "Europe/Berlin",
-                "Europe/London",
-                "America/New_York"
+                "Asia/Tbilisi",
+                "Europe/Warsaw",
+                "Europe/Berlin"
         );
 
         InlineKeyboardMarkup.InlineKeyboardMarkupBuilder<?, ?> markup = InlineKeyboardMarkup.builder();
@@ -124,6 +127,11 @@ public class AwaitingTimezoneStateHandler implements StateHandler {
 
             markup.keyboardRow(new InlineKeyboardRow(button));
         });
+
+        markup.keyboardRow(new InlineKeyboardRow(InlineKeyboardButton.builder()
+                .text("🌍 Другая (ввести вручную)")
+                .callbackData("SET_TZ_CUSTOM")
+                .build()));
 
         SendMessage message = SendMessage.builder()
                 .chatId(chatId.toString())

--- a/src/test/java/com/plantcare/bot/beans/PlantsCareBotTest.java
+++ b/src/test/java/com/plantcare/bot/beans/PlantsCareBotTest.java
@@ -1,0 +1,132 @@
+package com.plantcare.bot.beans;
+
+import com.plantcare.bot.command.CommandContainer;
+import com.plantcare.bot.command.impl.CancelCommand;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.service.DiseaseMenuService;
+import com.plantcare.bot.service.MenuCallbackService;
+import com.plantcare.bot.service.NotificationCallbackService;
+import com.plantcare.bot.service.NotificationDigestCallbackService;
+import com.plantcare.bot.service.UserService;
+import com.plantcare.bot.state.StateResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
+import org.telegram.telegrambots.meta.api.objects.message.MaybeInaccessibleMessage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Регрессионный тест диспетчера {@link PlantsCareBot} (issue #116).
+ *
+ * <p>Раньше callback с data, начинающейся на {@code "SET_TZ"} (как {@code SET_TZ:<zone>}
+ * из inline-пикера, так и {@code SET_TZ_CUSTOM}), не попадал ни в один prefix-ветку и
+ * проваливался в "Unhandled callback" — пользователь видел крутящийся спиннер, который
+ * исчезал по таймауту, выбор таймзоны молча терялся.
+ *
+ * <p>Эти тесты прогоняют именно диспетчер ({@code consume(Update)}), а не хендлер
+ * напрямую, чтобы dead-callback-баг ловился на уровне маршрутизации: проверяем, что
+ * {@code SET_TZ*}-callback уходит в {@link StateResolver#resolve}, а НЕ в
+ * {@link MenuCallbackService#handleCallback}.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PlantsCareBot dispatcher — маршрутизация SET_TZ callback (#116)")
+class PlantsCareBotTest {
+
+    private static final Long CHAT_ID = 4242L;
+
+    @Mock
+    private CommandContainer commandContainer;
+    @Mock
+    private UserService userService;
+    @Mock
+    private StateResolver stateResolver;
+    @Mock
+    private CancelCommand cancelCommand;
+    @Mock
+    private NotificationCallbackService notificationCallbackService;
+    @Mock
+    private NotificationDigestCallbackService notificationDigestCallbackService;
+    @Mock
+    private MenuCallbackService menuCallbackService;
+    @Mock
+    private DiseaseMenuService diseaseMenuService;
+
+    private PlantsCareBot bot;
+
+    @BeforeEach
+    void setUp() {
+        // Конструктор зеркалит PlantsCareBot.java:55-64. Токен — любой непустой:
+        // telegramClient (OkHttpTelegramClient) создаётся внутри, в маршрутизации не участвует.
+        bot = new PlantsCareBot(
+                "test:token",
+                commandContainer,
+                userService,
+                stateResolver,
+                cancelCommand,
+                notificationCallbackService,
+                notificationDigestCallbackService,
+                menuCallbackService,
+                diseaseMenuService
+        );
+    }
+
+    @Test
+    @DisplayName("SET_TZ:<zone> маршрутизируется в stateResolver.resolve, а не в menuCallbackService")
+    void should_route_to_state_resolver_when_callback_data_is_set_tz_zone() {
+        // arrange
+        User user = new User();
+        when(userService.findOrCreate(eq(CHAT_ID), any())).thenReturn(user);
+        Update update = callbackUpdate("SET_TZ:Asia/Almaty");
+
+        // act
+        bot.consume(update);
+
+        // assert
+        verify(stateResolver).resolve(eq(user), eq(update), any());
+        verify(menuCallbackService, never()).handleCallback(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("SET_TZ_CUSTOM маршрутизируется в stateResolver.resolve, а не в menuCallbackService")
+    void should_route_to_state_resolver_when_callback_data_is_set_tz_custom() {
+        // arrange
+        User user = new User();
+        when(userService.findOrCreate(eq(CHAT_ID), any())).thenReturn(user);
+        Update update = callbackUpdate("SET_TZ_CUSTOM");
+
+        // act
+        bot.consume(update);
+
+        // assert
+        verify(stateResolver).resolve(eq(user), eq(update), any());
+        verify(menuCallbackService, never()).handleCallback(any(), any(), any());
+    }
+
+    /**
+     * Конструирует {@link Update} с callback-query: data + chatId, как присылает Telegram.
+     * getFrom() намеренно не стабится (вернёт null) — getUserName() это переживает.
+     */
+    private Update callbackUpdate(String data) {
+        Update update = org.mockito.Mockito.mock(Update.class);
+        CallbackQuery callbackQuery = org.mockito.Mockito.mock(CallbackQuery.class);
+        MaybeInaccessibleMessage message = org.mockito.Mockito.mock(MaybeInaccessibleMessage.class);
+
+        when(update.hasCallbackQuery()).thenReturn(true);
+        when(update.getCallbackQuery()).thenReturn(callbackQuery);
+        when(callbackQuery.getData()).thenReturn(data);
+        when(callbackQuery.getMessage()).thenReturn(message);
+        when(message.getChatId()).thenReturn(CHAT_ID);
+
+        return update;
+    }
+}

--- a/src/test/java/com/plantcare/bot/service/MenuCallbackServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/MenuCallbackServiceTest.java
@@ -19,6 +19,7 @@ import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMa
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import org.telegram.telegrambots.meta.generics.TelegramClient;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -159,7 +160,7 @@ class MenuCallbackServiceTest {
     }
 
     @Test
-    @DisplayName("SETTINGS показывает меню настроек с кнопкой изменения региона")
+    @DisplayName("SETTINGS показывает меню настроек с кнопками таймзоны и тихих часов (#116)")
     void shouldShowSettingsMenu() throws TelegramApiException {
         when(callbackQuery.getData()).thenReturn("MENU:SETTINGS");
 
@@ -190,10 +191,16 @@ class MenuCallbackServiceTest {
                 .map(InlineKeyboardButton::getCallbackData)
                 .toList();
 
-        assertThat(buttonTexts).contains("🌍 Изменить регион");
+        assertThat(buttonTexts).contains("🌐 Таймзона: " + testUser.getTimezone());
+        assertThat(buttonTexts).contains(
+                "🌙 Тихие часы: "
+                        + testUser.getQuietHoursStart().format(DateTimeFormatter.ofPattern("HH:mm"))
+                        + "–"
+                        + testUser.getQuietHoursEnd().format(DateTimeFormatter.ofPattern("HH:mm")));
         assertThat(buttonTexts).contains("⬅️ Назад");
 
         assertThat(callbackData).contains("MENU:CHANGE_TZ");
+        assertThat(callbackData).contains("MENU:QUIET_HOURS");
         assertThat(callbackData).contains("MENU:BACK");
 
         verify(telegramClient).execute(any(AnswerCallbackQuery.class));

--- a/src/test/java/com/plantcare/bot/service/UserSettingsServiceIT.java
+++ b/src/test/java/com/plantcare/bot/service/UserSettingsServiceIT.java
@@ -1,0 +1,323 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.CareSchedule;
+import com.plantcare.bot.domain.Location;
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.repository.CareScheduleRepository;
+import com.plantcare.bot.repository.LocationRepository;
+import com.plantcare.bot.repository.PlantRepository;
+import com.plantcare.bot.repository.UserRepository;
+import com.plantcare.bot.service.UserSettingsService.TimezoneChangeResult;
+import com.plantcare.bot.support.IntegrationTestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Интеграционные тесты {@link UserSettingsService} (issue #116) на реальном Postgres
+ * (Testcontainers, не H2). Проверяем пересчёт {@code nextDueAt} при смене таймзоны,
+ * исключение архивных растений, флаг конфликта с тихими часами и сеттеры тихих часов.
+ *
+ * <p>Семантика: {@code nextDueAt} хранится как UTC wall-clock. Пересчёт сохраняет
+ * локальное время дня в новой зоне (полить в 09:00 в Минске остаётся 09:00 в Алматы).
+ *
+ * <p>Контейнер Postgres переиспользуется (reuse=true) и шарится между классами в
+ * рамках одного {@code mvn verify}. Поэтому этот тест НЕ делает глобальный
+ * {@code deleteAll()} — это затирало бы строки соседних ITs (например
+ * {@code MonthlyReportServiceTest}) и роняло их FK/optimistic-lock. Вместо этого
+ * каждый тест работает на уникальных telegram chatId (диапазон 200–207) и удаляет в
+ * {@code @AfterEach} ровно те сущности, которые сам вставил.
+ */
+@DisplayName("UserSettingsService — смена таймзоны и тихих часов (#116)")
+class UserSettingsServiceIT extends IntegrationTestBase {
+
+    private static final ZoneId MINSK = ZoneId.of("Europe/Minsk");
+    private static final ZoneId ALMATY = ZoneId.of("Asia/Almaty");
+    private static final ZoneId WARSAW = ZoneId.of("Europe/Warsaw");
+
+    @Autowired
+    private UserSettingsService userSettingsService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @Autowired
+    private PlantRepository plantRepository;
+
+    @Autowired
+    private CareScheduleRepository careScheduleRepository;
+
+    // Сущности, вставленные текущим тестом. Чистим только их, не трогая чужие строки.
+    private final List<CareSchedule> createdSchedules = new ArrayList<>();
+    private final List<Plant> createdPlants = new ArrayList<>();
+    private final List<Location> createdLocations = new ArrayList<>();
+    private final List<User> createdUsers = new ArrayList<>();
+
+    @AfterEach
+    void cleanupOwnRowsOnly() {
+        // Удаляем строго в порядке FK: schedule → plant → location → user.
+        careScheduleRepository.deleteAll(createdSchedules);
+        plantRepository.deleteAll(createdPlants);
+        locationRepository.deleteAll(createdLocations);
+        userRepository.deleteAll(createdUsers);
+
+        createdSchedules.clear();
+        createdPlants.clear();
+        createdLocations.clear();
+        createdUsers.clear();
+    }
+
+    @Test
+    @DisplayName("Минск → Алматы: локальное время дня расписания сохраняется (09:00), rescheduledCount == 1")
+    void should_preserve_local_time_of_day_when_changing_timezone_minsk_to_almaty() {
+        // arrange
+        User user = saveUser(200L, "Europe/Minsk");
+        Plant plant = savePlant(user, "Монстера", false);
+        // 06:00 UTC == 09:00 в Минске (UTC+3)
+        CareSchedule schedule = saveSchedule(plant, TaskType.WATERING,
+                LocalDateTime.of(2026, 6, 1, 6, 0), true);
+
+        // act
+        TimezoneChangeResult result = userSettingsService.changeTimezone(user, ALMATY);
+
+        // assert
+        assertThat(result.newZoneId()).isEqualTo("Asia/Almaty");
+        assertThat(result.rescheduledCount()).isEqualTo(1);
+
+        LocalDateTime newNext = careScheduleRepository.findById(schedule.getId())
+                .orElseThrow()
+                .getNextDueAt();
+        // в новой зоне локальное время дня == то же 09:00, что было в Минске
+        LocalTime localInAlmaty = newNext.toInstant(ZoneOffset.UTC).atZone(ALMATY).toLocalTime();
+        assertThat(localInAlmaty).isEqualTo(LocalTime.of(9, 0));
+        // конкретно: 09:00 Алматы (UTC+5) == 04:00 UTC того же дня
+        assertThat(newNext).isEqualTo(LocalDateTime.of(2026, 6, 1, 4, 0));
+
+        assertThat(userRepository.findById(user.getId()).orElseThrow().getTimezone())
+                .isEqualTo("Asia/Almaty");
+    }
+
+    @Test
+    @DisplayName("Asia/Almaty → Europe/Warsaw через spring-forward gap (2026-03-29 02:30): момент сдвигается на 03:30 CEST")
+    void should_keep_bridge_through_utc_correct_across_dst_spring_forward() {
+        // arrange: исходная зона Almaty без DST (UTC+5), целевая Warsaw с DST.
+        // 2026-03-29 02:00→03:00 — весенний перевод (CET→CEST). Локальное 02:30 в этот
+        // день в Варшаве НЕ существует (gap). Подбираем nextDueAt так, чтобы локальное
+        // время дня в Almaty было ровно 02:30 → при мосте через UTC оно реинтерпретируется
+        // как 02:30 Warsaw и попадает в дыру.
+        // 02:30 Almaty (UTC+5) == 21:30 UTC предыдущего дня (2026-03-28).
+        User user = saveUser(207L, "Asia/Almaty");
+        Plant plant = savePlant(user, "DST монстера", false);
+        CareSchedule schedule = saveSchedule(plant, TaskType.WATERING,
+                LocalDateTime.of(2026, 3, 28, 21, 30), true);
+
+        // act
+        TimezoneChangeResult result = userSettingsService.changeTimezone(user, WARSAW);
+
+        // assert
+        assertThat(result.rescheduledCount()).isEqualTo(1);
+
+        LocalDateTime newNext = careScheduleRepository.findById(schedule.getId())
+                .orElseThrow()
+                .getNextDueAt();
+
+        // ZonedDateTime.of для несуществующего локального времени сдвигает вперёд на длину
+        // перехода: 02:30 → 03:30 CEST (UTC+2). Это и есть корректное поведение моста.
+        java.time.ZonedDateTime newLocal = newNext.toInstant(ZoneOffset.UTC).atZone(WARSAW);
+        assertThat(newLocal.toLocalTime()).isEqualTo(LocalTime.of(3, 30));
+        assertThat(newLocal.getOffset()).isEqualTo(ZoneOffset.ofHours(2)); // CEST после перевода
+        assertThat(newLocal.toLocalDate()).isEqualTo(java.time.LocalDate.of(2026, 3, 29));
+
+        // и в терминах хранимого UTC wall-clock: 03:30 CEST == 01:30 UTC того же дня
+        assertThat(newNext).isEqualTo(LocalDateTime.of(2026, 3, 29, 1, 30));
+    }
+
+    @Test
+    @DisplayName("Расписание на архивном растении НЕ пересчитывается и не попадает в счётчик")
+    void should_not_reschedule_archived_plant_schedules() {
+        // arrange
+        User user = saveUser(201L, "Europe/Minsk");
+
+        Plant active = savePlant(user, "Живая монстера", false);
+        CareSchedule activeSchedule = saveSchedule(active, TaskType.WATERING,
+                LocalDateTime.of(2026, 6, 1, 6, 0), true);
+
+        Plant archived = savePlant(user, "Мёртвая монстера", true);
+        LocalDateTime archivedNextBefore = LocalDateTime.of(2026, 6, 1, 6, 0);
+        CareSchedule archivedSchedule = saveSchedule(archived, TaskType.WATERING,
+                archivedNextBefore, true);
+
+        // act
+        TimezoneChangeResult result = userSettingsService.changeTimezone(user, ALMATY);
+
+        // assert
+        assertThat(result.rescheduledCount()).isEqualTo(1);
+
+        LocalDateTime archivedNextAfter = careScheduleRepository.findById(archivedSchedule.getId())
+                .orElseThrow()
+                .getNextDueAt();
+        assertThat(archivedNextAfter).isEqualTo(archivedNextBefore);
+
+        LocalDateTime activeNextAfter = careScheduleRepository.findById(activeSchedule.getId())
+                .orElseThrow()
+                .getNextDueAt();
+        assertThat(activeNextAfter).isEqualTo(LocalDateTime.of(2026, 6, 1, 4, 0));
+    }
+
+    @Test
+    @DisplayName("Новый момент попадает в тихие часы (22:00–09:00) в новой зоне → quietHoursConflict == true")
+    void should_flag_quiet_hours_conflict_when_recomputed_instant_lands_in_quiet_window() {
+        // arrange: 03:00 в Минске → после переезда в Алматы локальное время дня остаётся
+        // 03:00, что внутри тихих часов 22:00–09:00.
+        User user = saveUser(202L, "Europe/Minsk");
+        Plant plant = savePlant(user, "Ночная монстера", false);
+        // 00:00 UTC == 03:00 в Минске (UTC+3)
+        saveSchedule(plant, TaskType.WATERING,
+                LocalDateTime.of(2026, 6, 1, 0, 0), true);
+
+        // act
+        TimezoneChangeResult result = userSettingsService.changeTimezone(user, ALMATY);
+
+        // assert
+        assertThat(result.quietHoursConflict()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Новый момент вне тихих часов → quietHoursConflict == false")
+    void should_not_flag_quiet_hours_conflict_when_recomputed_instant_is_in_daytime() {
+        // arrange: 09:00 в Минске → 09:00 локально в Алматы, конец тихих часов (исключительно) — не quiet
+        User user = saveUser(203L, "Europe/Minsk");
+        Plant plant = savePlant(user, "Дневная монстера", false);
+        // 06:00 UTC == 09:00 в Минске
+        saveSchedule(plant, TaskType.WATERING,
+                LocalDateTime.of(2026, 6, 1, 6, 0), true);
+
+        // act
+        TimezoneChangeResult result = userSettingsService.changeTimezone(user, ALMATY);
+
+        // assert
+        assertThat(result.quietHoursConflict()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Нет активных расписаний → rescheduledCount == 0, таймзона всё равно меняется")
+    void should_change_timezone_with_zero_rescheduled_when_no_active_schedules() {
+        // arrange
+        User user = saveUser(204L, "Europe/Minsk");
+
+        // act
+        TimezoneChangeResult result = userSettingsService.changeTimezone(user, ALMATY);
+
+        // assert
+        assertThat(result.rescheduledCount()).isZero();
+        assertThat(result.quietHoursConflict()).isFalse();
+        assertThat(userRepository.findById(user.getId()).orElseThrow().getTimezone())
+                .isEqualTo("Asia/Almaty");
+    }
+
+    @Test
+    @DisplayName("setQuietHoursStart / setQuietHoursEnd персистятся в БД")
+    void should_persist_quiet_hours_start_and_end() {
+        // arrange
+        User user = saveUser(205L, "Europe/Minsk");
+
+        // act
+        userSettingsService.setQuietHoursStart(user, LocalTime.of(23, 30));
+        userSettingsService.setQuietHoursEnd(user, LocalTime.of(8, 15));
+
+        // assert
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(reloaded.getQuietHoursStart()).isEqualTo(LocalTime.of(23, 30));
+        assertThat(reloaded.getQuietHoursEnd()).isEqualTo(LocalTime.of(8, 15));
+    }
+
+    @Test
+    @DisplayName("resetQuietHours возвращает дефолт 22:00 / 09:00")
+    void should_reset_quiet_hours_to_default() {
+        // arrange
+        User user = saveUser(206L, "Europe/Minsk");
+        userSettingsService.setQuietHoursStart(user, LocalTime.of(1, 0));
+        userSettingsService.setQuietHoursEnd(user, LocalTime.of(2, 0));
+
+        // act
+        userSettingsService.resetQuietHours(user);
+
+        // assert
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(reloaded.getQuietHoursStart()).isEqualTo(LocalTime.of(22, 0));
+        assertThat(reloaded.getQuietHoursEnd()).isEqualTo(LocalTime.of(9, 0));
+    }
+
+    // ====================================================================
+    // fixtures
+    // ====================================================================
+
+    private User saveUser(Long chatId, String timezone) {
+        User user = userRepository.save(User.builder()
+                .telegramChatId(chatId)
+                .timezone(timezone)
+                .blocked(false)
+                .quietHoursStart(LocalTime.of(22, 0))
+                .quietHoursEnd(LocalTime.of(9, 0))
+                .build());
+        createdUsers.add(user);
+        return user;
+    }
+
+    private Location saveDefaultLocation(User user) {
+        return locationRepository.findByUserIdAndDefaultLocationTrue(user.getId())
+                .orElseGet(() -> {
+                    Location location = locationRepository.save(Location.builder()
+                            .user(user)
+                            .name(Location.DEFAULT_NAME)
+                            .emoji(Location.DEFAULT_EMOJI)
+                            .defaultLocation(true)
+                            .build());
+                    createdLocations.add(location);
+                    return location;
+                });
+    }
+
+    private Plant savePlant(User user, String name, boolean archived) {
+        Location location = saveDefaultLocation(user);
+        Plant plant = plantRepository.save(Plant.builder()
+                .user(user)
+                .location(location)
+                .name(name)
+                .build());
+        if (archived) {
+            plant.archive();
+            plant = plantRepository.save(plant);
+        }
+        createdPlants.add(plant);
+        return plant;
+    }
+
+    private CareSchedule saveSchedule(Plant plant, TaskType taskType, LocalDateTime nextDueAt, boolean active) {
+        CareSchedule schedule = careScheduleRepository.save(CareSchedule.builder()
+                .plant(plant)
+                .taskType(taskType)
+                .intervalDays(7)
+                .nextDueAt(nextDueAt.truncatedTo(ChronoUnit.MICROS))
+                .active(active)
+                .build());
+        createdSchedules.add(schedule);
+        return schedule;
+    }
+}

--- a/src/test/java/com/plantcare/bot/state/impl/AwaitingQuietEndStateHandlerTest.java
+++ b/src/test/java/com/plantcare/bot/state/impl/AwaitingQuietEndStateHandlerTest.java
@@ -1,0 +1,98 @@
+package com.plantcare.bot.state.impl;
+
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.ConversationState;
+import com.plantcare.bot.service.UserService;
+import com.plantcare.bot.service.UserSettingsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit-тесты {@link AwaitingQuietEndStateHandler} (issue #116).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("AwaitingQuietEndStateHandler (#116)")
+class AwaitingQuietEndStateHandlerTest {
+
+    @Mock private UserService userService;
+    @Mock private UserSettingsService userSettingsService;
+    @Mock private TelegramClient telegramClient;
+
+    @InjectMocks
+    private AwaitingQuietEndStateHandler handler;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .telegramChatId(100L)
+                .timezone("Europe/Minsk")
+                .conversationState(ConversationState.AWAITING_QUIET_END)
+                .build();
+    }
+
+    @Test
+    @DisplayName("getSupportedState == AWAITING_QUIET_END")
+    void should_return_supported_state() {
+        assertThat(handler.getSupportedState())
+                .isEqualTo(ConversationState.AWAITING_QUIET_END);
+    }
+
+    @Test
+    @DisplayName("Валидное «09:00» → setQuietHoursEnd(09:00) + переход в IDLE")
+    void should_set_quiet_hours_end_when_input_is_valid() throws TelegramApiException {
+        handler.handle(user, textUpdate("09:00"), telegramClient);
+
+        verify(userSettingsService).setQuietHoursEnd(user, LocalTime.of(9, 0));
+        verify(userService).updateState(user, ConversationState.IDLE);
+
+        ArgumentCaptor<SendMessage> cap = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient).execute(cap.capture());
+        assertThat(cap.getValue().getText()).contains("09:00");
+    }
+
+    @Test
+    @DisplayName("Мусорный ввод «25:61» → ошибка, остаёмся в состоянии, ничего не сохраняем")
+    void should_reject_when_time_value_out_of_range() throws TelegramApiException {
+        handler.handle(user, textUpdate("25:61"), telegramClient);
+
+        verify(userSettingsService, never()).setQuietHoursEnd(any(), any());
+        verify(userService, never()).updateState(any(), any());
+
+        ArgumentCaptor<SendMessage> cap = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient).execute(cap.capture());
+        assertThat(cap.getValue().getText())
+                .contains("❌")
+                .contains("ЧЧ:ММ");
+    }
+
+    private Update textUpdate(String text) {
+        Update u = new Update();
+        Message m = new Message();
+        m.setText(text);
+        u.setMessage(m);
+        return u;
+    }
+}

--- a/src/test/java/com/plantcare/bot/state/impl/AwaitingQuietStartStateHandlerTest.java
+++ b/src/test/java/com/plantcare/bot/state/impl/AwaitingQuietStartStateHandlerTest.java
@@ -1,0 +1,131 @@
+package com.plantcare.bot.state.impl;
+
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.ConversationState;
+import com.plantcare.bot.service.UserService;
+import com.plantcare.bot.service.UserSettingsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit-тесты {@link AwaitingQuietStartStateHandler} (issue #116).
+ * Тихие часы законно пересекают полночь — ввод 22:00 не должен отвергаться,
+ * валидируется только формат HH:mm.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("AwaitingQuietStartStateHandler (#116)")
+class AwaitingQuietStartStateHandlerTest {
+
+    @Mock private UserService userService;
+    @Mock private UserSettingsService userSettingsService;
+    @Mock private TelegramClient telegramClient;
+
+    @InjectMocks
+    private AwaitingQuietStartStateHandler handler;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .telegramChatId(100L)
+                .timezone("Europe/Minsk")
+                .conversationState(ConversationState.AWAITING_QUIET_START)
+                .build();
+    }
+
+    @Test
+    @DisplayName("getSupportedState == AWAITING_QUIET_START")
+    void should_return_supported_state() {
+        assertThat(handler.getSupportedState())
+                .isEqualTo(ConversationState.AWAITING_QUIET_START);
+    }
+
+    @Test
+    @DisplayName("Валидное «08:30» → setQuietHoursStart(08:30) + переход в IDLE")
+    void should_set_quiet_hours_start_when_input_is_valid() throws TelegramApiException {
+        handler.handle(user, textUpdate("08:30"), telegramClient);
+
+        verify(userSettingsService).setQuietHoursStart(user, LocalTime.of(8, 30));
+        verify(userService).updateState(user, ConversationState.IDLE);
+
+        ArgumentCaptor<SendMessage> cap = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient).execute(cap.capture());
+        assertThat(cap.getValue().getText()).contains("08:30");
+    }
+
+    @Test
+    @DisplayName("«22:00» (пересечение полуночи) — валидный ввод, НЕ отвергается")
+    void should_accept_late_start_that_crosses_midnight() throws TelegramApiException {
+        handler.handle(user, textUpdate("22:00"), telegramClient);
+
+        verify(userSettingsService).setQuietHoursStart(user, LocalTime.of(22, 0));
+        verify(userService).updateState(user, ConversationState.IDLE);
+    }
+
+    @Test
+    @DisplayName("Невалидное время «99:99» → ошибка, остаёмся в состоянии, ничего не сохраняем")
+    void should_reject_when_time_value_out_of_range() throws TelegramApiException {
+        handler.handle(user, textUpdate("99:99"), telegramClient);
+
+        verify(userSettingsService, never()).setQuietHoursStart(any(), any());
+        verify(userService, never()).updateState(any(), any());
+
+        ArgumentCaptor<SendMessage> cap = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient).execute(cap.capture());
+        assertThat(cap.getValue().getText())
+                .contains("❌")
+                .contains("ЧЧ:ММ");
+    }
+
+    @Test
+    @DisplayName("Мусорный ввод «abc» → ошибка, остаёмся в состоянии, ничего не сохраняем")
+    void should_reject_when_input_is_not_a_time() throws TelegramApiException {
+        handler.handle(user, textUpdate("abc"), telegramClient);
+
+        verify(userSettingsService, never()).setQuietHoursStart(any(), any());
+        verify(userService, never()).updateState(any(), any());
+        verify(telegramClient).execute(any(SendMessage.class));
+    }
+
+    @Test
+    @DisplayName("Update без текста — handler молчит и ничего не дёргает")
+    void should_ignore_update_without_text() throws TelegramApiException {
+        Update update = new Update();
+        update.setMessage(new Message());
+
+        handler.handle(user, update, telegramClient);
+
+        verify(userSettingsService, never()).setQuietHoursStart(any(), any());
+        verify(telegramClient, never()).execute(any(SendMessage.class));
+    }
+
+    private Update textUpdate(String text) {
+        Update u = new Update();
+        Message m = new Message();
+        m.setText(text);
+        u.setMessage(m);
+        return u;
+    }
+}

--- a/src/test/java/com/plantcare/bot/state/impl/AwaitingTimezoneCustomStateHandlerTest.java
+++ b/src/test/java/com/plantcare/bot/state/impl/AwaitingTimezoneCustomStateHandlerTest.java
@@ -1,0 +1,122 @@
+package com.plantcare.bot.state.impl;
+
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.ConversationState;
+import com.plantcare.bot.service.UserService;
+import com.plantcare.bot.service.UserSettingsService;
+import com.plantcare.bot.service.UserSettingsService.TimezoneChangeResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.time.LocalTime;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit-тесты {@link AwaitingTimezoneCustomStateHandler} (issue #116).
+ * Внешний мир (UserService, UserSettingsService, TelegramClient) — моки.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("AwaitingTimezoneCustomStateHandler (#116)")
+class AwaitingTimezoneCustomStateHandlerTest {
+
+    @Mock private UserService userService;
+    @Mock private UserSettingsService userSettingsService;
+    @Mock private TelegramClient telegramClient;
+
+    @InjectMocks
+    private AwaitingTimezoneCustomStateHandler handler;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .telegramChatId(100L)
+                .timezone("Europe/Minsk")
+                .quietHoursStart(LocalTime.of(22, 0))
+                .quietHoursEnd(LocalTime.of(9, 0))
+                .conversationState(ConversationState.AWAITING_TIMEZONE_CUSTOM)
+                .build();
+    }
+
+    @Test
+    @DisplayName("getSupportedState == AWAITING_TIMEZONE_CUSTOM")
+    void should_return_supported_state() {
+        assertThat(handler.getSupportedState())
+                .isEqualTo(ConversationState.AWAITING_TIMEZONE_CUSTOM);
+    }
+
+    @Test
+    @DisplayName("Валидный ZoneId (Asia/Tbilisi) → changeTimezone + переход в IDLE + подтверждение")
+    void should_change_timezone_and_go_idle_when_zone_id_is_valid() throws TelegramApiException {
+        when(userSettingsService.changeTimezone(eq(user), eq(ZoneId.of("Asia/Tbilisi"))))
+                .thenReturn(new TimezoneChangeResult("Asia/Tbilisi", 2, false));
+
+        handler.handle(user, textUpdate("Asia/Tbilisi"), telegramClient);
+
+        verify(userSettingsService).changeTimezone(user, ZoneId.of("Asia/Tbilisi"));
+        verify(userService).updateState(user, ConversationState.IDLE);
+
+        ArgumentCaptor<SendMessage> cap = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient).execute(cap.capture());
+        assertThat(cap.getValue().getText())
+                .contains("Asia/Tbilisi");
+    }
+
+    @Test
+    @DisplayName("Невалидный ZoneId (Mars/Olympus) → changeTimezone НЕ зовётся, остаёмся в состоянии, ошибка")
+    void should_reprompt_and_stay_in_state_when_zone_id_is_invalid() throws TelegramApiException {
+        handler.handle(user, textUpdate("Mars/Olympus"), telegramClient);
+
+        verify(userSettingsService, never()).changeTimezone(any(), any());
+        verify(userService, never()).updateState(any(), any());
+
+        ArgumentCaptor<SendMessage> cap = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient).execute(cap.capture());
+        assertThat(cap.getValue().getText())
+                .contains("❌")
+                .contains("таймзону");
+    }
+
+    @Test
+    @DisplayName("Update без текста — handler молчит и ничего не дёргает")
+    void should_ignore_update_without_text() throws TelegramApiException {
+        Update update = new Update();
+        update.setMessage(new Message());
+
+        handler.handle(user, update, telegramClient);
+
+        verify(userSettingsService, never()).changeTimezone(any(), any());
+        verify(userService, never()).updateState(any(), any());
+        verify(telegramClient, never()).execute(any(SendMessage.class));
+    }
+
+    private Update textUpdate(String text) {
+        Update u = new Update();
+        Message m = new Message();
+        m.setText(text);
+        u.setMessage(m);
+        return u;
+    }
+}


### PR DESCRIPTION
Closes #116

## Что сделано
- В «⚙️ Настройки» добавлен пункт **«🌐 Таймзона: {current}»**: выбор из списка популярных зон (Europe/Minsk, Moscow, Kyiv, Asia/Almaty, Tbilisi, Europe/Warsaw, Berlin), ручной ввод любого `ZoneId` с валидацией, либо определение по локации.
- **Пересчёт `next_due_at`** при смене таймзоны: для активных расписаний неархивных растений локальное время дня сохраняется (Минск 09:00 → Алматы 09:00). Алгоритм — мост через UTC wall-clock (`next_due_at` хранится как `LocalDateTime` в UTC, как и `paused_until`). Если ближайшее напоминание попадает в тихие часы — текстовое предупреждение, расписание не сдвигаем (шедулер сам отложит до конца окна).
- В «⚙️ Настройки» добавлен пункт **«🌙 Тихие часы: {start}–{end}»**: изменить начало/конец (ввод `HH:mm`, окно может пересекать полночь) или сбросить к 22:00–09:00. Пересчёт расписаний не нужен — тихие часы применяются на этапе отправки.
- Новый `UserSettingsService` — смена TZ + пересчёт в одной `@Transactional`, без вызовов Telegram внутри транзакции. Новые состояния `AWAITING_TIMEZONE_CUSTOM`, `AWAITING_QUIET_START`, `AWAITING_QUIET_END` и обработчики.
- **Фикс мёртвого callback'а**: `PlantsCareBot` не маршрутизировал `SET_TZ*`-callback'и в машину состояний (терялись на «Unhandled callback»). Inline-пикер ручного выбора таймзоны теперь действительно работает (нашёл reviewer).

## Миграции
Нет — поля `users.timezone`, `users.quiet_hours_start/end`, `care_schedules.next_due_at` существуют с V1.

## Backward-compat риски
safe. Схема не меняется. Затронут общий онбординг-флоу таймзоны (теперь тоже идёт через `changeTimezone`), но для нового юзера без расписаний пересчёт — no-op, сообщение деградирует к простому подтверждению.

## Тесты
- `UserSettingsServiceIT` (Testcontainers Postgres): non-UTC happy (Минск→Алматы, локальное время сохранено), исключение архивных растений, флаг конфликта с тихими часами в обе стороны, ноль расписаний, DST-граница (Almaty→Warsaw spring-forward), сеттеры/сброс тихих часов.
- `AwaitingTimezoneCustomStateHandlerTest` — валидный ZoneId / невалидный «Mars/Olympus» (остаёмся в состоянии).
- `AwaitingQuietStartStateHandlerTest` / `AwaitingQuietEndStateHandlerTest` — happy, пересечение полуночи (22:00 принимается), плохой формат.
- `PlantsCareBotTest` — регрессия на маршрутизацию `SET_TZ:`/`SET_TZ_CUSTOM` в `stateResolver`.
- `MenuCallbackServiceTest` — обновлён под новые кнопки меню.

## Чек
- [x] Все тесты фичи (75 шт., новые + затронутые) зелёные при изолированном прогоне
- [x] reviewer прошёл — найденный 🔴 BLOCKING (мёртвый SET_TZ callback) исправлен + покрыт e2e-тестом; SHOULD-FIX (DST-кейс, scoped cleanup без глобального deleteAll) закрыты
- [ ] Полный `mvn verify` краснит на пресуществующих flaky-тестах develop (`SpeciesRepositoryTest`, `PlantServiceTest.getPopularSpecies_orderedByPopularity` + контаминация shared-контейнера через `deleteAll` в чужих тестах) — НЕ связано с этим PR, victim-классы зелёные при изолированном прогоне
