### PR TITLE
feat: админ-CRUD фактов вида и флаги токсичности (#131)

### DIFF
--- a/src/main/java/com/plantcare/bot/admin/controller/AdminSpeciesController.java
+++ b/src/main/java/com/plantcare/bot/admin/controller/AdminSpeciesController.java
@@ -3,6 +3,7 @@ package com.plantcare.bot.admin.controller;
 import com.plantcare.bot.admin.dto.SpeciesFormDto;
 import com.plantcare.bot.admin.dto.SpeciesListItem;
 import com.plantcare.bot.admin.exception.DuplicateSpeciesNameException;
+import com.plantcare.bot.admin.service.AdminSpeciesFactService;
 import com.plantcare.bot.admin.service.AdminSpeciesService;
 import com.plantcare.bot.domain.Species;
 import com.plantcare.bot.domain.enums.CareDifficulty;
@@ -43,6 +44,7 @@ public class AdminSpeciesController {
     );
 
     private final AdminSpeciesService adminSpeciesService;
+    private final AdminSpeciesFactService adminSpeciesFactService;
 
     // ============================================================ list + search
 
@@ -110,6 +112,11 @@ public class AdminSpeciesController {
         Species species = adminSpeciesService.findById(id);
         prepareFormModel(model, toDto(species),
                 "/admin/species/" + id, "Редактирование: " + species.getName(), id);
+
+        // Секция управления фактами (issue #131) — только на странице редактирования.
+        AdminSpeciesFactController.populateFactsSection(
+                id, adminSpeciesFactService.getFactsGrouped(id), model);
+
         return "admin/species/form";
     }
 
@@ -215,6 +222,9 @@ public class AdminSpeciesController {
         dto.setDescription(s.getDescription());
         dto.setSearchTags(s.getSearchTags());
         dto.setPopularity(s.getPopularity());
+        dto.setToxicToCats(s.getToxicToCats());
+        dto.setToxicToDogs(s.getToxicToDogs());
+        dto.setToxicToHumans(s.getToxicToHumans());
         return dto;
     }
 }

--- a/src/main/java/com/plantcare/bot/admin/controller/AdminSpeciesFactController.java
+++ b/src/main/java/com/plantcare/bot/admin/controller/AdminSpeciesFactController.java
@@ -1,0 +1,152 @@
+package com.plantcare.bot.admin.controller;
+
+import com.plantcare.bot.admin.dto.SpeciesFactFormDto;
+import com.plantcare.bot.admin.service.AdminSpeciesFactService;
+import com.plantcare.bot.domain.SpeciesFact;
+import com.plantcare.bot.domain.enums.FactCategory;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Админский CRUD энциклопедических фактов вида (issue #131).
+ *
+ * <p>Тонкий контроллер: парсит запрос → дёргает {@link AdminSpeciesFactService} →
+ * возвращает HTMX-фрагмент обновлённой секции фактов
+ * ({@code admin/species/facts/section :: factsSection}).
+ *
+ * <p>Все операции вложены в вид ({@code /admin/species/{speciesId}/facts}); сервис
+ * проверяет принадлежность факта виду, защищая от подмены {@code factId}.
+ */
+@Controller
+@RequestMapping("/admin/species/{speciesId}/facts")
+@RequiredArgsConstructor
+public class AdminSpeciesFactController {
+
+    /**
+     * Русские подписи категорий. Держим в контроллере, чтобы не трогать enum
+     * в {@code com.plantcare.bot.domain.enums}.
+     */
+    static final Map<FactCategory, String> CATEGORY_LABELS = Map.of(
+            FactCategory.ORIGIN,    "Происхождение",
+            FactCategory.CARE,      "Уход",
+            FactCategory.TOXICITY,  "Токсичность",
+            FactCategory.CURIOSITY, "Интересное"
+    );
+
+    private static final String FACTS_FRAGMENT = "admin/species/facts/section :: factsSection";
+
+    private final AdminSpeciesFactService adminSpeciesFactService;
+
+    /**
+     * Перерисовка секции с пустой формой (отмена редактирования).
+     */
+    @GetMapping
+    public String section(@PathVariable Long speciesId, Model model) {
+        return renderSection(speciesId, model);
+    }
+
+    /**
+     * Секция с формой в режиме правки выбранного факта (prefill значениями).
+     */
+    @GetMapping("/{factId}/edit")
+    public String editForm(@PathVariable Long speciesId,
+                           @PathVariable Long factId,
+                           Model model) {
+        SpeciesFact fact = adminSpeciesFactService.getOwnedFact(speciesId, factId);
+        model.addAttribute("factForm", SpeciesFactFormDto.from(fact));
+        model.addAttribute("editingFactId", factId);
+        return renderSection(speciesId, model);
+    }
+
+    /**
+     * Создаёт факт. При ошибках валидации форма перерисовывается с сообщениями,
+     * при успехе — очищается. Возвращает HTMX-фрагмент секции.
+     */
+    @PostMapping
+    public String create(@PathVariable Long speciesId,
+                         @Valid @ModelAttribute("factForm") SpeciesFactFormDto dto,
+                         BindingResult bindingResult,
+                         Model model,
+                         Authentication auth) {
+        if (!bindingResult.hasErrors()) {
+            adminSpeciesFactService.createFact(speciesId, dto, auth.getName());
+            // После успешного создания форму очищаем.
+            model.addAttribute("factForm", emptyForm());
+        }
+        return renderSection(speciesId, model);
+    }
+
+    /**
+     * Обновляет факт. При ошибках валидации форма остаётся в режиме правки этого
+     * факта, при успехе — очищается. Возвращает HTMX-фрагмент секции.
+     */
+    @PostMapping("/{factId}")
+    public String update(@PathVariable Long speciesId,
+                         @PathVariable Long factId,
+                         @Valid @ModelAttribute("factForm") SpeciesFactFormDto dto,
+                         BindingResult bindingResult,
+                         Model model,
+                         Authentication auth) {
+        if (!bindingResult.hasErrors()) {
+            adminSpeciesFactService.updateFact(speciesId, factId, dto, auth.getName());
+            model.addAttribute("factForm", emptyForm());
+        } else {
+            // Сохраняем редактируемый id, чтобы форма ниже секции осталась в режиме правки.
+            model.addAttribute("editingFactId", factId);
+        }
+        return renderSection(speciesId, model);
+    }
+
+    /**
+     * Удаляет факт и возвращает HTMX-фрагмент обновлённой секции.
+     */
+    @DeleteMapping("/{factId}")
+    public String delete(@PathVariable Long speciesId,
+                         @PathVariable Long factId,
+                         Model model,
+                         Authentication auth) {
+        adminSpeciesFactService.deleteFact(speciesId, factId, auth.getName());
+        return renderSection(speciesId, model);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    /**
+     * Кладёт в модель данные секции фактов и возвращает имя фрагмента.
+     * Используется и контроллером вида при первичном рендере страницы edit.
+     */
+    static String populateFactsSection(Long speciesId,
+                                       Map<FactCategory, List<SpeciesFact>> grouped,
+                                       Model model) {
+        model.addAttribute("speciesId", speciesId);
+        model.addAttribute("factsGrouped", grouped);
+        model.addAttribute("factCategories", FactCategory.values());
+        model.addAttribute("factCategoryLabels", CATEGORY_LABELS);
+        if (!model.containsAttribute("factForm")) {
+            model.addAttribute("factForm", emptyForm());
+        }
+        return FACTS_FRAGMENT;
+    }
+
+    private String renderSection(Long speciesId, Model model) {
+        return populateFactsSection(speciesId,
+                adminSpeciesFactService.getFactsGrouped(speciesId), model);
+    }
+
+    private static SpeciesFactFormDto emptyForm() {
+        return new SpeciesFactFormDto(null, null, null, null, 0);
+    }
+}

--- a/src/main/java/com/plantcare/bot/admin/dto/SpeciesFactFormDto.java
+++ b/src/main/java/com/plantcare/bot/admin/dto/SpeciesFactFormDto.java
@@ -1,0 +1,47 @@
+package com.plantcare.bot.admin.dto;
+
+import com.plantcare.bot.domain.SpeciesFact;
+import com.plantcare.bot.domain.enums.FactCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Форма создания/редактирования энциклопедического факта вида (issue #131).
+ *
+ * <p>DTO — record (требование AC). Конвертация в entity делается в
+ * {@code AdminSpeciesFactService}, обратная для заполнения формы — фабрикой
+ * {@link #from(SpeciesFact)}.
+ */
+public record SpeciesFactFormDto(
+
+        @NotNull(message = "Категория обязательна")
+        FactCategory category,
+
+        @Size(max = 160, message = "Заголовок не должен превышать 160 символов")
+        String title,
+
+        @NotBlank(message = "Текст факта обязателен")
+        String body,
+
+        @Size(max = 300, message = "Источник не должен превышать 300 символов")
+        String source,
+
+        @PositiveOrZero(message = "Порядок отображения не может быть отрицательным")
+        Integer displayOrder
+) {
+
+    /**
+     * Заполняет форму значениями существующего факта (для inline-редактирования).
+     */
+    public static SpeciesFactFormDto from(SpeciesFact fact) {
+        return new SpeciesFactFormDto(
+                fact.getCategory(),
+                fact.getTitle(),
+                fact.getBody(),
+                fact.getSource(),
+                fact.getDisplayOrder()
+        );
+    }
+}

--- a/src/main/java/com/plantcare/bot/admin/dto/SpeciesFormDto.java
+++ b/src/main/java/com/plantcare/bot/admin/dto/SpeciesFormDto.java
@@ -41,4 +41,18 @@ public class SpeciesFormDto {
     @Min(value = 0, message = "Популярность от 0 до 100")
     @Max(value = 100, message = "Популярность от 0 до 100")
     private Integer popularity = 50;
+
+    /**
+     * Токсичность для кошек. Tri-state: {@code true} — токсично,
+     * {@code false} — безопасно, {@code null} — нет данных. Все три состояния
+     * валидны. Пустое значение из {@code <select>} биндится в {@code null}
+     * штатным конвертером Spring (пустая строка → {@code null} для Boolean).
+     */
+    private Boolean toxicToCats;
+
+    /** Токсичность для собак. Tri-state, см. {@link #toxicToCats}. */
+    private Boolean toxicToDogs;
+
+    /** Токсичность для людей/детей. Tri-state, см. {@link #toxicToCats}. */
+    private Boolean toxicToHumans;
 }

--- a/src/main/java/com/plantcare/bot/admin/exception/SpeciesFactNotFoundException.java
+++ b/src/main/java/com/plantcare/bot/admin/exception/SpeciesFactNotFoundException.java
@@ -1,0 +1,20 @@
+package com.plantcare.bot.admin.exception;
+
+import jakarta.persistence.EntityNotFoundException;
+
+/**
+ * Факт не найден или не принадлежит указанному виду (issue #131).
+ *
+ * <p>Используется как защита от подмены {@code factId}: редактировать/удалять
+ * можно только факт, привязанный к виду из URL.
+ *
+ * <p>Наследуется от {@link EntityNotFoundException}, чтобы попасть в общий
+ * 404-хендлер {@code AdminControllerAdvice} (тело = сообщение, статус 404),
+ * консистентно с прочими not-found ошибками админки.
+ */
+public class SpeciesFactNotFoundException extends EntityNotFoundException {
+
+    public SpeciesFactNotFoundException(Long factId, Long speciesId) {
+        super("Факт id=" + factId + " не найден для вида id=" + speciesId);
+    }
+}

--- a/src/main/java/com/plantcare/bot/admin/service/AdminSpeciesFactService.java
+++ b/src/main/java/com/plantcare/bot/admin/service/AdminSpeciesFactService.java
@@ -1,0 +1,128 @@
+package com.plantcare.bot.admin.service;
+
+import com.plantcare.bot.admin.dto.SpeciesFactFormDto;
+import com.plantcare.bot.admin.exception.SpeciesFactNotFoundException;
+import com.plantcare.bot.domain.Species;
+import com.plantcare.bot.domain.SpeciesFact;
+import com.plantcare.bot.domain.enums.FactCategory;
+import com.plantcare.bot.repository.SpeciesFactRepository;
+import com.plantcare.bot.repository.SpeciesRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Админский CRUD энциклопедических фактов вида (issue #131).
+ *
+ * <p>Каждая операция привязана к виду: при update/delete проверяется
+ * принадлежность факта виду из URL ({@link SpeciesFactRepository#findByIdAndSpeciesId}),
+ * чтобы редактор не мог через подмену {@code factId} тронуть чужой факт.
+ *
+ * <p>{@code updated_at} факта обновляется триггером БД, руками не выставляется
+ * (см. {@link SpeciesFact}). Чтение фактов ({@code SpeciesFactService}) не кэшируется,
+ * поэтому {@code @CacheEvict} здесь не нужен.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminSpeciesFactService {
+
+    private final SpeciesFactRepository speciesFactRepository;
+    private final SpeciesRepository speciesRepository;
+
+    /**
+     * Факты вида, сгруппированные по категории в порядке показа
+     * (внутри категории — по {@code displayOrder}). Категории без фактов
+     * в результат не попадают.
+     */
+    @Transactional(readOnly = true)
+    public Map<FactCategory, List<SpeciesFact>> getFactsGrouped(Long speciesId) {
+        List<SpeciesFact> facts =
+                speciesFactRepository.findBySpeciesIdOrderByCategoryAscDisplayOrderAsc(speciesId);
+
+        Map<FactCategory, List<SpeciesFact>> grouped = new LinkedHashMap<>();
+        for (SpeciesFact fact : facts) {
+            grouped.computeIfAbsent(fact.getCategory(), k -> new ArrayList<>()).add(fact);
+        }
+        return grouped;
+    }
+
+    /**
+     * Один факт вида с проверкой принадлежности (для prefill формы редактирования).
+     */
+    @Transactional(readOnly = true)
+    public SpeciesFact getOwnedFact(Long speciesId, Long factId) {
+        return requireOwnedFact(speciesId, factId);
+    }
+
+    /**
+     * Создаёт факт у вида.
+     *
+     * @throws EntityNotFoundException если вид не найден
+     */
+    @Transactional
+    public SpeciesFact createFact(Long speciesId, SpeciesFactFormDto dto, String adminUsername) {
+        Species species = speciesRepository.findById(speciesId)
+                .orElseThrow(() -> new EntityNotFoundException("Вид не найден: " + speciesId));
+
+        SpeciesFact fact = new SpeciesFact();
+        fact.setSpecies(species);
+        applyDto(fact, dto);
+        SpeciesFact saved = speciesFactRepository.save(fact);
+
+        log.info("Admin [{}] created fact id={} for species id={} category={}",
+                adminUsername, saved.getId(), speciesId, saved.getCategory());
+        return saved;
+    }
+
+    /**
+     * Обновляет факт вида с проверкой принадлежности.
+     *
+     * @throws SpeciesFactNotFoundException если факт не найден или принадлежит другому виду
+     */
+    @Transactional
+    public SpeciesFact updateFact(Long speciesId, Long factId, SpeciesFactFormDto dto, String adminUsername) {
+        SpeciesFact fact = requireOwnedFact(speciesId, factId);
+        applyDto(fact, dto);
+        SpeciesFact saved = speciesFactRepository.save(fact);
+
+        log.info("Admin [{}] updated fact id={} for species id={} category={}",
+                adminUsername, factId, speciesId, saved.getCategory());
+        return saved;
+    }
+
+    /**
+     * Удаляет факт вида с проверкой принадлежности.
+     *
+     * @throws SpeciesFactNotFoundException если факт не найден или принадлежит другому виду
+     */
+    @Transactional
+    public void deleteFact(Long speciesId, Long factId, String adminUsername) {
+        SpeciesFact fact = requireOwnedFact(speciesId, factId);
+        speciesFactRepository.delete(fact);
+
+        log.info("Admin [{}] deleted fact id={} for species id={}", adminUsername, factId, speciesId);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private SpeciesFact requireOwnedFact(Long speciesId, Long factId) {
+        return speciesFactRepository.findByIdAndSpeciesId(factId, speciesId)
+                .orElseThrow(() -> new SpeciesFactNotFoundException(factId, speciesId));
+    }
+
+    private void applyDto(SpeciesFact fact, SpeciesFactFormDto dto) {
+        fact.setCategory(dto.category());
+        fact.setTitle(dto.title());
+        fact.setBody(dto.body());
+        fact.setSource(dto.source());
+        fact.setDisplayOrder(dto.displayOrder() == null ? 0 : dto.displayOrder());
+    }
+}

--- a/src/main/java/com/plantcare/bot/admin/service/AdminSpeciesService.java
+++ b/src/main/java/com/plantcare/bot/admin/service/AdminSpeciesService.java
@@ -184,6 +184,10 @@ public class AdminSpeciesService {
         s.setDescription(dto.getDescription());
         s.setSearchTags(dto.getSearchTags());
         s.setPopularity(dto.getPopularity() == null ? 50 : dto.getPopularity());
+        // Tri-state токсичность: null допустим (нет данных), в т.ч. сброс true→null.
+        s.setToxicToCats(dto.getToxicToCats());
+        s.setToxicToDogs(dto.getToxicToDogs());
+        s.setToxicToHumans(dto.getToxicToHumans());
     }
 
     private void validateUniqueName(Long currentId, String name) {

--- a/src/main/java/com/plantcare/bot/repository/SpeciesFactRepository.java
+++ b/src/main/java/com/plantcare/bot/repository/SpeciesFactRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Доступ к энциклопедическим фактам видов (ADR-011, issue #129).
@@ -31,4 +32,16 @@ public interface SpeciesFactRepository extends JpaRepository<SpeciesFact, Long> 
      * @return {@code true}, если у вида есть хотя бы один факт
      */
     boolean existsBySpeciesId(Long speciesId);
+
+    /**
+     * Факт по идентификатору с проверкой принадлежности виду.
+     *
+     * <p>Защита от подмены {@code factId} в админке: редактировать и удалять
+     * можно только факт, привязанный к виду из URL ({@code /admin/species/{speciesId}/facts/{factId}}).
+     *
+     * @param id        идентификатор факта
+     * @param speciesId идентификатор вида-владельца
+     * @return факт, если он принадлежит виду; иначе пусто
+     */
+    Optional<SpeciesFact> findByIdAndSpeciesId(Long id, Long speciesId);
 }

--- a/src/main/resources/templates/admin/species/facts/section.html
+++ b/src/main/resources/templates/admin/species/facts/section.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ru">
+<body>
+
+<!--
+  Секция управления фактами вида (issue #131).
+
+  Один фрагмент factsSection — список фактов с группировкой по категории
+  + форма создания/редактирования. HTMX-эндпоинты под /admin/species/{id}/facts
+  возвращают этот же фрагмент, swap по outerHTML #facts-section.
+
+  Модель:
+    speciesId           — id вида (владелец)
+    factsGrouped        — Map<FactCategory, List<SpeciesFact>> в порядке показа
+    factCategories      — FactCategory[] (для select)
+    factCategoryLabels  — Map<FactCategory,String> русские подписи
+    factForm            — SpeciesFactFormDto (форма создания/правки)
+    editingFactId       — id факта в режиме правки (null = создание)
+-->
+
+<div id="facts-section" th:fragment="factsSection" class="card bg-base-100 shadow max-w-3xl mt-6">
+    <div class="card-body">
+        <h2 class="card-title text-xl">Факты о виде</h2>
+
+        <!-- Список фактов по категориям -->
+        <div th:if="${factsGrouped.isEmpty()}" class="text-base-content/60 py-2">
+            Фактов пока нет.
+        </div>
+
+        <div th:each="entry : ${factsGrouped}" class="mb-4">
+            <h3 class="font-semibold text-base-content/80 mb-2"
+                th:text="${factCategoryLabels.get(entry.key)}">Категория</h3>
+
+            <ul class="space-y-2">
+                <li th:each="fact : ${entry.value}"
+                    th:id="'fact-' + ${fact.id}"
+                    class="flex items-start justify-between gap-3 border border-base-300 rounded-lg p-3">
+                    <div class="min-w-0">
+                        <div class="badge badge-ghost badge-sm mb-1"
+                             th:text="'#' + ${fact.displayOrder}">#0</div>
+                        <div th:if="${fact.title}" class="font-medium" th:text="${fact.title}">Заголовок</div>
+                        <div class="text-sm whitespace-pre-line" th:text="${fact.body}">Текст факта</div>
+                        <div th:if="${fact.source}" class="text-xs text-base-content/60 mt-1"
+                             th:text="'Источник: ' + ${fact.source}">Источник</div>
+                    </div>
+                    <div class="flex gap-1 shrink-0">
+                        <button type="button" class="btn btn-ghost btn-xs"
+                                th:attr="hx-get='/admin/species/' + ${speciesId} + '/facts/' + ${fact.id} + '/edit',
+                                         hx-target='#facts-section',
+                                         hx-swap='outerHTML'">Edit</button>
+                        <button type="button" class="btn btn-error btn-xs"
+                                th:attr="hx-delete='/admin/species/' + ${speciesId} + '/facts/' + ${fact.id},
+                                         hx-target='#facts-section',
+                                         hx-swap='outerHTML',
+                                         hx-confirm='Удалить факт?'">Delete</button>
+                    </div>
+                </li>
+            </ul>
+        </div>
+
+        <div class="divider"></div>
+
+        <!-- Форма создания / редактирования факта -->
+        <h3 class="font-semibold mb-2"
+            th:text="${editingFactId != null} ? 'Редактирование факта' : 'Новый факт'">Новый факт</h3>
+
+        <form th:object="${factForm}"
+              th:attr="hx-post=${editingFactId != null}
+                         ? '/admin/species/' + ${speciesId} + '/facts/' + ${editingFactId}
+                         : '/admin/species/' + ${speciesId} + '/facts'"
+              hx-target="#facts-section" hx-swap="outerHTML"
+              class="space-y-3">
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                <div class="form-control">
+                    <label class="label"><span class="label-text">Категория <span class="text-error">*</span></span></label>
+                    <select th:field="*{category}" class="select select-bordered w-full"
+                            th:classappend="${#fields.hasErrors('category')} ? 'select-error'">
+                        <option value="">— выберите —</option>
+                        <option th:each="c : ${factCategories}"
+                                th:value="${c.name()}"
+                                th:text="${factCategoryLabels.get(c)}"></option>
+                    </select>
+                    <label class="label" th:if="${#fields.hasErrors('category')}">
+                        <span class="label-text-alt text-error" th:errors="*{category}"></span>
+                    </label>
+                </div>
+                <div class="form-control">
+                    <label class="label"><span class="label-text">Порядок отображения</span></label>
+                    <input type="number" th:field="*{displayOrder}" min="0"
+                           class="input input-bordered w-full"
+                           th:classappend="${#fields.hasErrors('displayOrder')} ? 'input-error'"/>
+                    <label class="label" th:if="${#fields.hasErrors('displayOrder')}">
+                        <span class="label-text-alt text-error" th:errors="*{displayOrder}"></span>
+                    </label>
+                </div>
+            </div>
+
+            <div class="form-control">
+                <label class="label"><span class="label-text">Заголовок</span></label>
+                <input type="text" th:field="*{title}" maxlength="160"
+                       class="input input-bordered w-full"
+                       th:classappend="${#fields.hasErrors('title')} ? 'input-error'"
+                       placeholder="Необязательно"/>
+                <label class="label" th:if="${#fields.hasErrors('title')}">
+                    <span class="label-text-alt text-error" th:errors="*{title}"></span>
+                </label>
+            </div>
+
+            <div class="form-control">
+                <label class="label"><span class="label-text">Текст факта <span class="text-error">*</span></span></label>
+                <textarea th:field="*{body}" rows="3"
+                          class="textarea textarea-bordered w-full"
+                          th:classappend="${#fields.hasErrors('body')} ? 'textarea-error'"
+                          placeholder="Обязательно"></textarea>
+                <label class="label" th:if="${#fields.hasErrors('body')}">
+                    <span class="label-text-alt text-error" th:errors="*{body}"></span>
+                </label>
+            </div>
+
+            <div class="form-control">
+                <label class="label"><span class="label-text">Источник</span></label>
+                <input type="text" th:field="*{source}" maxlength="300"
+                       class="input input-bordered w-full"
+                       th:classappend="${#fields.hasErrors('source')} ? 'input-error'"
+                       placeholder="Необязательно"/>
+                <label class="label" th:if="${#fields.hasErrors('source')}">
+                    <span class="label-text-alt text-error" th:errors="*{source}"></span>
+                </label>
+            </div>
+
+            <div class="flex gap-2">
+                <button type="submit" class="btn btn-primary btn-sm"
+                        th:text="${editingFactId != null} ? 'Сохранить факт' : 'Добавить факт'">Добавить факт</button>
+                <button th:if="${editingFactId != null}" type="button" class="btn btn-ghost btn-sm"
+                        th:attr="hx-get='/admin/species/' + ${speciesId} + '/facts',
+                                 hx-target='#facts-section',
+                                 hx-swap='outerHTML'">Отмена</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/species/form.html
+++ b/src/main/resources/templates/admin/species/form.html
@@ -152,6 +152,43 @@
                     </label>
                 </div>
 
+                <!-- Токсичность (tri-state: токсично / не токсично / нет данных) — issue #131 -->
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div class="form-control">
+                        <label class="label" for="toxicToCats">
+                            <span class="label-text">Токсично для кошек</span>
+                        </label>
+                        <select id="toxicToCats" th:field="*{toxicToCats}"
+                                class="select select-bordered w-full">
+                            <option value="">— нет данных —</option>
+                            <option value="true">Токсично</option>
+                            <option value="false">Не токсично</option>
+                        </select>
+                    </div>
+                    <div class="form-control">
+                        <label class="label" for="toxicToDogs">
+                            <span class="label-text">Токсично для собак</span>
+                        </label>
+                        <select id="toxicToDogs" th:field="*{toxicToDogs}"
+                                class="select select-bordered w-full">
+                            <option value="">— нет данных —</option>
+                            <option value="true">Токсично</option>
+                            <option value="false">Не токсично</option>
+                        </select>
+                    </div>
+                    <div class="form-control">
+                        <label class="label" for="toxicToHumans">
+                            <span class="label-text">Токсично для людей</span>
+                        </label>
+                        <select id="toxicToHumans" th:field="*{toxicToHumans}"
+                                class="select select-bordered w-full">
+                            <option value="">— нет данных —</option>
+                            <option value="true">Токсично</option>
+                            <option value="false">Не токсично</option>
+                        </select>
+                    </div>
+                </div>
+
                 <div class="flex gap-2 pt-2">
                     <button type="submit" class="btn btn-primary">Сохранить</button>
                     <a href="/admin/species" class="btn btn-ghost">Отмена</a>
@@ -159,6 +196,10 @@
             </form>
         </div>
     </div>
+
+    <!-- Факты вида (issue #131) — только при редактировании существующего вида -->
+    <div th:if="${speciesId != null}"
+         th:insert="~{admin/species/facts/section :: factsSection}"></div>
 
 </section>
 </body>

--- a/src/test/java/com/plantcare/bot/admin/controller/AdminSpeciesFactControllerTest.java
+++ b/src/test/java/com/plantcare/bot/admin/controller/AdminSpeciesFactControllerTest.java
@@ -1,0 +1,289 @@
+package com.plantcare.bot.admin.controller;
+
+import com.plantcare.bot.admin.exception.SpeciesFactNotFoundException;
+import com.plantcare.bot.admin.ratelimit.LoginRateLimiter;
+import com.plantcare.bot.admin.service.AdminSpeciesFactService;
+import com.plantcare.bot.domain.Species;
+import com.plantcare.bot.domain.SpeciesFact;
+import com.plantcare.bot.domain.enums.FactCategory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/**
+ * Web-слайс тесты CRUD фактов вида в админке (issue #131).
+ *
+ * <p>Мокается только сервис ({@link AdminSpeciesFactService}) и {@link LoginRateLimiter}
+ * (требуется конфигом безопасности). Контроллер всегда возвращает один HTMX-фрагмент
+ * {@code admin/species/facts/section :: factsSection}; разница между успехом и ошибкой
+ * валидации — в том, дёрнут ли сервис и есть ли field-errors в модели.
+ */
+@WebMvcTest(AdminSpeciesFactController.class)
+@Import(AdminControllerAdvice.class)
+@WithMockUser(roles = "ADMIN")
+class AdminSpeciesFactControllerTest {
+
+    private static final String FACTS_FRAGMENT = "admin/species/facts/section :: factsSection";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LoginRateLimiter loginRateLimiter;
+
+    @MockitoBean
+    private AdminSpeciesFactService adminSpeciesFactService;
+
+    // ============================================================ create
+
+    @Test
+    void should_call_service_and_render_section_when_create_with_valid_body() throws Exception {
+        // arrange
+        when(adminSpeciesFactService.getFactsGrouped(7L)).thenReturn(Map.of());
+
+        // act
+        mockMvc.perform(post("/admin/species/7/facts").with(csrf())
+                        .param("category", "CARE")
+                        .param("title", "Полив")
+                        .param("body", "Поливать раз в неделю")
+                        .param("source", "Книга про растения")
+                        .param("displayOrder", "0"))
+                .andExpect(status().isOk())
+                .andExpect(view().name(FACTS_FRAGMENT))
+                .andExpect(model().hasNoErrors());
+
+        // assert — сервис получил именно те значения, что пришли в форме
+        verify(adminSpeciesFactService).createFact(
+                eq(7L),
+                argThat(dto ->
+                        dto.category() == FactCategory.CARE
+                                && "Полив".equals(dto.title())
+                                && "Поливать раз в неделю".equals(dto.body())
+                                && "Книга про растения".equals(dto.source())
+                                && dto.displayOrder() == 0),
+                eq("user"));
+    }
+
+    @Test
+    void should_not_call_service_when_create_with_blank_body() throws Exception {
+        // act
+        mockMvc.perform(post("/admin/species/7/facts").with(csrf())
+                        .param("category", "CARE")
+                        .param("body", "")
+                        .param("displayOrder", "0"))
+                .andExpect(status().isOk())
+                .andExpect(view().name(FACTS_FRAGMENT))
+                .andExpect(model().attributeHasFieldErrors("factForm", "body"));
+
+        // assert — валидация отсекла запрос, факт не создан
+        verify(adminSpeciesFactService, never()).createFact(any(), any(), any());
+    }
+
+    @Test
+    void should_not_call_service_when_create_without_category() throws Exception {
+        // act — @NotNull category: пустое значение enum не биндится
+        mockMvc.perform(post("/admin/species/7/facts").with(csrf())
+                        .param("category", "")
+                        .param("body", "Текст есть, категории нет")
+                        .param("displayOrder", "0"))
+                .andExpect(status().isOk())
+                .andExpect(model().attributeHasFieldErrors("factForm", "category"));
+
+        // assert
+        verify(adminSpeciesFactService, never()).createFact(any(), any(), any());
+    }
+
+    @Test
+    void should_not_call_service_when_create_with_too_long_title() throws Exception {
+        // arrange — title длиной 161 при @Size(max = 160)
+        String tooLong = "т".repeat(161);
+
+        // act
+        mockMvc.perform(post("/admin/species/7/facts").with(csrf())
+                        .param("category", "CARE")
+                        .param("title", tooLong)
+                        .param("body", "Валидное тело факта")
+                        .param("displayOrder", "0"))
+                .andExpect(status().isOk())
+                .andExpect(model().attributeHasFieldErrors("factForm", "title"));
+
+        // assert
+        verify(adminSpeciesFactService, never()).createFact(any(), any(), any());
+    }
+
+    @Test
+    void should_not_call_service_when_create_with_negative_display_order() throws Exception {
+        // act — @PositiveOrZero displayOrder
+        mockMvc.perform(post("/admin/species/7/facts").with(csrf())
+                        .param("category", "CARE")
+                        .param("body", "Валидное тело факта")
+                        .param("displayOrder", "-1"))
+                .andExpect(status().isOk())
+                .andExpect(model().attributeHasFieldErrors("factForm", "displayOrder"));
+
+        // assert
+        verify(adminSpeciesFactService, never()).createFact(any(), any(), any());
+    }
+
+    // ============================================================ update
+
+    @Test
+    void should_call_update_when_update_with_valid_body() throws Exception {
+        // arrange
+        when(adminSpeciesFactService.getFactsGrouped(7L)).thenReturn(Map.of());
+
+        // act
+        mockMvc.perform(post("/admin/species/7/facts/42").with(csrf())
+                        .param("category", "TOXICITY")
+                        .param("body", "Токсичен для кошек")
+                        .param("displayOrder", "1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name(FACTS_FRAGMENT))
+                .andExpect(model().hasNoErrors());
+
+        // assert
+        verify(adminSpeciesFactService).updateFact(
+                eq(7L),
+                eq(42L),
+                argThat(dto ->
+                        dto.category() == FactCategory.TOXICITY
+                                && "Токсичен для кошек".equals(dto.body())
+                                && dto.displayOrder() == 1),
+                eq("user"));
+    }
+
+    @Test
+    void should_not_call_update_when_update_with_blank_body() throws Exception {
+        // arrange
+        when(adminSpeciesFactService.getFactsGrouped(7L)).thenReturn(Map.of());
+
+        // act
+        mockMvc.perform(post("/admin/species/7/facts/42").with(csrf())
+                        .param("category", "TOXICITY")
+                        .param("body", "")
+                        .param("displayOrder", "1"))
+                .andExpect(status().isOk())
+                .andExpect(model().attributeHasFieldErrors("factForm", "body"))
+                // при ошибке форма остаётся в режиме правки выбранного факта
+                .andExpect(model().attribute("editingFactId", 42L));
+
+        // assert
+        verify(adminSpeciesFactService, never()).updateFact(any(), any(), any(), any());
+    }
+
+    // ============================================================ delete
+
+    @Test
+    void should_call_delete_and_render_section_when_delete_fact() throws Exception {
+        // arrange
+        when(adminSpeciesFactService.getFactsGrouped(7L)).thenReturn(Map.of());
+
+        // act
+        mockMvc.perform(delete("/admin/species/7/facts/42").with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(view().name(FACTS_FRAGMENT));
+
+        // assert
+        verify(adminSpeciesFactService).deleteFact(eq(7L), eq(42L), eq("user"));
+    }
+
+    // ============================================================ edit prefill
+
+    @Test
+    void should_prefill_form_when_edit_form_requested() throws Exception {
+        // arrange
+        Species species = new Species();
+        species.setName("Монстера");
+        SpeciesFact fact = new SpeciesFact();
+        fact.setSpecies(species);
+        fact.setCategory(FactCategory.ORIGIN);
+        fact.setBody("Родом из Центральной Америки");
+        fact.setDisplayOrder(0);
+        when(adminSpeciesFactService.getOwnedFact(7L, 42L)).thenReturn(fact);
+        when(adminSpeciesFactService.getFactsGrouped(7L))
+                .thenReturn(Map.of(FactCategory.ORIGIN, List.of(fact)));
+
+        // act
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .get("/admin/species/7/facts/42/edit"))
+                .andExpect(status().isOk())
+                .andExpect(view().name(FACTS_FRAGMENT))
+                .andExpect(model().attribute("editingFactId", 42L))
+                .andExpect(model().attributeExists("factForm"));
+
+        // assert
+        verify(adminSpeciesFactService).getOwnedFact(7L, 42L);
+    }
+
+    // ============================================================ not-found → 404
+
+    @Test
+    void should_return_404_when_update_targets_fact_not_owned_by_species() throws Exception {
+        // arrange — сервис не нашёл факт у этого вида (защита от подмены factId)
+        doThrow(new SpeciesFactNotFoundException(42L, 7L))
+                .when(adminSpeciesFactService).updateFact(eq(7L), eq(42L), any(), eq("user"));
+
+        // act
+        mockMvc.perform(post("/admin/species/7/facts/42").with(csrf())
+                        .param("category", "TOXICITY")
+                        .param("body", "Токсичен для кошек")
+                        .param("displayOrder", "1"))
+                .andExpect(status().isNotFound());
+
+        // assert — пробросилось в сервис, секция не перерисовывалась
+        verify(adminSpeciesFactService).updateFact(eq(7L), eq(42L), any(), eq("user"));
+        verify(adminSpeciesFactService, never()).getFactsGrouped(any());
+    }
+
+    @Test
+    void should_return_404_when_delete_targets_fact_not_owned_by_species() throws Exception {
+        // arrange
+        doThrow(new SpeciesFactNotFoundException(42L, 7L))
+                .when(adminSpeciesFactService).deleteFact(7L, 42L, "user");
+
+        // act
+        mockMvc.perform(delete("/admin/species/7/facts/42").with(csrf()))
+                .andExpect(status().isNotFound());
+
+        // assert
+        verify(adminSpeciesFactService).deleteFact(7L, 42L, "user");
+        verify(adminSpeciesFactService, never()).getFactsGrouped(any());
+    }
+
+    @Test
+    void should_return_404_when_edit_form_targets_fact_not_owned_by_species() throws Exception {
+        // arrange
+        when(adminSpeciesFactService.getOwnedFact(7L, 42L))
+                .thenThrow(new SpeciesFactNotFoundException(42L, 7L));
+
+        // act
+        mockMvc.perform(get("/admin/species/7/facts/42/edit"))
+                .andExpect(status().isNotFound());
+
+        // assert
+        verify(adminSpeciesFactService).getOwnedFact(7L, 42L);
+        verify(adminSpeciesFactService, never()).getFactsGrouped(any());
+    }
+}

--- a/src/test/java/com/plantcare/bot/admin/service/AdminSpeciesFactServiceTest.java
+++ b/src/test/java/com/plantcare/bot/admin/service/AdminSpeciesFactServiceTest.java
@@ -1,0 +1,289 @@
+package com.plantcare.bot.admin.service;
+
+import com.plantcare.bot.admin.dto.SpeciesFactFormDto;
+import com.plantcare.bot.admin.exception.SpeciesFactNotFoundException;
+import com.plantcare.bot.domain.Species;
+import com.plantcare.bot.domain.SpeciesFact;
+import com.plantcare.bot.domain.enums.FactCategory;
+import com.plantcare.bot.repository.SpeciesFactRepository;
+import com.plantcare.bot.repository.SpeciesRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Интеграционные тесты сервиса CRUD фактов вида (issue #131).
+ *
+ * <p>Только Postgres (Testcontainers): таблица species_facts опирается на CHECK
+ * по категории, ON DELETE CASCADE и триггер {@code trg_species_facts_updated_at}
+ * из V22 — на H2 это бы не воспроизвелось. Каждый тест создаёт собственные виды
+ * с уникальными именами, чтобы быть изолированным при reuse-контейнере.
+ *
+ * <p>Сервис ({@link AdminSpeciesFactService}) поднимается через {@link Import} —
+ * {@code @DataJpaTest} сам по себе сервисный слой не сканирует.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({AdminSpeciesFactService.class})
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=true",
+        "spring.flyway.locations=classpath:db/migration"
+})
+@Testcontainers
+class AdminSpeciesFactServiceTest {
+
+    private static final String ADMIN = "editor";
+
+    @Container
+    static PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withReuse(true);
+
+    @DynamicPropertySource
+    static void configureDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private AdminSpeciesFactService service;
+
+    @Autowired
+    private SpeciesFactRepository speciesFactRepository;
+
+    @Autowired
+    private SpeciesRepository speciesRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    // ============================================================ create
+
+    @Test
+    void should_persist_fact_bound_to_species_when_create_with_valid_dto() {
+        // arrange
+        Species species = givenSpecies("Фикус для создания факта");
+        var dto = new SpeciesFactFormDto(FactCategory.CARE, "Полив", "Раз в неделю", "Книга", 2);
+
+        // act
+        SpeciesFact created = service.createFact(species.getId(), dto, ADMIN);
+        flushAndClear();
+
+        // assert
+        SpeciesFact reloaded = speciesFactRepository.findById(created.getId()).orElseThrow();
+        assertThat(reloaded.getSpecies().getId()).isEqualTo(species.getId());
+        assertThat(reloaded.getCategory()).isEqualTo(FactCategory.CARE);
+        assertThat(reloaded.getTitle()).isEqualTo("Полив");
+        assertThat(reloaded.getBody()).isEqualTo("Раз в неделю");
+        assertThat(reloaded.getSource()).isEqualTo("Книга");
+        assertThat(reloaded.getDisplayOrder()).isEqualTo(2);
+    }
+
+    @Test
+    void should_default_display_order_to_zero_when_dto_display_order_is_null() {
+        // arrange
+        Species species = givenSpecies("Вид с null порядком");
+        var dto = new SpeciesFactFormDto(FactCategory.ORIGIN, null, "Родом из тропиков", null, null);
+
+        // act
+        SpeciesFact created = service.createFact(species.getId(), dto, ADMIN);
+        flushAndClear();
+
+        // assert
+        assertThat(speciesFactRepository.findById(created.getId()).orElseThrow().getDisplayOrder())
+                .isZero();
+    }
+
+    @Test
+    void should_throw_when_create_fact_for_missing_species() {
+        // arrange
+        var dto = new SpeciesFactFormDto(FactCategory.CARE, null, "Тело", null, 0);
+
+        // act + assert
+        assertThatThrownBy(() -> service.createFact(999_999L, dto, ADMIN))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("Вид не найден");
+    }
+
+    // ============================================================ getFactsGrouped
+
+    @Test
+    void should_group_facts_by_category_in_display_order_when_facts_exist() {
+        // arrange
+        Species species = givenSpecies("Вид с группировкой");
+        service.createFact(species.getId(),
+                new SpeciesFactFormDto(FactCategory.CARE, null, "уход-1", null, 1), ADMIN);
+        service.createFact(species.getId(),
+                new SpeciesFactFormDto(FactCategory.CARE, null, "уход-0", null, 0), ADMIN);
+        service.createFact(species.getId(),
+                new SpeciesFactFormDto(FactCategory.ORIGIN, null, "родина", null, 0), ADMIN);
+        flushAndClear();
+
+        // act
+        Map<FactCategory, List<SpeciesFact>> grouped = service.getFactsGrouped(species.getId());
+
+        // assert — две категории, внутри CARE сортировка по display_order
+        assertThat(grouped).containsOnlyKeys(FactCategory.CARE, FactCategory.ORIGIN);
+        assertThat(grouped.get(FactCategory.CARE))
+                .extracting(SpeciesFact::getBody)
+                .containsExactly("уход-0", "уход-1");
+        assertThat(grouped.get(FactCategory.ORIGIN))
+                .extracting(SpeciesFact::getBody)
+                .containsExactly("родина");
+    }
+
+    @Test
+    void should_return_empty_map_when_species_has_no_facts() {
+        // arrange
+        Species species = givenSpecies("Вид без фактов вообще");
+
+        // act
+        Map<FactCategory, List<SpeciesFact>> grouped = service.getFactsGrouped(species.getId());
+
+        // assert
+        assertThat(grouped).isEmpty();
+    }
+
+    // ============================================================ update
+
+    @Test
+    void should_update_owned_fact_fields_when_update_valid() {
+        // arrange
+        Species species = givenSpecies("Вид для обновления");
+        SpeciesFact fact = service.createFact(species.getId(),
+                new SpeciesFactFormDto(FactCategory.CARE, "старый", "старое тело", null, 0), ADMIN);
+        flushAndClear();
+
+        // act
+        service.updateFact(species.getId(), fact.getId(),
+                new SpeciesFactFormDto(FactCategory.TOXICITY, "новый", "новое тело", "источник", 5), ADMIN);
+        flushAndClear();
+
+        // assert
+        SpeciesFact reloaded = speciesFactRepository.findById(fact.getId()).orElseThrow();
+        assertThat(reloaded.getCategory()).isEqualTo(FactCategory.TOXICITY);
+        assertThat(reloaded.getTitle()).isEqualTo("новый");
+        assertThat(reloaded.getBody()).isEqualTo("новое тело");
+        assertThat(reloaded.getSource()).isEqualTo("источник");
+        assertThat(reloaded.getDisplayOrder()).isEqualTo(5);
+    }
+
+    // ============================================================ ownership / security
+
+    @Test
+    void should_throw_when_update_fact_belonging_to_another_species() {
+        // arrange — факт принадлежит виду A, пытаемся обновить «от имени» вида B
+        Species owner = givenSpecies("Вид-владелец факта");
+        Species attacker = givenSpecies("Чужой вид");
+        SpeciesFact fact = service.createFact(owner.getId(),
+                new SpeciesFactFormDto(FactCategory.CARE, null, "приватный факт", null, 0), ADMIN);
+        flushAndClear();
+
+        var dto = new SpeciesFactFormDto(FactCategory.CARE, null, "взлом", null, 0);
+
+        // act + assert — подмена speciesId не должна дать тронуть чужой факт
+        assertThatThrownBy(() -> service.updateFact(attacker.getId(), fact.getId(), dto, ADMIN))
+                .isInstanceOf(SpeciesFactNotFoundException.class);
+
+        // и факт остался нетронутым
+        flushAndClear();
+        assertThat(speciesFactRepository.findById(fact.getId()).orElseThrow().getBody())
+                .isEqualTo("приватный факт");
+    }
+
+    @Test
+    void should_throw_when_delete_fact_belonging_to_another_species() {
+        // arrange
+        Species owner = givenSpecies("Владелец под удаление");
+        Species attacker = givenSpecies("Чужак под удаление");
+        SpeciesFact fact = service.createFact(owner.getId(),
+                new SpeciesFactFormDto(FactCategory.CARE, null, "нельзя удалить", null, 0), ADMIN);
+        flushAndClear();
+
+        // act + assert
+        assertThatThrownBy(() -> service.deleteFact(attacker.getId(), fact.getId(), ADMIN))
+                .isInstanceOf(SpeciesFactNotFoundException.class);
+
+        // факт всё ещё на месте
+        flushAndClear();
+        assertThat(speciesFactRepository.findById(fact.getId())).isPresent();
+    }
+
+    @Test
+    void should_delete_fact_when_owned_by_species() {
+        // arrange
+        Species species = givenSpecies("Вид с удаляемым фактом");
+        SpeciesFact fact = service.createFact(species.getId(),
+                new SpeciesFactFormDto(FactCategory.CARE, null, "удалить меня", null, 0), ADMIN);
+        flushAndClear();
+
+        // act
+        service.deleteFact(species.getId(), fact.getId(), ADMIN);
+        flushAndClear();
+
+        // assert
+        assertThat(speciesFactRepository.findById(fact.getId())).isEmpty();
+    }
+
+    @Test
+    void should_throw_when_get_owned_fact_for_wrong_species() {
+        // arrange
+        Species owner = givenSpecies("Владелец для prefill");
+        Species other = givenSpecies("Другой для prefill");
+        SpeciesFact fact = service.createFact(owner.getId(),
+                new SpeciesFactFormDto(FactCategory.CARE, null, "тело", null, 0), ADMIN);
+        flushAndClear();
+
+        // act + assert
+        assertThatThrownBy(() -> service.getOwnedFact(other.getId(), fact.getId()))
+                .isInstanceOf(SpeciesFactNotFoundException.class);
+    }
+
+    @Test
+    void should_have_updated_at_set_by_db_after_create() {
+        // arrange — поле updated_at помечено insertable=false/updatable=false:
+        // значение ставит БД (DEFAULT now()), не код
+        Species species = givenSpecies("Вид для проверки маппинга updated_at");
+        SpeciesFact created = service.createFact(species.getId(),
+                new SpeciesFactFormDto(FactCategory.CARE, null, "тело", null, 0), ADMIN);
+        flushAndClear();
+
+        // act
+        SpeciesFact reloaded = speciesFactRepository.findById(created.getId()).orElseThrow();
+
+        // assert — БД проставила updated_at даже без участия кода
+        assertThat(reloaded.getUpdatedAt()).isNotNull();
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private Species givenSpecies(String name) {
+        var s = new Species();
+        s.setName(name);
+        s.setWateringDays(7);
+        s.setPopularity(0);
+        return speciesRepository.save(s);
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+}

--- a/src/test/java/com/plantcare/bot/admin/service/AdminSpeciesFactUpdatedAtTest.java
+++ b/src/test/java/com/plantcare/bot/admin/service/AdminSpeciesFactUpdatedAtTest.java
@@ -1,0 +1,145 @@
+package com.plantcare.bot.admin.service;
+
+import com.plantcare.bot.admin.dto.SpeciesFactFormDto;
+import com.plantcare.bot.domain.Species;
+import com.plantcare.bot.domain.enums.FactCategory;
+import com.plantcare.bot.repository.SpeciesFactRepository;
+import com.plantcare.bot.repository.SpeciesRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Проверка обновления {@code updated_at} факта триггером БД (issue #131, AC «updated_at обновляется при изменении»).
+ *
+ * <p>{@code updated_at} ставит триггер {@code trg_species_facts_updated_at} (V22),
+ * значение — {@code CURRENT_TIMESTAMP}, то есть время ТРАНЗАКЦИИ. Чтобы увидеть сдвиг
+ * времени, insert и update обязаны быть в РАЗНЫХ транзакциях, иначе они получат
+ * идентичный таймстемп. Поэтому класс работает без оборачивающей rollback-транзакции
+ * {@code @DataJpaTest} ({@link Transactional} с {@link Propagation#NOT_SUPPORTED}):
+ * каждый вызов {@code @Transactional}-метода сервиса коммитится отдельно. Созданные
+ * строки чистим в {@link AfterEach}.
+ *
+ * <p>Только Postgres (Testcontainers): на H2 триггера нет.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({AdminSpeciesFactService.class})
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=true",
+        "spring.flyway.locations=classpath:db/migration"
+})
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Rollback(false)
+@Testcontainers
+class AdminSpeciesFactUpdatedAtTest {
+
+    private static final String ADMIN = "editor";
+
+    @Container
+    static PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withReuse(true);
+
+    @DynamicPropertySource
+    static void configureDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private AdminSpeciesFactService service;
+
+    @Autowired
+    private SpeciesFactRepository speciesFactRepository;
+
+    @Autowired
+    private SpeciesRepository speciesRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private Long createdSpeciesId;
+
+    @AfterEach
+    void cleanup() {
+        // Без оборачивающей транзакции данные реально коммитятся — чистим за собой,
+        // чтобы не контаминировать reuse-контейнер.
+        if (createdSpeciesId != null) {
+            speciesRepository.deleteById(createdSpeciesId);
+        }
+    }
+
+    @Test
+    void should_advance_updated_at_when_fact_updated_in_separate_transaction() {
+        // arrange — создаём факт (commit 1) и читаем исходный updated_at прямо из БД
+        Long speciesId = givenCommittedSpecies("Вид для updated_at");
+        Long factId = service.createFact(speciesId,
+                new SpeciesFactFormDto(FactCategory.CARE, null, "исходное тело", null, 0), ADMIN).getId();
+
+        Instant before = readUpdatedAt(factId);
+        assertThat(before).isNotNull();
+
+        // act — обновляем факт (commit 2 → новый CURRENT_TIMESTAMP)
+        service.updateFact(speciesId, factId,
+                new SpeciesFactFormDto(FactCategory.CARE, null, "изменённое тело", null, 0), ADMIN);
+
+        // assert — триггер сдвинул updated_at строго вперёд
+        Instant after = readUpdatedAt(factId);
+        assertThat(after)
+                .isNotNull()
+                .isAfter(before);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private Long givenCommittedSpecies(String name) {
+        var s = new Species();
+        s.setName(name);
+        s.setWateringDays(7);
+        s.setPopularity(0);
+        Long id = speciesRepository.save(s).getId();
+        this.createdSpeciesId = id;
+        return id;
+    }
+
+    /**
+     * Читает updated_at нативно из БД как {@link Instant} (колонка TIMESTAMPTZ),
+     * видим реальное значение, проставленное триггером, без влияния persistence-контекста.
+     */
+    private Instant readUpdatedAt(Long factId) {
+        Object value = entityManager.createNativeQuery(
+                        "SELECT updated_at FROM species_facts WHERE id = :id")
+                .setParameter("id", factId)
+                .getSingleResult();
+        return switch (value) {
+            case Instant instant -> instant;
+            case Timestamp ts -> ts.toInstant();
+            case OffsetDateTime odt -> odt.toInstant();
+            case java.time.LocalDateTime ldt -> ldt.toInstant(ZoneOffset.UTC);
+            default -> throw new IllegalStateException(
+                    "Неожиданный тип updated_at: " + value.getClass());
+        };
+    }
+}

--- a/src/test/java/com/plantcare/bot/admin/service/AdminSpeciesToxicityTest.java
+++ b/src/test/java/com/plantcare/bot/admin/service/AdminSpeciesToxicityTest.java
@@ -1,0 +1,155 @@
+package com.plantcare.bot.admin.service;
+
+import com.plantcare.bot.admin.dto.SpeciesFormDto;
+import com.plantcare.bot.domain.Species;
+import com.plantcare.bot.repository.SpeciesRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tri-state флаги токсичности вида через {@link AdminSpeciesService} (issue #131, #130).
+ *
+ * <p>Три состояния: {@code true} (токсично) / {@code false} (безопасно) /
+ * {@code null} (нет данных). Ключевой кейс AC — сброс {@code true → null}: вид был
+ * помечен токсичным, редактор выбрал «нет данных», колонка обязана занулиться.
+ *
+ * <p>Сохранение идёт реальным {@code applyDto} сервиса и реальной колонкой Postgres
+ * (V26), а не в обход entity. {@code @CacheEvict} на методах сервиса в слайс-тесте
+ * без CacheManager — no-op, на проверяемое поведение не влияет.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({AdminSpeciesService.class})
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=true",
+        "spring.flyway.locations=classpath:db/migration"
+})
+@Testcontainers
+class AdminSpeciesToxicityTest {
+
+    private static final String ADMIN = "editor";
+
+    @Container
+    static PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withReuse(true);
+
+    @DynamicPropertySource
+    static void configureDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private AdminSpeciesService service;
+
+    @Autowired
+    private SpeciesRepository speciesRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void should_persist_all_three_toxicity_states_when_created() {
+        // arrange — кошки токсично, собаки безопасно, люди — нет данных
+        SpeciesFormDto dto = baseDto("Вид с тремя состояниями");
+        dto.setToxicToCats(true);
+        dto.setToxicToDogs(false);
+        dto.setToxicToHumans(null);
+
+        // act
+        Species created = service.create(dto, ADMIN);
+        flushAndClear();
+
+        // assert
+        Species reloaded = speciesRepository.findById(created.getId()).orElseThrow();
+        assertThat(reloaded.getToxicToCats()).isTrue();
+        assertThat(reloaded.getToxicToDogs()).isFalse();
+        assertThat(reloaded.getToxicToHumans()).isNull();
+    }
+
+    @Test
+    void should_reset_toxicity_to_null_when_updated_from_true_to_no_data() {
+        // arrange — был токсичен для всех троих
+        SpeciesFormDto createDto = baseDto("Вид со сбросом токсичности");
+        createDto.setToxicToCats(true);
+        createDto.setToxicToDogs(true);
+        createDto.setToxicToHumans(true);
+        Species created = service.create(createDto, ADMIN);
+        flushAndClear();
+        // sanity: значения действительно лежат в БД
+        assertThat(readToxicToCats(created.getId())).isTrue();
+
+        // act — редактор выставил «нет данных» (null) по всем трём
+        SpeciesFormDto updateDto = baseDto("Вид со сбросом токсичности");
+        updateDto.setToxicToCats(null);
+        updateDto.setToxicToDogs(null);
+        updateDto.setToxicToHumans(null);
+        service.update(created.getId(), updateDto, ADMIN);
+        flushAndClear();
+
+        // assert — колонки реально занулены, а не остались true
+        Species reloaded = speciesRepository.findById(created.getId()).orElseThrow();
+        assertThat(reloaded.getToxicToCats()).isNull();
+        assertThat(reloaded.getToxicToDogs()).isNull();
+        assertThat(reloaded.getToxicToHumans()).isNull();
+        // и нативно в БД именно NULL, не false
+        assertThat(readToxicToCats(reloaded.getId())).isNull();
+    }
+
+    @Test
+    void should_set_toxicity_to_true_when_updated_from_null() {
+        // arrange — изначально нет данных
+        Species created = service.create(baseDto("Вид без данных о токсичности"), ADMIN);
+        flushAndClear();
+        assertThat(readToxicToCats(created.getId())).isNull();
+
+        // act — отметили токсичным для кошек
+        SpeciesFormDto updateDto = baseDto("Вид без данных о токсичности");
+        updateDto.setToxicToCats(true);
+        service.update(created.getId(), updateDto, ADMIN);
+        flushAndClear();
+
+        // assert
+        assertThat(speciesRepository.findById(created.getId()).orElseThrow().getToxicToCats())
+                .isTrue();
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private SpeciesFormDto baseDto(String name) {
+        SpeciesFormDto dto = new SpeciesFormDto();
+        dto.setName(name);
+        dto.setWateringDays(7);
+        dto.setPopularity(50);
+        return dto;
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    /**
+     * Читает toxic_to_cats нативно — отличаем настоящий SQL NULL от false.
+     */
+    private Boolean readToxicToCats(Long speciesId) {
+        return (Boolean) entityManager.createNativeQuery(
+                        "SELECT toxic_to_cats FROM species WHERE id = :id")
+                .setParameter("id", speciesId)
+                .getSingleResult();
+    }
+}


### PR DESCRIPTION
Closes #131

## Что сделано
- **CRUD фактов вида** на странице редактирования вида в админке (#58): список фактов с группировкой по категории и `display_order`, создание / редактирование / удаление (HTMX, паттерн #58).
- `SpeciesFactFormDto` — **record** + Bean Validation: `body` `@NotBlank` (обязателен), `title` `@Size(max=160)`, `source` `@Size(max=300)`, `category` `@NotNull` (enum `FactCategory`, 4 значения), `displayOrder` `@PositiveOrZero`.
- `AdminSpeciesFactService` (`@Transactional`) — все мутации через `findByIdAndSpeciesId(factId, speciesId)`: факт нельзя отредактировать/удалить подменив id в URL (защита от IDOR).
- `SpeciesFactNotFoundException extends EntityNotFoundException` → промах привязки отдаёт **404** через существующий `AdminControllerAdvice` (а не 500).
- **Редактирование 3 флагов токсичности** вида на той же странице, tri-state: «токсично» / «не токсично» / «нет данных» (`true` / `false` / `null`). Пустое значение `<select>` биндится в `null`; сброс `true→null` сохраняется (`applyDto` всегда проставляет значение).
- `updated_at` факта обновляется **триггером БД** (поле `insertable=false, updatable=false`, кодом не трогается).

## Миграции
Нет — схема `species_facts` (#129, V22) и флаги токсичности (#130, V26) уже на develop. Только новый код + Thymeleaf-шаблоны.

## Backward-compat риски
**safe.** Новые endpoint'ы под `/admin/**` (уже защищены `hasRole("ADMIN")`, security не тронут), новый код, +3 nullable-колонки токсичности уже существуют в схеме. Существующий CRUD видов и публичный API не меняются.

## Тесты
- `AdminSpeciesFactControllerTest` (`@WebMvcTest`, 12): create/update/delete happy; **валидация пустого `body`** (сервис не вызван); edge — title>160, displayOrder<0, пустая category; **404 при чужом факте** (update/delete/edit → `SpeciesFactNotFoundException`).
- `AdminSpeciesFactServiceTest` (`@DataJpaTest` + Testcontainers Postgres, 11): создание/привязка к виду, группировка, **IDOR — update/delete/get чужого факта → `SpeciesFactNotFoundException`**, факт не тронут.
- `AdminSpeciesFactUpdatedAtTest` (1): `updated_at` растёт при update (insert/update в раздельных транзакциях — иначе таймстемп триггера совпал бы).
- `AdminSpeciesToxicityTest` (3): сохранение true/false/null; **сброс true→null** (проверен реальный SQL NULL); null→true.
- Итого по затронутым классам: **27 тестов зелёные**.

## Чек
- [x] reviewer прошёл — 1 BLOCKING (404 вместо 500 на ownership-промахе) **исправлен** + покрыт регрессионным тестом; SHOULD-FIX приняты (см. ниже)
- [ ] `mvn verify` локально красное **только** из-за pre-existing flaky от Testcontainers reuse=true (`SpeciesRepositoryTest.topPopularReturnsInCorrectOrder`, `PlantServiceTest.getPopularSpecies` — контаминация `popularity` в общем контейнере). Зелёные в изоляции; 27 тестов фичи зелёные. На фреш-контейнере CI ожидается зелёным.

## Принятые SHOULD-FIX (вне scope #131)
- `SpeciesFormDto` остаётся `@Data` POJO (pre-existing, #58) — конвертация в record потребовала бы переработки биндинга формы вида и шаблона, это отдельная задача. Новый `SpeciesFactFormDto` — корректный record.
- MVC-биндинг tri-state (пусто→null) покрыт на сервисном уровне (`AdminSpeciesToxicityTest`, реальный SQL NULL), но не web-тестом: существующий `AdminSpeciesControllerTest` закомментирован на develop, поднимать его ради одного биндинг-кейса — отдельная чистка.
