### PR TITLE
feat: health score растения с зонами (#138)

### DIFF
--- a/src/main/java/com/plantcare/bot/PlantsCareApplication.java
+++ b/src/main/java/com/plantcare/bot/PlantsCareApplication.java
@@ -1,6 +1,7 @@
 package com.plantcare.bot;
 
 import com.plantcare.bot.config.CalendarProperties;
+import com.plantcare.bot.config.HealthScoreProperties;
 import com.plantcare.bot.config.SpeciesProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -9,7 +10,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
-@EnableConfigurationProperties({SpeciesProperties.class, CalendarProperties.class})
+@EnableConfigurationProperties({SpeciesProperties.class, CalendarProperties.class, HealthScoreProperties.class})
 public class PlantsCareApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/plantcare/bot/config/HealthScoreProperties.java
+++ b/src/main/java/com/plantcare/bot/config/HealthScoreProperties.java
@@ -1,0 +1,57 @@
+package com.plantcare.bot.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Issue #138: коэффициенты формулы health-score растения и пороги зон.
+ *
+ * <p>Формула прозрачна и линейна:
+ * <pre>
+ *   score = round(onTimePct * onTimeWeight)
+ *         + (есть фото  ? photoBonus : 0)
+ *         + (есть заметки ? notesBonus : 0)
+ * </pre>
+ * затем клампится в [0, 100].
+ *
+ * <ul>
+ *   <li>{@code onTimeWeight} — доля 100-балльной шкалы, отдаваемая под % on-time за
+ *       30 дней. По умолчанию 0.8 → идеальная серия (100% on-time) даёт 80 баллов,
+ *       оставшиеся 20 — на бонусы.</li>
+ *   <li>{@code photoBonus} — баллы за наличие фото (issue #24). По умолчанию 10.</li>
+ *   <li>{@code notesBonus} — баллы за наличие заметок (issue #25). По умолчанию 10.</li>
+ *   <li>{@code greenThreshold} — score ≥ него → зелёная зона 🟢 (по умолчанию 80).</li>
+ *   <li>{@code yellowThreshold} — score ≥ него (но &lt; green) → жёлтая зона 🟡
+ *       (по умолчанию 50); ниже — красная 🔴.</li>
+ * </ul>
+ */
+@ConfigurationProperties(prefix = "app.health-score")
+public record HealthScoreProperties(
+        double onTimeWeight,
+        int photoBonus,
+        int notesBonus,
+        int greenThreshold,
+        int yellowThreshold
+) {
+
+    public HealthScoreProperties {
+        if (onTimeWeight <= 0) {
+            onTimeWeight = 0.8;
+        }
+        if (photoBonus < 0) {
+            photoBonus = 10;
+        }
+        if (notesBonus < 0) {
+            notesBonus = 10;
+        }
+        if (greenThreshold <= 0) {
+            greenThreshold = 80;
+        }
+        if (yellowThreshold <= 0) {
+            yellowThreshold = 50;
+        }
+        if (yellowThreshold >= greenThreshold) {
+            greenThreshold = 80;
+            yellowThreshold = 50;
+        }
+    }
+}

--- a/src/main/java/com/plantcare/bot/domain/enums/HealthZone.java
+++ b/src/main/java/com/plantcare/bot/domain/enums/HealthZone.java
@@ -1,0 +1,25 @@
+package com.plantcare.bot.domain.enums;
+
+/**
+ * Зона здоровья растения (issue #138). Маппинг числового health-score → цветовая
+ * зона для подсветки в карточке и сводки в списке.
+ *
+ * <p>Конкретные пороги задаются в {@code app.health-score} (см.
+ * {@code HealthScoreProperties}) — enum несёт только семантику и эмодзи.
+ */
+public enum HealthZone {
+
+    GREEN("🟢"),
+    YELLOW("🟡"),
+    RED("🔴");
+
+    private final String emoji;
+
+    HealthZone(String emoji) {
+        this.emoji = emoji;
+    }
+
+    public String emoji() {
+        return emoji;
+    }
+}

--- a/src/main/java/com/plantcare/bot/service/HealthScoreService.java
+++ b/src/main/java/com/plantcare/bot/service/HealthScoreService.java
@@ -1,0 +1,149 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.config.HealthScoreProperties;
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.enums.HealthZone;
+import com.plantcare.bot.repository.CareHistoryRepository;
+import com.plantcare.bot.util.TimeUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+/**
+ * Issue #138: health-score растения — числовой балл 0–100 поверх уже имеющихся
+ * данных ({@code care_history}, фото, заметки) без новой схемы и без материализации.
+ *
+ * <p>Формула (см. {@link HealthScoreProperties}): основной вес — % on-time за окно
+ * 30 дней, плюс фиксированные бонусы за наличие фото и заметок, с клампом в [0, 100].
+ *
+ * <p><b>Источник on-time:</b> переиспользуется расчёт из #51 на уровне репозитория
+ * ({@link CareHistoryRepository#countActiveByPlantIdSince} /
+ * {@link CareHistoryRepository#countActiveOnTimeByPlantIdSince}). Формула on-time не
+ * дублируется. Отличие от {@code CareHistoryService.getPlantStats}: там граница окна
+ * берётся по {@code LocalDateTime.now()} (фактически UTC), а AC #138 требует окно в
+ * TZ юзера — поэтому границу {@code since} считаем здесь сами (начало дня
+ * «30 дней назад» в TZ юзера → UTC) и зовём repo-методы напрямую.
+ *
+ * <p>Порог «мало данных» — тот же {@link CareHistoryService#MIN_ACTIONS_FOR_STATS}
+ * (&lt;3 активных записей → балл не считаем).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HealthScoreService {
+
+    /** Окно on-time-% — как в #51 («за последние 30 дней»). */
+    private static final int ON_TIME_WINDOW_DAYS = 30;
+
+    private final CareHistoryRepository careHistoryRepository;
+    private final HealthScoreProperties properties;
+    private final Clock clock;
+
+    /**
+     * Health-score одного растения. Если активных записей &lt;
+     * {@link CareHistoryService#MIN_ACTIONS_FOR_STATS} — возвращается
+     * {@link HealthScore#insufficient()} (балл не считаем).
+     *
+     * <p>Требует, чтобы {@code plant.getUser()} был доступен (TZ юзера). Зовётся из
+     * сервисов с открытой read-only транзакцией — lazy {@code user} инициализируется.
+     */
+    @Transactional(readOnly = true)
+    public HealthScore computeForPlant(Plant plant) {
+        Long plantId = plant.getId();
+        long total = careHistoryRepository.countActiveByPlantId(plantId);
+
+        if (total < CareHistoryService.MIN_ACTIONS_FOR_STATS) {
+            log.debug("Health score for plant={}: insufficient data (total={})", plantId, total);
+            return HealthScore.insufficient();
+        }
+
+        String timezone = plant.getUser() != null ? plant.getUser().getTimezone() : null;
+        LocalDateTime since = windowStartUtc(timezone);
+
+        long actionsInWindow = careHistoryRepository.countActiveByPlantIdSince(plantId, since);
+        long onTimeInWindow = careHistoryRepository.countActiveOnTimeByPlantIdSince(plantId, since);
+
+        int onTimePct = actionsInWindow == 0
+                ? 0
+                : (int) Math.round(100.0 * onTimeInWindow / actionsInWindow);
+
+        int score = scoreFrom(onTimePct, plant);
+        HealthZone zone = zoneFor(score);
+
+        log.debug("Health score for plant={}: onTimePct={} score={} zone={}",
+                plantId, onTimePct, score, zone);
+        return HealthScore.of(score, zone);
+    }
+
+    /**
+     * Прозрачная формула: вес on-time + бонусы, клампится в [0, 100].
+     * Бонусы — за непустые фото ({@link Plant#getPhotoFileId()}) и заметки
+     * ({@link Plant#getNotes()}).
+     */
+    private int scoreFrom(int onTimePct, Plant plant) {
+        int raw = (int) Math.round(onTimePct * properties.onTimeWeight());
+
+        if (plant.getPhotoFileId() != null && !plant.getPhotoFileId().isBlank()) {
+            raw += properties.photoBonus();
+        }
+        if (plant.getNotes() != null && !plant.getNotes().isBlank()) {
+            raw += properties.notesBonus();
+        }
+
+        return Math.clamp(raw, 0, 100);
+    }
+
+    /** Маппинг балла в зону по конфигурируемым порогам. */
+    public HealthZone zoneFor(int score) {
+        if (score >= properties.greenThreshold()) {
+            return HealthZone.GREEN;
+        }
+        if (score >= properties.yellowThreshold()) {
+            return HealthZone.YELLOW;
+        }
+        return HealthZone.RED;
+    }
+
+    /**
+     * Граница окon-time-окна в UTC: начало дня «30 дней назад» в TZ юзера.
+     * Repo-методы фильтруют {@code doneAt > since} (doneAt хранится в UTC), поэтому
+     * вычисляем локальную полночь нужного дня и переводим в UTC.
+     */
+    private LocalDateTime windowStartUtc(String timezone) {
+        ZoneId zone = TimeUtils.safeZone(timezone);
+        LocalDate windowStartDay = clock.instant().atZone(zone).toLocalDate()
+                .minusDays(ON_TIME_WINDOW_DAYS);
+        return windowStartDay.atStartOfDay(zone)
+                .withZoneSameInstant(ZoneOffset.UTC)
+                .toLocalDateTime();
+    }
+
+    /**
+     * Результат расчёта health-score (issue #138).
+     *
+     * @param insufficientData {@code true} → данных мало (&lt;3 действий), score/zone
+     *                         не заполнены; UI показывает «Пока мало данных»
+     * @param score            балл 0–100 (валиден только если {@code !insufficientData})
+     * @param zone             зона (валидна только если {@code !insufficientData})
+     */
+    public record HealthScore(boolean insufficientData, int score, HealthZone zone) {
+
+        private static final HealthScore INSUFFICIENT = new HealthScore(true, 0, null);
+
+        public static HealthScore insufficient() {
+            return INSUFFICIENT;
+        }
+
+        public static HealthScore of(int score, HealthZone zone) {
+            return new HealthScore(false, score, zone);
+        }
+    }
+}

--- a/src/main/java/com/plantcare/bot/service/PlantCardService.java
+++ b/src/main/java/com/plantcare/bot/service/PlantCardService.java
@@ -85,6 +85,7 @@ public class PlantCardService {
     private final MainMenuService mainMenuService;
     private final UserService userService;
     private final CareHistoryService careHistoryService;
+    private final HealthScoreService healthScoreService;
     private final PlantEventService plantEventService;
     private final SpeciesFactService speciesFactService;
     private final com.plantcare.bot.seasonal.service.SeasonalIntervalService seasonalIntervalService;
@@ -1391,6 +1392,9 @@ public class PlantCardService {
             sb.append("🌱 Потомки: ").append(childrenCount).append("\n");
         }
 
+        // issue #138: health-score после локации/потомков, до «С тобой с …».
+        appendHealthScoreLine(sb, plant);
+
         // issue #117: «С тобой с …» — после имени/локации, до фото/баннеров.
         appendAcquiredAtLine(sb, plant);
 
@@ -1810,6 +1814,23 @@ public class PlantCardService {
             return "✅ Я уже " + doneVerb(only).toLowerCase();
         }
         return "✅ Я уже ухаживал";
+    }
+
+    /**
+     * Добавляет в карточку строку health-score (issue #138):
+     * «Health: 82 🟢» либо «Health: Пока мало данных», если действий &lt; 3.
+     */
+    private void appendHealthScoreLine(StringBuilder sb, Plant plant) {
+        HealthScoreService.HealthScore health = healthScoreService.computeForPlant(plant);
+        if (health.insufficientData()) {
+            sb.append("❤️ Health: Пока мало данных\n");
+        } else {
+            sb.append("❤️ Health: ")
+                    .append(health.score())
+                    .append(" ")
+                    .append(health.zone().emoji())
+                    .append("\n");
+        }
     }
 
     /**

--- a/src/main/java/com/plantcare/bot/service/PlantMenuService.java
+++ b/src/main/java/com/plantcare/bot/service/PlantMenuService.java
@@ -35,6 +35,7 @@ import java.util.List;
 public class PlantMenuService {
 
     private final PlantRepository plantRepository;
+    private final HealthScoreService healthScoreService;
 
     /**
      * Показать список растений пользователя.
@@ -77,9 +78,42 @@ public class PlantMenuService {
             return sb.toString();
         }
 
-        sb.append("Всего: ").append(plants.size()).append("\n\n");
-        sb.append("Открой карточку, чтобы увидеть статус ухода и быстро отметить полив.");
+        sb.append("Всего: ").append(plants.size()).append("\n");
+
+        // issue #138: сводка по зонам health-score. Растения с «мало данных»
+        // (<3 действий) в сводку не попадают — у них балл ещё не считается.
+        appendHealthSummary(sb, plants);
+
+        sb.append("\nОткрой карточку, чтобы увидеть статус ухода и быстро отметить полив.");
         return sb.toString();
+    }
+
+    /**
+     * Сводка «🟢 N · 🟡 N · 🔴 N» по активным растениям коллекции (issue #138).
+     * Печатается только если есть хотя бы одно растение с достаточными данными.
+     */
+    private void appendHealthSummary(StringBuilder sb, List<Plant> plants) {
+        int green = 0;
+        int yellow = 0;
+        int red = 0;
+        for (Plant plant : plants) {
+            HealthScoreService.HealthScore health = healthScoreService.computeForPlant(plant);
+            if (health.insufficientData()) {
+                continue;
+            }
+            switch (health.zone()) {
+                case GREEN -> green++;
+                case YELLOW -> yellow++;
+                case RED -> red++;
+            }
+        }
+        if (green + yellow + red == 0) {
+            return;
+        }
+        sb.append("🟢 ").append(green)
+                .append(" · 🟡 ").append(yellow)
+                .append(" · 🔴 ").append(red)
+                .append("\n");
     }
 
     private InlineKeyboardMarkup buildListKeyboard(List<Plant> plants, long archivedCount) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,16 @@ app:
     base-url: ${CALENDAR_BASE_URL:https://example.com}
     event-window-days: 90
 
+  # Issue #138: health-score растения. Формула:
+  #   score = round(onTimePct * on-time-weight) + (есть фото ? photo-bonus) + (есть заметки ? notes-bonus)
+  # затем клампится в [0, 100]. Идеальная серия (100% on-time) + фото + заметки = 100.
+  health-score:
+    on-time-weight: 0.8    # доля 100-балльной шкалы под % on-time за 30 дней (макс. 80 баллов)
+    photo-bonus: 10        # бонус за наличие фото (issue #24)
+    notes-bonus: 10        # бонус за наличие заметок (issue #25)
+    green-threshold: 80    # score >= → зелёная зона 🟢
+    yellow-threshold: 50   # score >= (но < green) → жёлтая 🟡; ниже — красная 🔴
+
 weather:
   cache-minutes: 60          # дефолт 60
   threshold-defer-ok: 80     # дефолт 80

--- a/src/test/java/com/plantcare/bot/service/HealthScoreServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/HealthScoreServiceTest.java
@@ -1,0 +1,287 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.CareHistory;
+import com.plantcare.bot.domain.Location;
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.HealthZone;
+import com.plantcare.bot.domain.enums.TaskType;
+import com.plantcare.bot.repository.CareHistoryRepository;
+import com.plantcare.bot.repository.LocationRepository;
+import com.plantcare.bot.repository.PlantRepository;
+import com.plantcare.bot.repository.UserRepository;
+import com.plantcare.bot.service.HealthScoreService.HealthScore;
+import com.plantcare.bot.support.IntegrationTestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+/**
+ * Интеграционные тесты health-score (issue #138) на реальном Postgres через
+ * Testcontainers — формула считается поверх настоящих {@code care_history}-записей
+ * и repo-агрегатов on-time из #51, а не на моках репозитория.
+ *
+ * <p>Окно on-time-% — 30 дней в TZ юзера. Чтобы граница окна была детерминированной,
+ * {@link Clock}-бин подменён фиксированным моментом ({@link #FIXED_NOW}) — все
+ * {@code doneAt} в тестах расставляются относительно него.
+ *
+ * <p>Покрывает AC #138:
+ * <ul>
+ *   <li>happy — идеальная серия on-time + фото + заметки → ~100 и GREEN 🟢;</li>
+ *   <li>happy — запущенное растение (низкий on-time, без бонусов) → низкий балл, RED 🔴;</li>
+ *   <li>промежуточный on-time-% → YELLOW 🟡;</li>
+ *   <li>вклад бонусов: фото/заметки поднимают балл на ожидаемую величину;</li>
+ *   <li>edge — мало данных (&lt;3 действий) → insufficientData=true, балл не считаем;</li>
+ *   <li>edge — не-UTC TZ (Asia/Almaty) на границе окна 30 дней: действие, попадающее
+ *       в окно по локальному календарю, учитывается — а при UTC-расчёте выпало бы.</li>
+ * </ul>
+ */
+@DisplayName("HealthScoreService — health-score растения (issue #138)")
+@Import(HealthScoreServiceTest.FixedClockConfig.class)
+class HealthScoreServiceTest extends IntegrationTestBase {
+
+    /**
+     * Фиксированный «сейчас». 00:30 UTC выбрано специально: для восточных TZ
+     * (Almaty UTC+5) локальная дата уже «сегодня», а UTC-полночь окна и
+     * локальная-полночь окна расходятся на день — это и проверяет TZ-кейс.
+     */
+    static final Instant FIXED_NOW = Instant.parse("2026-05-25T00:30:00Z");
+
+    @TestConfiguration
+    static class FixedClockConfig {
+        @Bean
+        @Primary
+        Clock fixedClock() {
+            return Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+        }
+    }
+
+    @Autowired private HealthScoreService service;
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private LocationRepository locationRepository;
+    @Autowired private PlantRepository plantRepository;
+    @Autowired private CareHistoryRepository careHistoryRepository;
+
+    @AfterEach
+    void cleanup() {
+        careHistoryRepository.deleteAll();
+        plantRepository.deleteAll();
+        locationRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("should_score_near_100_and_green_when_perfect_streak_with_photo_and_notes")
+    void should_score_near_100_and_green_when_perfect_streak_with_photo_and_notes() {
+        // arrange: 5 действий за окно, все on-time → on-time 100% → 80 баллов;
+        // фото (+10) и заметки (+10) → ровно 100.
+        User user = savedUser(8001L, "UTC");
+        Plant plant = savedPlant(user, "Образцовый фикус", "photo-file-id-xyz", "поливаю по графику");
+        for (int i = 1; i <= 5; i++) {
+            saveCare(plant, TaskType.WATERING, daysAgoUtc(i), true);
+        }
+
+        // act
+        HealthScore result = service.computeForPlant(plant);
+
+        // assert
+        assertSoftly(softly -> {
+            softly.assertThat(result.insufficientData()).isFalse();
+            softly.assertThat(result.score()).isEqualTo(100);
+            softly.assertThat(result.zone()).isEqualTo(HealthZone.GREEN);
+        });
+    }
+
+    @Test
+    @DisplayName("should_score_low_and_red_when_neglected_plant_without_bonuses")
+    void should_score_low_and_red_when_neglected_plant_without_bonuses() {
+        // arrange: 4 действия за окно, лишь 1 on-time → on-time 25% → round(25*0.8)=20.
+        // Ни фото, ни заметок → бонусов нет → score 20, ниже yellowThreshold(50) → RED.
+        User user = savedUser(8002L, "UTC");
+        Plant plant = savedPlant(user, "Запущенный кактус", null, null);
+        saveCare(plant, TaskType.WATERING, daysAgoUtc(1), true);
+        saveCare(plant, TaskType.WATERING, daysAgoUtc(2), false);
+        saveCare(plant, TaskType.WATERING, daysAgoUtc(3), false);
+        saveCare(plant, TaskType.WATERING, daysAgoUtc(4), false);
+
+        // act
+        HealthScore result = service.computeForPlant(plant);
+
+        // assert
+        assertSoftly(softly -> {
+            softly.assertThat(result.insufficientData()).isFalse();
+            softly.assertThat(result.score()).isEqualTo(20);
+            softly.assertThat(result.zone()).isEqualTo(HealthZone.RED);
+        });
+    }
+
+    @Test
+    @DisplayName("should_be_yellow_when_on_time_is_moderate_without_bonuses")
+    void should_be_yellow_when_on_time_is_moderate_without_bonuses() {
+        // arrange: 4 действия, 3 on-time → 75% → round(75*0.8)=60. Бонусов нет.
+        // 60 ∈ [yellow=50, green=80) → YELLOW.
+        User user = savedUser(8003L, "UTC");
+        Plant plant = savedPlant(user, "Средняя монстера", null, null);
+        saveCare(plant, TaskType.WATERING, daysAgoUtc(1), true);
+        saveCare(plant, TaskType.WATERING, daysAgoUtc(2), true);
+        saveCare(plant, TaskType.WATERING, daysAgoUtc(3), true);
+        saveCare(plant, TaskType.WATERING, daysAgoUtc(4), false);
+
+        // act
+        HealthScore result = service.computeForPlant(plant);
+
+        // assert
+        assertSoftly(softly -> {
+            softly.assertThat(result.score()).isEqualTo(60);
+            softly.assertThat(result.zone()).isEqualTo(HealthZone.YELLOW);
+        });
+    }
+
+    @Test
+    @DisplayName("should_add_twenty_points_when_photo_and_notes_present_vs_bare_plant")
+    void should_add_twenty_points_when_photo_and_notes_present_vs_bare_plant() {
+        // arrange: одинаковая on-time-история (3 on-time из 4 = 75% → база 60),
+        // но одно растение без бонусов, другое — с фото и заметками (+10+10).
+        User user = savedUser(8004L, "UTC");
+
+        Plant bare = savedPlant(user, "Без бонусов", null, null);
+        Plant decorated = savedPlant(user, "С фото и заметками", "file-id", "любимая");
+        for (Plant p : new Plant[]{bare, decorated}) {
+            saveCare(p, TaskType.WATERING, daysAgoUtc(1), true);
+            saveCare(p, TaskType.WATERING, daysAgoUtc(2), true);
+            saveCare(p, TaskType.WATERING, daysAgoUtc(3), true);
+            saveCare(p, TaskType.WATERING, daysAgoUtc(4), false);
+        }
+
+        // act
+        HealthScore bareScore = service.computeForPlant(bare);
+        HealthScore decoratedScore = service.computeForPlant(decorated);
+
+        // assert: бонусы дают ровно +20 (10 фото + 10 заметки).
+        assertThat(decoratedScore.score() - bareScore.score()).isEqualTo(20);
+        assertThat(bareScore.score()).isEqualTo(60);
+        assertThat(decoratedScore.score()).isEqualTo(80);
+    }
+
+    @Test
+    @DisplayName("should_return_insufficient_data_when_fewer_than_three_actions")
+    void should_return_insufficient_data_when_fewer_than_three_actions() {
+        // arrange: всего 2 активных действия (порог MIN_ACTIONS_FOR_STATS = 3).
+        User user = savedUser(8005L, "UTC");
+        Plant plant = savedPlant(user, "Новичок", "file-id", "заметка");
+        saveCare(plant, TaskType.WATERING, daysAgoUtc(1), true);
+        saveCare(plant, TaskType.WATERING, daysAgoUtc(2), true);
+
+        // act
+        HealthScore result = service.computeForPlant(plant);
+
+        // assert: балл не считаем — состояние «мало данных», не падение.
+        assertSoftly(softly -> {
+            softly.assertThat(result.insufficientData()).isTrue();
+            softly.assertThat(result.score()).isZero();
+            softly.assertThat(result.zone()).isNull();
+        });
+    }
+
+    @Test
+    @DisplayName("should_count_action_on_window_edge_in_user_timezone_not_utc")
+    void should_count_action_on_window_edge_in_user_timezone_not_utc() {
+        // arrange: юзер в Asia/Almaty (UTC+5). Фиксированный «сейчас» = 2026-05-25 00:30 UTC,
+        // что локально = 2026-05-25 05:30 Алматы → сегодня (локально) = 25 мая.
+        // Окно 30 дней в TZ юзера → начало дня 25 апреля по Алматы:
+        //   2026-04-25 00:00 +05:00 = 2026-04-24 19:00 UTC  → это граница `since`.
+        // При наивном UTC-расчёте границей было бы 2026-04-25 00:00 UTC.
+        //
+        // Граничное действие: 2026-04-24 20:00 UTC = 2026-04-25 01:00 Алматы.
+        //   - по локальному календарю Алматы оно ВНУТРИ последних 30 дней (после since);
+        //   - по UTC-расчёту (since=2026-04-25 00:00 UTC) оно бы ВЫПАЛО из окна.
+        // Делаем его on-time, а все «глубокие» действия в окне — late, чтобы включение
+        // граничного действия сдвинуло on-time-% (и зону) заметно.
+        User user = savedUser(8006L, "Asia/Almaty");
+        Plant plant = savedPlant(user, "Алматинское граничное", null, null);
+
+        // Граничное on-time действие — попадает в окно только при TZ-расчёте.
+        saveCare(plant, TaskType.WATERING, Instant.parse("2026-04-24T20:00:00Z"), true);
+        // Три глубоко-внутри-окна late действия (никаких споров о границе).
+        saveCare(plant, TaskType.WATERING, daysAgoUtc(2), false);
+        saveCare(plant, TaskType.WATERING, daysAgoUtc(3), false);
+        saveCare(plant, TaskType.WATERING, daysAgoUtc(4), false);
+
+        // act
+        HealthScore result = service.computeForPlant(plant);
+
+        // assert: окно содержит 4 действия, 1 on-time → 25% → round(25*0.8)=20.
+        // Если бы границу считали в UTC, граничное действие выпало бы → 3 действия,
+        // 0 on-time → 0%. Балл 20 (а не 0) доказывает учёт действия в окне по TZ юзера.
+        assertSoftly(softly -> {
+            softly.assertThat(result.insufficientData()).isFalse();
+            softly.assertThat(result.score()).isEqualTo(20);
+            softly.assertThat(result.zone()).isEqualTo(HealthZone.RED);
+        });
+    }
+
+    // ===================== helpers =====================
+
+    private User savedUser(Long chatId, String timezone) {
+        return userRepository.save(User.builder()
+                .telegramChatId(chatId)
+                .timezone(timezone)
+                .blocked(false)
+                .build());
+    }
+
+    private Location savedDefaultLocation(User user) {
+        return locationRepository.findByUserIdAndDefaultLocationTrue(user.getId())
+                .orElseGet(() -> locationRepository.save(Location.builder()
+                        .user(user)
+                        .name(Location.DEFAULT_NAME)
+                        .emoji(Location.DEFAULT_EMOJI)
+                        .defaultLocation(true)
+                        .build()));
+    }
+
+    private Plant savedPlant(User user, String name, String photoFileId, String notes) {
+        return plantRepository.save(Plant.builder()
+                .user(user)
+                .location(savedDefaultLocation(user))
+                .name(name)
+                .photoFileId(photoFileId)
+                .notes(notes)
+                .acquiredAt(LocalDate.of(2024, 1, 1))
+                .build());
+    }
+
+    /** doneAt хранится в UTC; конвертим момент во времени в UTC LocalDateTime. */
+    private CareHistory saveCare(Plant plant, TaskType type, Instant instant, boolean onTime) {
+        LocalDateTime doneAtUtc = instant.atZone(ZoneOffset.UTC)
+                .toLocalDateTime().truncatedTo(ChronoUnit.MICROS);
+        return careHistoryRepository.save(CareHistory.builder()
+                .plant(plant)
+                .taskType(type)
+                .doneAt(doneAtUtc)
+                .onTime(onTime)
+                .build());
+    }
+
+    /** Момент «N суток назад» относительно фиксированного {@link #FIXED_NOW}. */
+    private Instant daysAgoUtc(int days) {
+        return FIXED_NOW.minus(days, ChronoUnit.DAYS);
+    }
+}

--- a/src/test/java/com/plantcare/bot/service/PlantCardSpeciesFactsTest.java
+++ b/src/test/java/com/plantcare/bot/service/PlantCardSpeciesFactsTest.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 /**
@@ -43,6 +45,7 @@ class PlantCardSpeciesFactsTest {
     @Mock private MainMenuService mainMenuService;
     @Mock private UserService userService;
     @Mock private CareHistoryService careHistoryService;
+    @Mock private HealthScoreService healthScoreService;
     @Mock private PlantEventService plantEventService;
     @Mock private SpeciesFactService speciesFactService;
     @Mock private SeasonalIntervalService seasonalIntervalService;
@@ -55,7 +58,12 @@ class PlantCardSpeciesFactsTest {
     void setUp() {
         cardService = new PlantCardService(
                 plantService, plantRepository, careScheduleRepository, mainMenuService, userService,
-                careHistoryService, plantEventService, speciesFactService, seasonalIntervalService);
+                careHistoryService, healthScoreService, plantEventService, speciesFactService,
+                seasonalIntervalService);
+
+        // issue #138: карточка дёргает health-score; для фактов вида он не важен.
+        lenient().when(healthScoreService.computeForPlant(any()))
+                .thenReturn(HealthScoreService.HealthScore.insufficient());
     }
 
     @Test

--- a/src/test/java/com/plantcare/bot/service/PlantCardToxicityTest.java
+++ b/src/test/java/com/plantcare/bot/service/PlantCardToxicityTest.java
@@ -3,6 +3,7 @@ package com.plantcare.bot.service;
 import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.Species;
 import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.HealthZone;
 import com.plantcare.bot.repository.PlantRepository;
 import com.plantcare.bot.seasonal.service.SeasonalIntervalService;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +20,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 /**
@@ -43,6 +46,7 @@ class PlantCardToxicityTest {
     @Mock private MainMenuService mainMenuService;
     @Mock private UserService userService;
     @Mock private CareHistoryService careHistoryService;
+    @Mock private HealthScoreService healthScoreService;
     @Mock private PlantEventService plantEventService;
     @Mock private SpeciesFactService speciesFactService;
     @Mock private SeasonalIntervalService seasonalIntervalService;
@@ -55,7 +59,13 @@ class PlantCardToxicityTest {
     void setUp() {
         cardService = new PlantCardService(
                 plantService, plantRepository, careScheduleRepository, mainMenuService, userService,
-                careHistoryService, plantEventService, speciesFactService, seasonalIntervalService);
+                careHistoryService, healthScoreService, plantEventService, speciesFactService,
+                seasonalIntervalService);
+
+        // issue #138: карточка дёргает health-score; для токсичности он не важен —
+        // возвращаем «мало данных», чтобы строка балла не мешала ассертам.
+        lenient().when(healthScoreService.computeForPlant(any()))
+                .thenReturn(HealthScoreService.HealthScore.insufficient());
     }
 
     @Test
@@ -174,6 +184,45 @@ class PlantCardToxicityTest {
         assertThat(text).doesNotContain(DOGS_BADGE);
         assertThat(text).doesNotContain(HUMANS_BADGE);
         assertThat(text).doesNotContain("токсично");
+    }
+
+    // ------------------------------------------------------ health-score (issue #138)
+
+    @Test
+    void should_render_health_score_line_with_value_and_zone_emoji_when_score_computed()
+            throws Exception {
+        // arrange — реальный балл в зелёной зоне; здесь стаб health-score
+        // перекрывает дефолтный insufficient() из setUp
+        Species species = givenSpecies(100L);
+        givenCardFor(species);
+        when(healthScoreService.computeForPlant(any()))
+                .thenReturn(HealthScoreService.HealthScore.of(82, HealthZone.GREEN));
+
+        // act
+        cardService.showPlantCard(givenUser(1L, 555L), 10L, null, PlantCardService.BACK_TO_LIST, client);
+
+        // assert
+        String text = cardText();
+        assertThat(text).contains("❤️ Health: 82 🟢");
+        assertThat(text).doesNotContain("Пока мало данных");
+    }
+
+    @Test
+    void should_render_insufficient_data_line_when_health_score_has_not_enough_data()
+            throws Exception {
+        // arrange — мок по умолчанию из setUp возвращает insufficient()
+        Species species = givenSpecies(100L);
+        givenCardFor(species);
+
+        // act
+        cardService.showPlantCard(givenUser(1L, 555L), 10L, null, PlantCardService.BACK_TO_LIST, client);
+
+        // assert
+        String text = cardText();
+        assertThat(text).contains("❤️ Health: Пока мало данных");
+        assertThat(text).doesNotContain("🟢");
+        assertThat(text).doesNotContain("🟡");
+        assertThat(text).doesNotContain("🔴");
     }
 
     // ------------------------------------------------------------------ helpers

--- a/src/test/java/com/plantcare/bot/service/PlantMenuServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/PlantMenuServiceTest.java
@@ -3,6 +3,7 @@ package com.plantcare.bot.service;
 import com.plantcare.bot.domain.Location;
 import com.plantcare.bot.domain.Plant;
 import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.HealthZone;
 import com.plantcare.bot.repository.PlantRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,6 +25,8 @@ import java.lang.reflect.Field;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -32,6 +35,7 @@ import static org.mockito.Mockito.when;
 class PlantMenuServiceTest {
 
     @Mock private PlantRepository plantRepository;
+    @Mock private HealthScoreService healthScoreService;
     @Mock private TelegramClient client;
 
     @InjectMocks
@@ -45,6 +49,11 @@ class PlantMenuServiceTest {
                 .telegramChatId(100L)
                 .build();
         setPrivateField(user, "id", 7L);
+
+        // issue #138: по умолчанию «мало данных» — сводка по зонам не печатается,
+        // существующие ассерты про текст/клавиатуру не задеваются.
+        lenient().when(healthScoreService.computeForPlant(any()))
+                .thenReturn(HealthScoreService.HealthScore.insufficient());
     }
 
     @Test
@@ -170,6 +179,62 @@ class PlantMenuServiceTest {
                 .flatExtracting(row -> row)
                 .extracting(InlineKeyboardButton::getCallbackData)
                 .doesNotContain("ARCHIVE:LIST");
+    }
+
+    @Test
+    @DisplayName("issue #138: сводка «🟢 N · 🟡 N · 🔴 N» считает зоны, insufficient не учитывается")
+    void should_render_health_summary_with_zone_counts_excluding_insufficient_plants()
+            throws TelegramApiException {
+        // arrange: 5 растений — 2 GREEN, 1 YELLOW, 1 RED, 1 insufficient
+        Plant green1 = plant(1L, "Алоэ", location(10L, "Кухня", "🍳"));
+        Plant green2 = plant(2L, "Бегония", location(10L, "Кухня", "🍳"));
+        Plant yellow = plant(3L, "Фикус", location(11L, "Спальня", null));
+        Plant red = plant(4L, "Орхидея", location(11L, "Спальня", null));
+        Plant noData = plant(5L, "Кактус", location(11L, "Спальня", null));
+
+        when(plantRepository.findAllByUserIdAndArchivedAtIsNullOrderByNameAsc(7L))
+                .thenReturn(List.of(green1, green2, yellow, red, noData));
+        when(healthScoreService.computeForPlant(green1))
+                .thenReturn(HealthScoreService.HealthScore.of(90, HealthZone.GREEN));
+        when(healthScoreService.computeForPlant(green2))
+                .thenReturn(HealthScoreService.HealthScore.of(81, HealthZone.GREEN));
+        when(healthScoreService.computeForPlant(yellow))
+                .thenReturn(HealthScoreService.HealthScore.of(55, HealthZone.YELLOW));
+        when(healthScoreService.computeForPlant(red))
+                .thenReturn(HealthScoreService.HealthScore.of(20, HealthZone.RED));
+        when(healthScoreService.computeForPlant(noData))
+                .thenReturn(HealthScoreService.HealthScore.insufficient());
+
+        // act
+        service.sendMyPlantsList(user, null, client);
+
+        // assert: insufficient (Кактус) в счётчики не попал → 2 / 1 / 1
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(client).execute(captor.capture());
+        assertThat(captor.getValue().getText()).contains("🟢 2 · 🟡 1 · 🔴 1");
+    }
+
+    @Test
+    @DisplayName("issue #138: при всех insufficient строка-сводка не печатается")
+    void should_not_render_health_summary_when_all_plants_have_insufficient_data()
+            throws TelegramApiException {
+        // arrange: оба растения без достаточных данных (дефолтный стаб из setUp)
+        Plant a = plant(1L, "Алоэ", location(10L, "Кухня", "🍳"));
+        Plant b = plant(2L, "Фикус", location(11L, "Спальня", null));
+        when(plantRepository.findAllByUserIdAndArchivedAtIsNullOrderByNameAsc(7L))
+                .thenReturn(List.of(a, b));
+
+        // act
+        service.sendMyPlantsList(user, null, client);
+
+        // assert: ни одной зональной строки
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(client).execute(captor.capture());
+        String text = captor.getValue().getText();
+        assertThat(text).contains("Всего: 2");
+        assertThat(text).doesNotContain("🟢");
+        assertThat(text).doesNotContain("🟡");
+        assertThat(text).doesNotContain("🔴");
     }
 
     // ---- helpers ----


### PR DESCRIPTION
Closes #138

## Что сделано
- `HealthScoreService` (`@Transactional(readOnly = true)`): балл 0–100 на растение по прозрачной формуле `round(onTimePct * on-time-weight) + (фото?+10) + (заметки?+10)`, clamp 0..100. Идеальная серия + фото + заметки = 100.
- Балл маппится в зоны 🟢 / 🟡 / 🔴 по конфигурируемым порогам.
- Окно «% on-time за 30 дней» считается **в TZ юзера** (начало дня 30 дней назад в зоне юзера → UTC), переиспользует repo-расчёт on-time из #51 (`countActive*Since`) без дублирования формулы. Существующий `getPlantStats` считает окно в UTC, поэтому для health-score граница окна вычисляется отдельно (TZ-aware).
- Порог `<3` действий (как в #51) → состояние «Пока мало данных», балл не считается.
- Все веса и пороги зон — через `HealthScoreProperties` (`@ConfigurationProperties`, prefix `app.health-score`), дефолты в `application.yml`, с sanity на относительный порядок порогов.
- Карточка растения (#26): строка «❤️ Health: 82 🟢» / «❤️ Health: Пока мало данных».
- `/menu`: сводка по коллекции «🟢 N · 🟡 N · 🔴 N» (растения с «мало данных» в счётчики не входят).

## Миграции
Нет — балл вычисляется на лету из `care_history` / `photo_file_id` / `notes`, без новой схемы (как и предписано issue).

## Backward-compat риски
**safe.** Только новый код + аддитивный блок конфигурации `app.health-score` с дефолтами. Схему БД не трогает, существующие запросы не меняет.

## Тесты
`HealthScoreServiceTest` (6, `@SpringBootTest` + Testcontainers Postgres, не H2): формула happy (идеальная серия → 100 GREEN), RED (запущенное), YELLOW (промежуточный), вклад бонусов (+20), edge «мало данных» (insufficientData), **edge не-UTC TZ на границе окна 30 дней** (Asia/Almaty, фиксированный `Clock`: граничное действие учитывается по TZ юзера, при UTC-расчёте балл был бы иным).
Рендер: `PlantCardToxicityTest` (+2) — строка «❤️ Health: …» и «Пока мало данных»; `PlantMenuServiceTest` (+2) — сводка «🟢 N · 🟡 N · 🔴 N» с исключением insufficient. Итого по затронутым классам: 25 тестов зелёные.

## Чек
- [x] reviewer прошёл — 0 BLOCKING; SHOULD-FIX #1 (тесты рендера) закрыт, NIT (порядок порогов) закрыт
- [ ] `mvn verify` локально красное **только** из-за pre-existing flaky тестов от Testcontainers reuse=true (контаминация общего контейнера: ordering/FK/optimistic-lock — `SpeciesRepositoryTest`, `PlantServiceTest.getPopularSpecies`, `MonthlyReportServiceTest`, `PlantCardServiceLineageTest`, `SimpleRepositoriesTest` и т.п.). Все зелёные в изоляции; 25 тестов фичи зелёные. На фреш-контейнере CI ожидается зелёным.

## Известный долг (принят для P3)
- `/menu`-сводка считает health per-plant (~3 count-запроса на растение) — потенциальный N+1 на больших коллекциях. Issue сам относит оптимизацию (кэш/групповой агрегат) на «если станет тяжело», поэтому не материализуем сейчас.
