### PR TITLE
feat: авто-подсказка расходников перед пересадкой (#141)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 - **V27** — таблица `shopping_items` (issue #136): персональный список покупок пользователя, по строке на позицию. `title` (до 160 символов), `checked` (DEFAULT false). FK `ON DELETE CASCADE` на `users`, btree-индекс `(user_id, checked)` под выборку списка с разбивкой по статусу
 - **V28** — добавляет `plants.parent_id BIGINT NULL` — self-FK на `plants(id)` для родословной растений (ADR-012, issue #139). Растение-черенок ссылается на материнское; NULL = корень родословной. FK `ON DELETE SET NULL` (удаление родителя обрывает связь, потомок остаётся). btree-индекс `idx_plants_parent_id` под выборку потомков по родителю. Карточка показывает «🌱 Потомки: N» у родителя и кликабельную ссылку «⬅️ Родитель: …» у потомка
 - **V29** — сидинг энциклопедических фактов в `species_facts` (`ORIGIN`/`CARE`/`TOXICITY`/`CURIOSITY`) и простановка флагов токсичности `species.toxic_to_*` для топ-видов по популярности (issue #132). Это сидинг, обещанный в V22 (#129), и данные под флаги из V26 (#130). Чистый сид без DDL. Привязка к виду по `latin_name`, не по id. Идемпотентен: факты — `INSERT ... WHERE NOT EXISTS` по `(species_id, category, body)`, токсичность — `UPDATE`. Виды без достоверных данных ASPCA остаются с `NULL` («нет данных»)
+- **V30** — таблица `transplant_supply_suggestions` (issue #141): трекер идемпотентности подсказок расходников перед пересадкой. По строке на `(user_id, plant_id, source_event_id)`, где `source_event_id` — id записи TRANSPLANT в `plant_events`, от которой посчитана предстоящая пересадка. UNIQUE `(user_id, plant_id, source_event_id)` гарантирует один пуш на одно предстоящее событие (новая пересадка → новый `source_event_id` → можно подсказать снова). `status` (`SUGGESTED`/`ADDED`/`DISMISSED`, CHECK), `predicted_transplant_at`. FK на `users`/`plants`/`plant_events` `ON DELETE CASCADE`. Индексы `(user_id, status)` и по обоим FK
 
 ## REST API
 
@@ -336,6 +337,29 @@ Telegram ~30/sec). На 429 поток ждёт `retry_after` и повторя�
 | `TELEGRAM_RATE_LIMIT_MAX_RETRIES` | `3` | Сколько раз повторять отправку при 429 перед признанием неудачи |
 | `TELEGRAM_RATE_LIMIT_DEFAULT_RETRY_AFTER_SECONDS` | `1` | Fallback retry-after, если 429 не содержит распарсиваемого значения |
 | `TELEGRAM_RATE_LIMIT_MAX_RETRY_AFTER_SECONDS` | `60` | Потолок для `retry_after` из 429 — чтобы одно сообщение не заблокировало очередь на часы |
+
+## Подсказка расходников перед пересадкой (issue #141)
+
+Раз в день шедулер (cron `0 0 9 * * *` UTC) вычисляет «предстоящую пересадку» как
+дату последней записи `TRANSPLANT` в журнале растения (issue #76) плюс `interval-months`.
+Если эта дата попадает в окно ближайших `horizon-days` в таймзоне пользователя (и не в
+quiet hours), бот шлёт мягкую нотификацию с кнопками «➕ В список покупок» / «Не нужно».
+Подсказка появляется только для растений, у которых уже есть `TRANSPLANT` в истории.
+
+Нажатие «➕ В список покупок» добавляет позиции из `supplies` в список покупок (issue #136)
+и идемпотентно: повтор по тому же событию не дублирует ни подсказку (UNIQUE
+`(user_id, plant_id, source_event_id)`), ни товары.
+
+Конфигурация — `plants.transplant-suggestion` в `application.yml`:
+
+| Переменная | Дефолт | Описание |
+|---|---|---|
+| `PLANTS_TRANSPLANT_SUGGESTION_ENABLED` | `true` | Мастер-переключатель фичи |
+| `PLANTS_TRANSPLANT_SUGGESTION_HORIZON_DAYS` | `14` | За сколько дней до предстоящей пересадки подсказывать |
+| `PLANTS_TRANSPLANT_SUGGESTION_INTERVAL_MONTHS` | `12` | Типовой интервал между пересадками |
+
+`supplies` (по умолчанию «Грунт», «Дренаж») и `message-template` задаются списком/строкой
+в `application.yml`, env-override для них не предусмотрен.
 
 ## Деплой на Railway
 

--- a/src/main/java/com/plantcare/bot/PlantsCareApplication.java
+++ b/src/main/java/com/plantcare/bot/PlantsCareApplication.java
@@ -4,6 +4,7 @@ import com.plantcare.bot.config.CalendarProperties;
 import com.plantcare.bot.config.HealthScoreProperties;
 import com.plantcare.bot.config.SpeciesProperties;
 import com.plantcare.bot.config.TelegramRateLimitProperties;
+import com.plantcare.bot.config.TransplantSuggestionProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -11,7 +12,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
-@EnableConfigurationProperties({SpeciesProperties.class, CalendarProperties.class, HealthScoreProperties.class, TelegramRateLimitProperties.class})
+@EnableConfigurationProperties({SpeciesProperties.class, CalendarProperties.class, HealthScoreProperties.class, TelegramRateLimitProperties.class, TransplantSuggestionProperties.class})
 public class PlantsCareApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/plantcare/bot/beans/PlantsCareBot.java
+++ b/src/main/java/com/plantcare/bot/beans/PlantsCareBot.java
@@ -9,6 +9,7 @@ import com.plantcare.bot.service.DiseaseMenuService;
 import com.plantcare.bot.service.MenuCallbackService;
 import com.plantcare.bot.service.NotificationCallbackService;
 import com.plantcare.bot.service.NotificationDigestCallbackService;
+import com.plantcare.bot.service.TransplantSuggestionCallbackService;
 import com.plantcare.bot.observability.SentryTags;
 import com.plantcare.bot.observability.SentryTags.Layer;
 import com.plantcare.bot.service.UserService;
@@ -41,6 +42,8 @@ public class PlantsCareBot implements LongPollingSingleThreadUpdateConsumer, Tel
     private static final String SHOPPING_CALLBACK_PREFIX = "SHOPPING:";
     private static final String DISEASE_CALLBACK_PREFIX = "DISEASE:";
     private static final String SET_TZ_CALLBACK_PREFIX = "SET_TZ";
+    private static final String TRANSPLANT_SUGGEST_CALLBACK_PREFIX =
+            TransplantSuggestionCallbackService.CALLBACK_PREFIX;
 
     private final TelegramClient telegramClient;
     private final CommandContainer commandContainer;
@@ -51,6 +54,7 @@ public class PlantsCareBot implements LongPollingSingleThreadUpdateConsumer, Tel
     private final NotificationDigestCallbackService notificationDigestCallbackService;
     private final MenuCallbackService menuCallbackService;
     private final DiseaseMenuService diseaseMenuService;
+    private final TransplantSuggestionCallbackService transplantSuggestionCallbackService;
 
     public PlantsCareBot(
             @Value("${telegram.bot.token}") String botToken,
@@ -61,7 +65,8 @@ public class PlantsCareBot implements LongPollingSingleThreadUpdateConsumer, Tel
             NotificationCallbackService notificationCallbackService,
             NotificationDigestCallbackService notificationDigestCallbackService,
             MenuCallbackService menuCallbackService,
-            DiseaseMenuService diseaseMenuService
+            DiseaseMenuService diseaseMenuService,
+            TransplantSuggestionCallbackService transplantSuggestionCallbackService
     ) {
         this.telegramClient = new OkHttpTelegramClient(botToken);
         this.commandContainer = commandContainer;
@@ -72,6 +77,7 @@ public class PlantsCareBot implements LongPollingSingleThreadUpdateConsumer, Tel
         this.notificationDigestCallbackService = notificationDigestCallbackService;
         this.menuCallbackService = menuCallbackService;
         this.diseaseMenuService = diseaseMenuService;
+        this.transplantSuggestionCallbackService = transplantSuggestionCallbackService;
     }
 
     @Override
@@ -111,6 +117,15 @@ public class PlantsCareBot implements LongPollingSingleThreadUpdateConsumer, Tel
 
                 if (data != null && data.startsWith(NOTIFICATION_CALLBACK_PREFIX)) {
                     notificationCallbackService.handleCallback(update.getCallbackQuery(), telegramClient);
+                    return;
+                }
+
+                if (data != null && data.startsWith(TRANSPLANT_SUGGEST_CALLBACK_PREFIX)) {
+                    String userName = getUserName(update);
+                    User user = userService.findOrCreate(chatId, userName);
+
+                    transplantSuggestionCallbackService.handleCallback(
+                            update.getCallbackQuery(), telegramClient, user);
                     return;
                 }
 

--- a/src/main/java/com/plantcare/bot/config/TransplantSuggestionProperties.java
+++ b/src/main/java/com/plantcare/bot/config/TransplantSuggestionProperties.java
@@ -1,0 +1,56 @@
+package com.plantcare.bot.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+/**
+ * Issue #141: настройки подсказки расходников перед предстоящей пересадкой.
+ *
+ * <p>«Предстоящая пересадка» вычисляется как дата последней TRANSPLANT-записи
+ * в журнале растения ({@code plant_events}, issue #76) плюс {@link #intervalMonths()}.
+ * Если эта дата попадает в окно ближайших {@link #horizonDays()} дней (в TZ
+ * юзера), шедулер шлёт мягкую нотификацию с предложением добавить
+ * {@link #supplies()} в список покупок (issue #136).
+ *
+ * <ul>
+ *   <li>{@code enabled} — мастер-переключатель фичи (default {@code true});</li>
+ *   <li>{@code horizonDays} — за сколько дней до предстоящей пересадки подсказывать
+ *       (default 14);</li>
+ *   <li>{@code intervalMonths} — типовой интервал между пересадками (default 12);</li>
+ *   <li>{@code supplies} — какие позиции предлагать в список покупок
+ *       (default {@code ["Грунт", "Дренаж"]});</li>
+ *   <li>{@code messageTemplate} — шаблон текста нотификации; первый {@code %s} —
+ *       имя растения, второй — перечисление расходников.</li>
+ * </ul>
+ */
+@ConfigurationProperties(prefix = "plants.transplant-suggestion")
+public record TransplantSuggestionProperties(
+        boolean enabled,
+        int horizonDays,
+        int intervalMonths,
+        List<String> supplies,
+        String messageTemplate
+) {
+
+    private static final List<String> DEFAULT_SUPPLIES = List.of("Грунт", "Дренаж");
+    private static final String DEFAULT_MESSAGE_TEMPLATE =
+            "🪴 Растению «%s» скоро пересадка — добавить расходники (%s) в список покупок?";
+
+    public TransplantSuggestionProperties {
+        if (horizonDays <= 0) {
+            horizonDays = 14;
+        }
+        if (intervalMonths <= 0) {
+            intervalMonths = 12;
+        }
+        if (supplies == null || supplies.isEmpty()) {
+            supplies = DEFAULT_SUPPLIES;
+        } else {
+            supplies = List.copyOf(supplies);
+        }
+        if (messageTemplate == null || messageTemplate.isBlank()) {
+            messageTemplate = DEFAULT_MESSAGE_TEMPLATE;
+        }
+    }
+}

--- a/src/main/java/com/plantcare/bot/domain/TransplantSupplySuggestion.java
+++ b/src/main/java/com/plantcare/bot/domain/TransplantSupplySuggestion.java
@@ -1,0 +1,95 @@
+package com.plantcare.bot.domain;
+
+import com.plantcare.bot.domain.base.BaseEntity;
+import com.plantcare.bot.domain.enums.SuggestionStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Трекер идемпотентности подсказок расходников перед пересадкой (issue #141).
+ *
+ * <p>По строке на {@code (user_id, plant_id, source_event_id)}: шедулер раз в
+ * день вычисляет предстоящую пересадку как {@code last TRANSPLANT + интервал}
+ * из конфига и, если по этому событию ещё не подсказывал, создаёт строку
+ * {@link SuggestionStatus#SUGGESTED} и шлёт мягкую нотификацию с кнопками
+ * «➕ В список покупок» / «Не нужно».
+ *
+ * <p>{@code source_event_id} — id записи TRANSPLANT в {@link PlantEvent}, от
+ * которой посчитана пересадка. Это ключ идемпотентности: новая пересадка →
+ * новый source_event_id → можно подсказать снова. UNIQUE на
+ * {@code (user_id, plant_id, source_event_id)} (см. V29) фиксирует гарантию на
+ * уровне БД.
+ *
+ * <p>id и created_at наследуются из {@link BaseEntity}.
+ */
+@Entity
+@Table(name = "transplant_supply_suggestions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TransplantSupplySuggestion extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "plant_id", nullable = false)
+    private Plant plant;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "source_event_id", nullable = false)
+    private PlantEvent sourceEvent;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private SuggestionStatus status;
+
+    @Column(name = "predicted_transplant_at", nullable = false)
+    private LocalDateTime predictedTransplantAt;
+
+    @Column(name = "responded_at")
+    private LocalDateTime respondedAt;
+
+    public TransplantSupplySuggestion(
+            User user,
+            Plant plant,
+            PlantEvent sourceEvent,
+            LocalDateTime predictedTransplantAt
+    ) {
+        this.user = user;
+        this.plant = plant;
+        this.sourceEvent = sourceEvent;
+        this.predictedTransplantAt = predictedTransplantAt;
+        this.status = SuggestionStatus.SUGGESTED;
+    }
+
+    /**
+     * Идемпотентно переводит подсказку в {@link SuggestionStatus#ADDED} и
+     * фиксирует момент реакции. Вызывается, когда юзер добавил расходники в
+     * список покупок.
+     */
+    public void markAdded(LocalDateTime respondedAt) {
+        this.status = SuggestionStatus.ADDED;
+        this.respondedAt = respondedAt;
+    }
+
+    /**
+     * Идемпотентно переводит подсказку в {@link SuggestionStatus#DISMISSED} и
+     * фиксирует момент реакции. Вызывается, когда юзер нажал «Не нужно».
+     */
+    public void markDismissed(LocalDateTime respondedAt) {
+        this.status = SuggestionStatus.DISMISSED;
+        this.respondedAt = respondedAt;
+    }
+}

--- a/src/main/java/com/plantcare/bot/domain/enums/SuggestionStatus.java
+++ b/src/main/java/com/plantcare/bot/domain/enums/SuggestionStatus.java
@@ -1,0 +1,17 @@
+package com.plantcare.bot.domain.enums;
+
+/**
+ * Статус подсказки расходников перед пересадкой (issue #141).
+ *
+ * <ul>
+ *   <li>{@link #SUGGESTED} — нотификация отправлена, ждём реакции юзера;</li>
+ *   <li>{@link #ADDED} — юзер нажал «В список покупок», позиции добавлены в shopping_items;</li>
+ *   <li>{@link #DISMISSED} — юзер нажал «Не нужно».</li>
+ * </ul>
+ */
+public enum SuggestionStatus {
+
+    SUGGESTED,
+    ADDED,
+    DISMISSED
+}

--- a/src/main/java/com/plantcare/bot/repository/PlantEventRepository.java
+++ b/src/main/java/com/plantcare/bot/repository/PlantEventRepository.java
@@ -5,8 +5,11 @@ import com.plantcare.bot.domain.enums.PlantEventType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -30,4 +33,46 @@ public interface PlantEventRepository extends JpaRepository<PlantEvent, Long> {
      * счётчик/наличие журнала без загрузки самих записей.
      */
     long countByPlantId(Long plantId);
+
+    /**
+     * Последние события заданного типа по всем активным (не архивным) растениям —
+     * источник «предстоящих пересадок» для подсказки расходников (issue #141).
+     *
+     * <p>Возвращает ровно по одной записи на растение — последнюю по
+     * {@code event_date}, а при равных {@code event_date} (импорт журнала,
+     * бэкфил, двойной тап) — с максимальным {@code id} (большее id = создано
+     * позже). Тай-брейк по {@code id} обязателен: иначе подзапрос вернул бы обе
+     * строки с одинаковым MAX(event_date) и юзер получил бы две подсказки про
+     * одно растение (UNIQUE по триплету их не схлопнет — source_event_id разные).
+     *
+     * <p>Отбор сведён к одному {@code id} на растение: внутренний подзапрос ищет
+     * MAX(event_date) этого типа для растения, внешний — MAX(id) среди строк с
+     * этим MAX(event_date). Так {@code WHERE e.id = (...)} гарантирует одну
+     * строку и сохраняет {@code JOIN FETCH} (нативка с fetch join не дружит).
+     *
+     * <p>{@code JOIN FETCH} тянет {@code plant} и его {@code user}, потому что
+     * шедулер для каждого кандидата читает имя растения и timezone юзера — без
+     * fetch будет N+1.
+     *
+     * <p>Архивные растения исключены: подсказывать пересадку по убранному в
+     * архив растению смысла нет.
+     */
+    @Query("""
+            SELECT e FROM PlantEvent e
+            JOIN FETCH e.plant p
+            JOIN FETCH p.user
+            WHERE e.eventType = :eventType
+              AND p.archivedAt IS NULL
+              AND e.id = (
+                  SELECT MAX(e2.id) FROM PlantEvent e2
+                  WHERE e2.plant = e.plant
+                    AND e2.eventType = :eventType
+                    AND e2.eventDate = (
+                        SELECT MAX(e3.eventDate) FROM PlantEvent e3
+                        WHERE e3.plant = e.plant
+                          AND e3.eventType = :eventType
+                    )
+              )
+            """)
+    List<PlantEvent> findLatestEventPerActivePlant(@Param("eventType") PlantEventType eventType);
 }

--- a/src/main/java/com/plantcare/bot/repository/TransplantSupplySuggestionRepository.java
+++ b/src/main/java/com/plantcare/bot/repository/TransplantSupplySuggestionRepository.java
@@ -1,0 +1,25 @@
+package com.plantcare.bot.repository;
+
+import com.plantcare.bot.domain.TransplantSupplySuggestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TransplantSupplySuggestionRepository
+        extends JpaRepository<TransplantSupplySuggestion, Long> {
+
+    /**
+     * «Уже подсказывали по этой предстоящей пересадке?» — проверка идемпотентности
+     * перед созданием новой подсказки. Совпадает с UNIQUE
+     * {@code (user_id, plant_id, source_event_id)} из V29.
+     */
+    boolean existsByUserIdAndPlantIdAndSourceEventId(Long userId, Long plantId, Long sourceEventId);
+
+    /**
+     * Подсказка, скоупленная по владельцу — чтобы юзер не смог тронуть чужую
+     * строку через подделанный callback_data.
+     */
+    Optional<TransplantSupplySuggestion> findByUserIdAndId(Long userId, Long id);
+}

--- a/src/main/java/com/plantcare/bot/service/TransplantSuggestionCallbackService.java
+++ b/src/main/java/com/plantcare/bot/service/TransplantSuggestionCallbackService.java
@@ -1,0 +1,133 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.service.TransplantSuggestionService.ReactionResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.telegram.telegrambots.meta.api.methods.AnswerCallbackQuery;
+import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText;
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+import org.springframework.stereotype.Service;
+
+/**
+ * Обработчик callback'ов подсказки расходников перед пересадкой (issue #141).
+ *
+ * <p>callback_data: {@code TRANSPLANT_SUGGEST:ADD:{id}} и
+ * {@code TRANSPLANT_SUGGEST:SKIP:{id}}. Тонкий слой: парсит данные, дёргает
+ * {@link TransplantSuggestionService}, отвечает {@code answerCallbackQuery} и
+ * убирает кнопки у сообщения. Репозиториев не держит (CLAUDE.md).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TransplantSuggestionCallbackService {
+
+    public static final String CALLBACK_PREFIX = "TRANSPLANT_SUGGEST:";
+
+    private final TransplantSuggestionService suggestionService;
+
+    public void handleCallback(CallbackQuery callbackQuery, TelegramClient client, User user) {
+        String data = callbackQuery.getData();
+        String callbackId = callbackQuery.getId();
+        Long chatId = callbackQuery.getMessage().getChatId();
+        Integer messageId = callbackQuery.getMessage().getMessageId();
+
+        String[] parts = data.split(":");
+        if (parts.length != 3) {
+            answerCallback(client, callbackId, "❌ Неизвестная команда");
+            return;
+        }
+
+        String action = parts[1];
+
+        long suggestionId;
+        try {
+            suggestionId = Long.parseLong(parts[2]);
+        } catch (NumberFormatException e) {
+            answerCallback(client, callbackId, "❌ Неверный ID");
+            return;
+        }
+
+        switch (action) {
+            case "ADD" -> handleAdd(user, suggestionId, client, callbackId, chatId, messageId);
+            case "SKIP" -> handleSkip(user, suggestionId, client, callbackId, chatId, messageId);
+            default -> answerCallback(client, callbackId, "❌ Неизвестное действие");
+        }
+    }
+
+    private void handleAdd(
+            User user,
+            long suggestionId,
+            TelegramClient client,
+            String callbackId,
+            Long chatId,
+            Integer messageId
+    ) {
+        ReactionResult result = suggestionService.addToShoppingList(user.getId(), suggestionId);
+
+        switch (result) {
+            case OK -> {
+                editMessage(client, chatId, messageId,
+                        "✅ Добавил в список покупок: " + suggestionService.suppliesLabel());
+                answerCallback(client, callbackId, "Готово!");
+            }
+            case ALREADY_HANDLED -> {
+                editMessage(client, chatId, messageId,
+                        "✅ Уже добавлено в список покупок");
+                answerCallback(client, callbackId, "Уже обработано");
+            }
+            case NOT_FOUND -> answerCallback(client, callbackId, "❌ Подсказка не найдена");
+        }
+    }
+
+    private void handleSkip(
+            User user,
+            long suggestionId,
+            TelegramClient client,
+            String callbackId,
+            Long chatId,
+            Integer messageId
+    ) {
+        ReactionResult result = suggestionService.dismiss(user.getId(), suggestionId);
+
+        switch (result) {
+            case OK -> {
+                editMessage(client, chatId, messageId, "Хорошо, не буду напоминать 👌");
+                answerCallback(client, callbackId, "Готово");
+            }
+            case ALREADY_HANDLED -> {
+                editMessage(client, chatId, messageId, "Хорошо, не буду напоминать 👌");
+                answerCallback(client, callbackId, "Уже обработано");
+            }
+            case NOT_FOUND -> answerCallback(client, callbackId, "❌ Подсказка не найдена");
+        }
+    }
+
+    private void editMessage(TelegramClient client, Long chatId, Integer messageId, String text) {
+        EditMessageText edit = EditMessageText.builder()
+                .chatId(chatId.toString())
+                .messageId(messageId)
+                .text(text)
+                .replyMarkup(null)
+                .build();
+
+        try {
+            client.execute(edit);
+        } catch (TelegramApiException e) {
+            log.error("Failed to edit transplant suggestion message: {}", e.getMessage(), e);
+        }
+    }
+
+    private void answerCallback(TelegramClient client, String callbackId, String text) {
+        try {
+            client.execute(AnswerCallbackQuery.builder()
+                    .callbackQueryId(callbackId)
+                    .text(text)
+                    .build());
+        } catch (TelegramApiException e) {
+            log.error("Failed to answer transplant suggestion callback: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/plantcare/bot/service/TransplantSuggestionInserter.java
+++ b/src/main/java/com/plantcare/bot/service/TransplantSuggestionInserter.java
@@ -1,0 +1,45 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.TransplantSupplySuggestion;
+import com.plantcare.bot.repository.TransplantSupplySuggestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Вспомогательный компонент: вставка строки-трекера подсказки в ОТДЕЛЬНОЙ
+ * транзакции ({@link Propagation#REQUIRES_NEW}).
+ *
+ * <p>Зачем отдельный бин и отдельная транзакция: id у
+ * {@link TransplantSupplySuggestion} генерируется стратегией IDENTITY, поэтому
+ * {@code saveAndFlush} выполняет INSERT немедленно. При нарушении UNIQUE
+ * {@code (user_id, plant_id, source_event_id)} (гонка/повтор тика) откат
+ * конфликтной вставки изолирован в этой вложенной транзакции и НЕ помечает
+ * внешнюю транзакцию {@code recordSuggested} как rollback-only. Благодаря этому
+ * вызывающий метод может поймать {@code DataIntegrityViolationException} и
+ * корректно вернуть {@code Optional.empty()} вместо падения
+ * {@code UnexpectedRollbackException} на коммите внешней транзакции.
+ *
+ * <p>Вынесено в отдельный бин намеренно: self-invocation внутри
+ * {@code TransplantSuggestionService} не прошёл бы через прокси и не дал бы
+ * новую транзакцию.
+ */
+@Component
+@RequiredArgsConstructor
+class TransplantSuggestionInserter {
+
+    private final TransplantSupplySuggestionRepository suggestionRepository;
+
+    /**
+     * Вставляет строку-трекер во вложенной транзакции и сразу флашит, чтобы
+     * нарушение UNIQUE всплыло здесь (в изолированной транзакции), а не на
+     * коммите внешней.
+     *
+     * @return id созданной строки
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Long insert(TransplantSupplySuggestion suggestion) {
+        return suggestionRepository.saveAndFlush(suggestion).getId();
+    }
+}

--- a/src/main/java/com/plantcare/bot/service/TransplantSuggestionScheduler.java
+++ b/src/main/java/com/plantcare/bot/service/TransplantSuggestionScheduler.java
@@ -1,0 +1,145 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.config.TransplantSuggestionProperties;
+import com.plantcare.bot.observability.SentryTags;
+import com.plantcare.bot.observability.SentryTags.Layer;
+import com.plantcare.bot.repository.UserRepository;
+import com.plantcare.bot.service.TransplantSuggestionService.DueSuggestion;
+import com.plantcare.bot.telegram.RateLimitedTelegramSender;
+import com.plantcare.bot.telegram.SendCallbacks;
+import io.sentry.Sentry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardRow;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Ежедневный шедулер подсказок расходников перед предстоящей пересадкой (issue #141).
+ *
+ * <p>Раз в день (09:00 UTC) подбирает растения, у которых предстоящая пересадка
+ * (last TRANSPLANT + интервал из конфига) попадает в окно ближайших
+ * {@code horizon-days} в TZ юзера, и шлёт мягкую нотификацию с кнопками
+ * «➕ В список покупок» / «Не нужно».
+ *
+ * <p>Идемпотентность — на уровне БД ({@code transplant_supply_suggestions}, UNIQUE
+ * по {@code (user_id, plant_id, source_event_id)}): повторный тик по той же
+ * предстоящей пересадке не создаёт строку и не шлёт повтор.
+ *
+ * <p>Telegram-вызовы вне транзакции к БД: сервис в read-only выборке считает
+ * кандидатов, затем строка-трекер создаётся в своей транзакции
+ * ({@link TransplantSuggestionService#recordSuggested}), и только потом сообщение
+ * уходит в rate-limited очередь. Уважаем quiet-hours юзера — мягкую подсказку
+ * незачем слать ночью.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TransplantSuggestionScheduler {
+
+    static final String CALLBACK_PREFIX = "TRANSPLANT_SUGGEST";
+    static final String ACTION_ADD = "ADD";
+    static final String ACTION_SKIP = "SKIP";
+
+    private final TransplantSuggestionService suggestionService;
+    private final TransplantSuggestionProperties properties;
+    private final QuietHoursPolicy quietHoursPolicy;
+    private final UserRepository userRepository;
+    private final RateLimitedTelegramSender telegramSender;
+    private final java.time.Clock clock;
+
+    /**
+     * Cron в UTC: каждый день в 09:00. Мягкая подсказка, не привязанная к
+     * минуте — daily-тика достаточно. Quiet-hours юзера всё равно проверяются
+     * по его TZ перед отправкой.
+     */
+    @Scheduled(cron = "0 0 9 * * *", zone = "UTC")
+    public void tick() {
+        if (!properties.enabled()) {
+            return;
+        }
+
+        SentryTags.runWithLayer(Layer.SCHEDULER, "TransplantSuggestionScheduler", () -> {
+            Instant now = clock.instant();
+            List<DueSuggestion> due = suggestionService.findDueSuggestions(now);
+
+            if (due.isEmpty()) {
+                return;
+            }
+            log.info("Transplant suggestion tick: {} candidates found", due.size());
+
+            for (DueSuggestion suggestion : due) {
+                try {
+                    if (isQuietForUser(suggestion.userId(), now)) {
+                        continue;
+                    }
+                    enqueueSuggestion(suggestion);
+                } catch (Exception e) {
+                    log.error("Failed to handle transplant suggestion for plant {}: {}",
+                            suggestion.plantId(), e.getMessage(), e);
+                    Sentry.captureException(e);
+                }
+            }
+        });
+    }
+
+    /**
+     * Quiet-hours проверяем по свежему юзеру (TZ мог измениться между выборкой
+     * кандидатов и отправкой). Если юзер исчез — считаем «тихо», не шлём.
+     */
+    private boolean isQuietForUser(Long userId, Instant now) {
+        return userRepository.findById(userId)
+                .map(user -> quietHoursPolicy.isQuiet(user, now))
+                .orElse(true);
+    }
+
+    /**
+     * Создаёт строку-трекер (получая id для callback_data), затем кладёт
+     * сообщение в очередь. id нужен ДО построения клавиатуры — поэтому
+     * {@code recordSuggested} вызывается до enqueue, в отличие от анниверсари-
+     * шедулера. Если строку уже создал параллельный тик — пропускаем.
+     */
+    private void enqueueSuggestion(DueSuggestion suggestion) {
+        Optional<Long> suggestionId = suggestionService.recordSuggested(suggestion);
+        if (suggestionId.isEmpty()) {
+            return;
+        }
+
+        long id = suggestionId.get();
+        SendMessage message = SendMessage.builder()
+                .chatId(suggestion.telegramChatId().toString())
+                .text(suggestionService.buildMessageText(suggestion.plantName()))
+                .replyMarkup(buildKeyboard(id))
+                .build();
+
+        final long plantId = suggestion.plantId();
+        final long chatId = suggestion.telegramChatId();
+        telegramSender.enqueue(message, new SendCallbacks(
+                () -> log.info("Transplant suggestion {} sent: plant={} chat={}",
+                        id, plantId, chatId),
+                null));
+    }
+
+    private InlineKeyboardMarkup buildKeyboard(long suggestionId) {
+        InlineKeyboardButton addButton = InlineKeyboardButton.builder()
+                .text("➕ В список покупок")
+                .callbackData(CALLBACK_PREFIX + ":" + ACTION_ADD + ":" + suggestionId)
+                .build();
+
+        InlineKeyboardButton skipButton = InlineKeyboardButton.builder()
+                .text("Не нужно")
+                .callbackData(CALLBACK_PREFIX + ":" + ACTION_SKIP + ":" + suggestionId)
+                .build();
+
+        return InlineKeyboardMarkup.builder()
+                .keyboardRow(new InlineKeyboardRow(addButton, skipButton))
+                .build();
+    }
+}

--- a/src/main/java/com/plantcare/bot/service/TransplantSuggestionService.java
+++ b/src/main/java/com/plantcare/bot/service/TransplantSuggestionService.java
@@ -1,0 +1,286 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.config.TransplantSuggestionProperties;
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.PlantEvent;
+import com.plantcare.bot.domain.TransplantSupplySuggestion;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.PlantEventType;
+import com.plantcare.bot.domain.enums.SuggestionStatus;
+import com.plantcare.bot.repository.PlantEventRepository;
+import com.plantcare.bot.repository.PlantRepository;
+import com.plantcare.bot.repository.TransplantSupplySuggestionRepository;
+import com.plantcare.bot.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Подсказка расходников перед предстоящей пересадкой (issue #141).
+ *
+ * <p>«Предстоящая пересадка» в системе не хранится отдельной датой
+ * (ADR — вариант A): она вычисляется как дата последней TRANSPLANT-записи в
+ * журнале растения (issue #76) плюс {@link TransplantSuggestionProperties#intervalMonths()}.
+ * Подсказка появляется только для растений, у которых уже есть TRANSPLANT в
+ * истории.
+ *
+ * <p>Telegram-вызов остаётся за рамками сервиса (CLAUDE.md): {@link #findDueSuggestions}
+ * в read-only транзакции подбирает кандидатов и отдаёт DTO, шедулер шлёт пуш вне
+ * транзакции, затем для каждого отправленного дёргает {@link #recordSuggested} в
+ * отдельной транзакции. Идемпотентность создания — UNIQUE
+ * {@code (user_id, plant_id, source_event_id)} (V29): повторный тик по той же
+ * предстоящей пересадке ничего не создаёт и ничего не шлёт.
+ *
+ * <p>Реакции на кнопки ({@link #addToShoppingList}/{@link #dismiss}) идемпотентны:
+ * повторно доставленный/двойной callback приводит к одному конечному состоянию.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TransplantSuggestionService {
+
+    private final TransplantSupplySuggestionRepository suggestionRepository;
+    private final PlantEventRepository plantEventRepository;
+    private final UserRepository userRepository;
+    private final PlantRepository plantRepository;
+    private final ShoppingListService shoppingListService;
+    private final TransplantSuggestionProperties properties;
+    private final TransplantSuggestionInserter suggestionInserter;
+    private final Clock clock;
+
+    /**
+     * Подобрать растения, у которых предстоящая пересадка (last TRANSPLANT +
+     * interval) попадает в окно {@code [today; today + horizonDays]} в TZ юзера
+     * и по которым ещё не подсказывали. Возвращает готовые DTO для отправки —
+     * Telegram-вызов делает caller, чтобы не держать транзакцию открытой во
+     * время HTTP.
+     *
+     * @param now момент проверки (UTC); передаётся явно — для тестов и
+     *            согласованности с {@code Clock}-бином caller'а
+     */
+    @Transactional(readOnly = true)
+    public List<DueSuggestion> findDueSuggestions(Instant now) {
+        if (!properties.enabled()) {
+            return List.of();
+        }
+
+        List<PlantEvent> latestTransplants =
+                plantEventRepository.findLatestEventPerActivePlant(PlantEventType.TRANSPLANT);
+        if (latestTransplants.isEmpty()) {
+            return List.of();
+        }
+
+        List<DueSuggestion> due = new ArrayList<>();
+        for (PlantEvent event : latestTransplants) {
+            Plant plant = event.getPlant();
+            User user = plant.getUser();
+            if (user == null || user.isBlocked()) {
+                continue;
+            }
+
+            LocalDateTime predicted = event.getEventDate().plusMonths(properties.intervalMonths());
+
+            if (!isWithinHorizon(predicted, now, user)) {
+                continue;
+            }
+
+            if (suggestionRepository.existsByUserIdAndPlantIdAndSourceEventId(
+                    user.getId(), plant.getId(), event.getId())) {
+                continue;
+            }
+
+            due.add(new DueSuggestion(
+                    user.getId(),
+                    user.getTelegramChatId(),
+                    plant.getId(),
+                    plant.getName(),
+                    event.getId(),
+                    predicted
+            ));
+        }
+        return due;
+    }
+
+    /**
+     * Зафиксировать факт отправки подсказки — отдельная транзакция, чтобы caller
+     * мог дёрнуть её сразу после успешного Telegram send. Создаёт строку
+     * {@link SuggestionStatus#SUGGESTED}.
+     *
+     * <p>Возвращает id созданной подсказки — он нужен caller'у для подстановки в
+     * callback_data кнопок. Если строка уже есть (гонка между тиками), возвращает
+     * {@link Optional#empty()} — слать кнопки с «чужим» id нельзя.
+     *
+     * <p>Сама вставка делегируется {@link TransplantSuggestionInserter} в
+     * отдельной транзакции ({@code REQUIRES_NEW}): нарушение UNIQUE при гонке/повторе
+     * откатывает только вложенную транзакцию, поэтому эта (внешняя) не помечается
+     * rollback-only и {@code DataIntegrityViolationException} здесь ловится без
+     * последующего {@code UnexpectedRollbackException} на коммите.
+     */
+    @Transactional
+    public Optional<Long> recordSuggested(DueSuggestion suggestion) {
+        try {
+            Long id = suggestionInserter.insert(
+                    new TransplantSupplySuggestion(
+                            userRepository.getReferenceById(suggestion.userId()),
+                            plantRepository.getReferenceById(suggestion.plantId()),
+                            plantEventRepository.getReferenceById(suggestion.sourceEventId()),
+                            suggestion.predictedTransplantAt()
+                    )
+            );
+            return Optional.of(id);
+        } catch (DataIntegrityViolationException e) {
+            log.debug("Transplant suggestion already exists for user={} plant={} event={}",
+                    suggestion.userId(), suggestion.plantId(), suggestion.sourceEventId());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Реакция «➕ В список покупок». Если подсказка в статусе
+     * {@link SuggestionStatus#SUGGESTED} — добавляет каждую позицию из конфига в
+     * список покупок юзера (issue #136) и переводит подсказку в
+     * {@link SuggestionStatus#ADDED}. Повторное нажатие — no-op
+     * ({@link ReactionResult#ALREADY_HANDLED}).
+     */
+    @Transactional
+    public ReactionResult addToShoppingList(Long userId, Long suggestionId) {
+        Optional<TransplantSupplySuggestion> optional =
+                suggestionRepository.findByUserIdAndId(userId, suggestionId);
+
+        if (optional.isEmpty()) {
+            return ReactionResult.NOT_FOUND;
+        }
+
+        TransplantSupplySuggestion suggestion = optional.get();
+
+        // Атомарность статусного перехода SUGGESTED -> ADDED здесь не защищена
+        // ни @Version, ни SELECT FOR UPDATE: проверка статуса и markAdded() — не
+        // атомарны. Это допустимо, потому что callback'и одного юзера
+        // сериализуются единственным поллинг-потоком
+        // (LongPollingSingleThreadUpdateConsumer), поэтому два конкурентных ADD по
+        // одной подсказке невозможны и расходники не задвоятся. При переходе на
+        // многопоточную доставку апдейтов сюда нужно добавить @Version
+        // (оптимистичная блокировка) или пессимистичную блокировку строки.
+        if (suggestion.getStatus() != SuggestionStatus.SUGGESTED) {
+            return ReactionResult.ALREADY_HANDLED;
+        }
+
+        User user = suggestion.getUser();
+        for (String supply : properties.supplies()) {
+            shoppingListService.add(user, supply);
+        }
+
+        suggestion.markAdded(nowUtc());
+
+        log.info("Transplant suggestion {} of user {} added {} supplies to shopping list",
+                suggestionId, userId, properties.supplies().size());
+
+        return ReactionResult.OK;
+    }
+
+    /**
+     * Реакция «Не нужно». Если подсказка в статусе {@link SuggestionStatus#SUGGESTED}
+     * — переводит в {@link SuggestionStatus#DISMISSED}. Повторное нажатие — no-op.
+     */
+    @Transactional
+    public ReactionResult dismiss(Long userId, Long suggestionId) {
+        Optional<TransplantSupplySuggestion> optional =
+                suggestionRepository.findByUserIdAndId(userId, suggestionId);
+
+        if (optional.isEmpty()) {
+            return ReactionResult.NOT_FOUND;
+        }
+
+        TransplantSupplySuggestion suggestion = optional.get();
+
+        if (suggestion.getStatus() != SuggestionStatus.SUGGESTED) {
+            return ReactionResult.ALREADY_HANDLED;
+        }
+
+        suggestion.markDismissed(nowUtc());
+
+        log.info("Transplant suggestion {} of user {} dismissed", suggestionId, userId);
+
+        return ReactionResult.OK;
+    }
+
+    /** Текст расходников для подстановки в шаблон нотификации. */
+    public String suppliesLabel() {
+        return String.join(", ", properties.supplies());
+    }
+
+    /** Готовый текст нотификации по шаблону из конфига. */
+    public String buildMessageText(String plantName) {
+        return String.format(properties.messageTemplate(), plantName, suppliesLabel());
+    }
+
+    /**
+     * Попадает ли предстоящая пересадка в окно {@code [today; today + horizonDays]}
+     * в TZ юзера. {@code predicted} и {@code now} — в UTC (event_date хранится
+     * как UTC wall-clock LocalDateTime, см. issue #76). Сравнение ведём по
+     * локальным датам в TZ юзера, чтобы граница «скоро» совпадала с восприятием
+     * юзера, а не с границей суток UTC.
+     */
+    private boolean isWithinHorizon(LocalDateTime predicted, Instant now, User user) {
+        ZoneId zone = safeZone(user.getTimezone());
+        LocalDate today = now.atZone(zone).toLocalDate();
+        LocalDate windowEnd = today.plusDays(properties.horizonDays());
+
+        // predicted — UTC wall-clock; приводим к локальной дате юзера через UTC.
+        LocalDate predictedLocalDate = predicted.atZone(ZoneOffset.UTC)
+                .withZoneSameInstant(zone)
+                .toLocalDate();
+
+        return !predictedLocalDate.isBefore(today) && !predictedLocalDate.isAfter(windowEnd);
+    }
+
+    private LocalDateTime nowUtc() {
+        return LocalDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
+    }
+
+    private static ZoneId safeZone(String tz) {
+        if (tz == null || tz.isBlank()) return ZoneOffset.UTC;
+        try {
+            return ZoneId.of(tz);
+        } catch (Exception e) {
+            return ZoneOffset.UTC;
+        }
+    }
+
+    /**
+     * DTO с готовыми данными для одной подсказки. record — чтобы шедулер
+     * использовал поля напрямую, без лазания в entity с закрытой JPA-сессией.
+     */
+    public record DueSuggestion(
+            Long userId,
+            Long telegramChatId,
+            Long plantId,
+            String plantName,
+            Long sourceEventId,
+            LocalDateTime predictedTransplantAt
+    ) {
+    }
+
+    /** Результат реакции на кнопку — для маппинга в ответ юзеру в Telegram-слое. */
+    public enum ReactionResult {
+        /** Действие применено (добавлено в список / отклонено). */
+        OK,
+        /** Подсказка уже обработана ранее — идемпотентный повтор. */
+        ALREADY_HANDLED,
+        /** Подсказка не найдена (или принадлежит другому юзеру). */
+        NOT_FOUND
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -111,6 +111,19 @@ plants:
       # Для более агрессивного мониторинга можно поставить PT3M (3 пропуска).
       max-tick-age: ${PLANTS_SCHEDULER_MAX_TICK_AGE:PT15M}
 
+  # Issue #141: подсказка расходников перед предстоящей пересадкой.
+  # «Предстоящая пересадка» = дата последней TRANSPLANT из журнала (#76) + interval-months.
+  # Если она в окне ближайших horizon-days (в TZ юзера) — бот шлёт мягкую нотификацию
+  # с кнопками «➕ В список покупок» / «Не нужно».
+  transplant-suggestion:
+    enabled: ${PLANTS_TRANSPLANT_SUGGESTION_ENABLED:true}
+    horizon-days: ${PLANTS_TRANSPLANT_SUGGESTION_HORIZON_DAYS:14}
+    interval-months: ${PLANTS_TRANSPLANT_SUGGESTION_INTERVAL_MONTHS:12}
+    supplies:
+      - Грунт
+      - Дренаж
+    message-template: "🪴 Растению «%s» скоро пересадка — добавить расходники (%s) в список покупок?"
+
 # Telegram (placeholder, используется со следующей задачи)
 telegram:
   bot:

--- a/src/main/resources/db/migration/V30__create_transplant_supply_suggestions.sql
+++ b/src/main/resources/db/migration/V30__create_transplant_supply_suggestions.sql
@@ -1,0 +1,91 @@
+-- V30__create_transplant_supply_suggestions.sql
+-- Issue #141: подсказка «добавить расходники перед пересадкой».
+--
+-- Раз в день шедулер вычисляет предстоящую пересадку как
+--   (дата последнего события TRANSPLANT из plant_events) + интервал из конфига
+-- и шлёт пользователю мягкую нотификацию с кнопками
+--   «➕ В список покупок» / «Не нужно».
+--
+-- Эта таблица — трекер идемпотентности подсказок:
+--   * не дать слать повторно по одному и тому же предстоящему событию;
+--   * не дать дублировать товары в shopping_items при повторном нажатии кнопки.
+--
+-- Ключ идемпотентности — source_event_id: это id записи TRANSPLANT в
+-- plant_events, от которой посчитана предстоящая пересадка. Появилась новая
+-- пересадка → новый source_event_id → можно подсказать снова. UNIQUE на
+-- (user_id, plant_id, source_event_id) фиксирует эту гарантию на уровне БД:
+-- шедулер перед отправкой пытается INSERT, конфликт UNIQUE = «уже подсказывали».
+--
+-- status:
+--   SUGGESTED  — нотификация отправлена, ждём реакции юзера;
+--   ADDED      — юзер нажал «В список покупок», позиции добавлены в shopping_items;
+--   DISMISSED  — юзер нажал «Не нужно».
+--
+-- Backward-compat note:
+--   * Новая таблица — для старого кода невидима (аддитивно, один релиз).
+--   * id маппится JPA как GenerationType.IDENTITY → BIGSERIAL.
+--   * created_at маппится @CreationTimestamp → TIMESTAMPTZ (UTC), как в остальных таблицах.
+--   * ON DELETE CASCADE на user_id / plant_id / source_event_id: при удалении
+--     пользователя, растения или самого события пересадки трекер уезжает вместе
+--     с ними — это ок, id не переиспользуются, висячих подсказок не остаётся.
+--   * Безопасно для rolling deploy. Только DDL, без сидинга.
+
+BEGIN;
+
+CREATE TABLE transplant_supply_suggestions (
+    id                      BIGSERIAL    PRIMARY KEY,
+    user_id                 BIGINT       NOT NULL REFERENCES users(id)        ON DELETE CASCADE,
+    plant_id                BIGINT       NOT NULL REFERENCES plants(id)       ON DELETE CASCADE,
+    source_event_id         BIGINT       NOT NULL REFERENCES plant_events(id) ON DELETE CASCADE,
+    status                  VARCHAR(16)  NOT NULL,
+    predicted_transplant_at TIMESTAMPTZ  NOT NULL,
+    created_at              TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    responded_at            TIMESTAMPTZ,
+
+    CONSTRAINT chk_transplant_supply_suggestion_status
+        CHECK (status IN ('SUGGESTED', 'ADDED', 'DISMISSED')),
+
+    CONSTRAINT uq_transplant_supply_suggestion_event
+        UNIQUE (user_id, plant_id, source_event_id)
+);
+
+COMMENT ON TABLE transplant_supply_suggestions IS
+    'Трекер идемпотентности подсказок расходников перед пересадкой (issue #141): '
+        'по строке на (user_id, plant_id, source_event_id). Шедулер перед '
+        'отправкой пытается INSERT — конфликт UNIQUE означает «уже подсказывали '
+        'по этой предстоящей пересадке».';
+
+COMMENT ON COLUMN transplant_supply_suggestions.source_event_id IS
+    'id записи TRANSPLANT в plant_events, от которой посчитана предстоящая '
+        'пересадка. Ключ идемпотентности: новая пересадка → новый source_event_id '
+        '→ можно подсказать снова.';
+
+COMMENT ON COLUMN transplant_supply_suggestions.status IS
+    'SUGGESTED — нотификация отправлена, ждём реакции; ADDED — юзер добавил в '
+        'список покупок; DISMISSED — юзер нажал «не нужно».';
+
+COMMENT ON COLUMN transplant_supply_suggestions.predicted_transplant_at IS
+    'Вычисленная дата предстоящей пересадки (last TRANSPLANT + интервал из конфига) '
+        'в UTC (TIMESTAMPTZ). Для аудита/отладки расчёта шедулера.';
+
+COMMENT ON COLUMN transplant_supply_suggestions.created_at IS
+    'Момент создания строки (= момент отправки нотификации) в UTC (TIMESTAMPTZ).';
+
+COMMENT ON COLUMN transplant_supply_suggestions.responded_at IS
+    'Момент нажатия кнопки юзером в UTC (TIMESTAMPTZ). NULL, пока статус SUGGESTED.';
+
+-- Основной запрос: «активные подсказки юзера, ждущие реакции».
+--   SELECT ... WHERE user_id = :uid AND status = 'SUGGESTED'
+-- Покрывает и FK user_id.
+CREATE INDEX idx_transplant_supply_suggestions_user_status
+    ON transplant_supply_suggestions (user_id, status);
+
+-- FK plant_id и source_event_id под ON DELETE CASCADE и под обратный поиск
+-- «подсказывали ли уже по этому событию». Postgres не индексирует FK сам.
+CREATE INDEX idx_transplant_supply_suggestions_plant
+    ON transplant_supply_suggestions (plant_id);
+
+CREATE INDEX idx_transplant_supply_suggestions_source_event
+    ON transplant_supply_suggestions (source_event_id);
+
+COMMIT;

--- a/src/test/java/com/plantcare/bot/beans/PlantsCareBotTest.java
+++ b/src/test/java/com/plantcare/bot/beans/PlantsCareBotTest.java
@@ -60,6 +60,8 @@ class PlantsCareBotTest {
     private MenuCallbackService menuCallbackService;
     @Mock
     private DiseaseMenuService diseaseMenuService;
+    @Mock
+    private com.plantcare.bot.service.TransplantSuggestionCallbackService transplantSuggestionCallbackService;
 
     private PlantsCareBot bot;
 
@@ -76,7 +78,8 @@ class PlantsCareBotTest {
                 notificationCallbackService,
                 notificationDigestCallbackService,
                 menuCallbackService,
-                diseaseMenuService
+                diseaseMenuService,
+                transplantSuggestionCallbackService
         );
     }
 

--- a/src/test/java/com/plantcare/bot/service/TransplantSuggestionSchedulerTest.java
+++ b/src/test/java/com/plantcare/bot/service/TransplantSuggestionSchedulerTest.java
@@ -1,0 +1,217 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.config.TransplantSuggestionProperties;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.repository.UserRepository;
+import com.plantcare.bot.service.TransplantSuggestionService.DueSuggestion;
+import com.plantcare.bot.telegram.RateLimitedTelegramSender;
+import com.plantcare.bot.telegram.SendCallbacks;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit-тесты {@link TransplantSuggestionScheduler} (issue #141): оркестрация
+ * выборки кандидатов → фиксации трекера → постановки нотификации в rate-limited
+ * очередь. Окно горизонта и идемпотентность создания на уровне БД проверяются в
+ * {@link TransplantSuggestionServiceTest} (Testcontainers); здесь мокаем сервис и
+ * внешний мир (Telegram), проверяем именно поведение шедулера.
+ *
+ * <p>Telegram — внешний API, мокается. Идемпотентность шедулера: если
+ * {@code recordSuggested} вернул empty (строку уже создал параллельный тик),
+ * сообщение НЕ ставится в очередь.
+ */
+@DisplayName("TransplantSuggestionScheduler — оркестрация отправки (issue #141)")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TransplantSuggestionSchedulerTest {
+
+    @Mock private TransplantSuggestionService suggestionService;
+    @Mock private QuietHoursPolicy quietHoursPolicy;
+    @Mock private UserRepository userRepository;
+    @Mock private RateLimitedTelegramSender telegramSender;
+
+    private static final Instant NOW = Instant.parse("2026-05-25T09:00:00Z");
+
+    private TransplantSuggestionScheduler newScheduler(TransplantSuggestionProperties props) {
+        return new TransplantSuggestionScheduler(
+                suggestionService,
+                props,
+                quietHoursPolicy,
+                userRepository,
+                telegramSender,
+                Clock.fixed(NOW, ZoneOffset.UTC));
+    }
+
+    private static TransplantSuggestionProperties enabledProps() {
+        return new TransplantSuggestionProperties(true, 14, 12, null, null);
+    }
+
+    @Test
+    @DisplayName("should_record_and_enqueue_message_when_candidate_due_and_not_quiet")
+    void should_record_and_enqueue_message_when_candidate_due_and_not_quiet() {
+        // arrange
+        TransplantSuggestionScheduler scheduler = newScheduler(enabledProps());
+        DueSuggestion candidate = dueSuggestion(1L, 555L, 42L, "Фикус", 77L);
+        when(suggestionService.findDueSuggestions(NOW)).thenReturn(List.of(candidate));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(notBlockedUser()));
+        when(quietHoursPolicy.isQuiet(any(User.class), eq(NOW))).thenReturn(false);
+        when(suggestionService.recordSuggested(candidate)).thenReturn(Optional.of(999L));
+        when(suggestionService.buildMessageText("Фикус")).thenReturn("текст про Фикус");
+
+        // act
+        scheduler.tick();
+
+        // assert: трекер зафиксирован ДО постановки в очередь, сообщение ушло на нужный чат
+        verify(suggestionService).recordSuggested(candidate);
+        ArgumentCaptor<SendMessage> messageCaptor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramSender, times(1)).enqueue(messageCaptor.capture(), any(SendCallbacks.class));
+        assertThat(messageCaptor.getValue().getChatId()).isEqualTo("555");
+        assertThat(messageCaptor.getValue().getText()).isEqualTo("текст про Фикус");
+    }
+
+    @Test
+    @DisplayName("should_not_enqueue_when_recordSuggested_returns_empty_due_to_race")
+    void should_not_enqueue_when_recordSuggested_returns_empty_due_to_race() {
+        // arrange: параллельный тик уже создал строку → recordSuggested вернул empty.
+        TransplantSuggestionScheduler scheduler = newScheduler(enabledProps());
+        DueSuggestion candidate = dueSuggestion(1L, 555L, 42L, "Фикус", 77L);
+        when(suggestionService.findDueSuggestions(NOW)).thenReturn(List.of(candidate));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(notBlockedUser()));
+        when(quietHoursPolicy.isQuiet(any(User.class), eq(NOW))).thenReturn(false);
+        when(suggestionService.recordSuggested(candidate)).thenReturn(Optional.empty());
+
+        // act
+        scheduler.tick();
+
+        // assert: ничего не шлём — иначе кнопки уехали бы с чужим id
+        verify(telegramSender, never()).enqueue(any(SendMessage.class), any(SendCallbacks.class));
+    }
+
+    @Test
+    @DisplayName("should_not_enqueue_when_user_in_quiet_hours")
+    void should_not_enqueue_when_user_in_quiet_hours() {
+        // arrange
+        TransplantSuggestionScheduler scheduler = newScheduler(enabledProps());
+        DueSuggestion candidate = dueSuggestion(1L, 555L, 42L, "Фикус", 77L);
+        when(suggestionService.findDueSuggestions(NOW)).thenReturn(List.of(candidate));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(notBlockedUser()));
+        when(quietHoursPolicy.isQuiet(any(User.class), eq(NOW))).thenReturn(true);
+
+        // act
+        scheduler.tick();
+
+        // assert: тихие часы — мягкую подсказку не шлём и трекер не создаём
+        verify(suggestionService, never()).recordSuggested(any());
+        verifyNoInteractions(telegramSender);
+    }
+
+    @Test
+    @DisplayName("should_treat_missing_user_as_quiet_and_skip")
+    void should_treat_missing_user_as_quiet_and_skip() {
+        // arrange: юзер исчез между выборкой и отправкой → считаем «тихо», не шлём.
+        TransplantSuggestionScheduler scheduler = newScheduler(enabledProps());
+        DueSuggestion candidate = dueSuggestion(1L, 555L, 42L, "Фикус", 77L);
+        when(suggestionService.findDueSuggestions(NOW)).thenReturn(List.of(candidate));
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // act
+        scheduler.tick();
+
+        // assert
+        verify(suggestionService, never()).recordSuggested(any());
+        verifyNoInteractions(telegramSender);
+    }
+
+    @Test
+    @DisplayName("should_do_nothing_when_no_candidates")
+    void should_do_nothing_when_no_candidates() {
+        // arrange
+        TransplantSuggestionScheduler scheduler = newScheduler(enabledProps());
+        when(suggestionService.findDueSuggestions(NOW)).thenReturn(List.of());
+
+        // act
+        scheduler.tick();
+
+        // assert
+        verifyNoInteractions(telegramSender);
+        verify(suggestionService, never()).recordSuggested(any());
+    }
+
+    @Test
+    @DisplayName("should_skip_feature_entirely_when_disabled")
+    void should_skip_feature_entirely_when_disabled() {
+        // arrange: enabled=false → шедулер даже не дёргает сервис.
+        TransplantSuggestionProperties disabled =
+                new TransplantSuggestionProperties(false, 14, 12, null, null);
+        TransplantSuggestionScheduler scheduler = newScheduler(disabled);
+
+        // act
+        scheduler.tick();
+
+        // assert
+        verifyNoInteractions(suggestionService, telegramSender, userRepository, quietHoursPolicy);
+    }
+
+    @Test
+    @DisplayName("should_continue_other_candidates_when_one_throws")
+    void should_continue_other_candidates_when_one_throws() {
+        // arrange: первый кандидат падает на recordSuggested, второй обрабатывается норм.
+        TransplantSuggestionScheduler scheduler = newScheduler(enabledProps());
+        DueSuggestion bad = dueSuggestion(1L, 111L, 42L, "Плохой", 77L);
+        DueSuggestion good = dueSuggestion(2L, 222L, 43L, "Хороший", 78L);
+        when(suggestionService.findDueSuggestions(NOW)).thenReturn(List.of(bad, good));
+        when(userRepository.findById(any())).thenReturn(Optional.of(notBlockedUser()));
+        when(quietHoursPolicy.isQuiet(any(User.class), eq(NOW))).thenReturn(false);
+        when(suggestionService.recordSuggested(bad)).thenThrow(new RuntimeException("boom"));
+        when(suggestionService.recordSuggested(good)).thenReturn(Optional.of(999L));
+        when(suggestionService.buildMessageText("Хороший")).thenReturn("текст про Хороший");
+
+        // act
+        scheduler.tick();
+
+        // assert: несмотря на падение первого, второй ушёл в очередь
+        ArgumentCaptor<SendMessage> messageCaptor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramSender, times(1)).enqueue(messageCaptor.capture(), any(SendCallbacks.class));
+        assertThat(messageCaptor.getValue().getChatId()).isEqualTo("222");
+    }
+
+    // ===================== helpers =====================
+
+    private static DueSuggestion dueSuggestion(
+            Long userId, Long chatId, Long plantId, String plantName, Long sourceEventId) {
+        return new DueSuggestion(
+                userId,
+                chatId,
+                plantId,
+                plantName,
+                sourceEventId,
+                LocalDateTime.of(2026, 6, 1, 12, 0));
+    }
+
+    private static User notBlockedUser() {
+        return User.builder().telegramChatId(555L).timezone("UTC").blocked(false).build();
+    }
+}

--- a/src/test/java/com/plantcare/bot/service/TransplantSuggestionServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/TransplantSuggestionServiceTest.java
@@ -1,0 +1,561 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.bot.domain.Location;
+import com.plantcare.bot.domain.Plant;
+import com.plantcare.bot.domain.PlantEvent;
+import com.plantcare.bot.domain.ShoppingItem;
+import com.plantcare.bot.domain.TransplantSupplySuggestion;
+import com.plantcare.bot.domain.User;
+import com.plantcare.bot.domain.enums.PlantEventType;
+import com.plantcare.bot.domain.enums.SuggestionStatus;
+import com.plantcare.bot.repository.LocationRepository;
+import com.plantcare.bot.repository.PlantEventRepository;
+import com.plantcare.bot.repository.PlantRepository;
+import com.plantcare.bot.repository.ShoppingItemRepository;
+import com.plantcare.bot.repository.TransplantSupplySuggestionRepository;
+import com.plantcare.bot.repository.UserRepository;
+import com.plantcare.bot.service.TransplantSuggestionService.DueSuggestion;
+import com.plantcare.bot.service.TransplantSuggestionService.ReactionResult;
+import com.plantcare.bot.support.IntegrationTestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Интеграционные тесты {@link TransplantSuggestionService} (issue #141) на реальном
+ * Postgres через Testcontainers. Репозитории не мокаются — проверяем фактический
+ * расчёт горизонта в TZ юзера, идемпотентность создания (UNIQUE) и идемпотентность
+ * реакций на кнопки с записью в shopping_items (issue #136).
+ *
+ * <p>«Предстоящая пересадка» = дата последней TRANSPLANT-записи + intervalMonths
+ * (дефолт 12). Окно «скоро» = predicted-дата в [today; today + horizonDays] (дефолт 14)
+ * в TZ юзера. Конфиг берётся из application.yml (профиль test не переопределяет фичу).
+ */
+@DisplayName("TransplantSuggestionService — подсказка расходников перед пересадкой (issue #141)")
+class TransplantSuggestionServiceTest extends IntegrationTestBase {
+
+    @Autowired private TransplantSuggestionService service;
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private LocationRepository locationRepository;
+    @Autowired private PlantRepository plantRepository;
+    @Autowired private PlantEventRepository plantEventRepository;
+    @Autowired private TransplantSupplySuggestionRepository suggestionRepository;
+    @Autowired private ShoppingItemRepository shoppingItemRepository;
+
+    @AfterEach
+    void cleanup() {
+        suggestionRepository.deleteAll();
+        shoppingItemRepository.deleteAll();
+        plantEventRepository.deleteAll();
+        plantRepository.deleteAll();
+        locationRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ===================== AC: подсказка появляется в горизонте =====================
+
+    @Test
+    @DisplayName("should_return_due_suggestion_when_predicted_transplant_within_horizon")
+    void should_return_due_suggestion_when_predicted_transplant_within_horizon() {
+        // arrange: пересадка год назад минус неделю → predicted = через ~7 дней,
+        // что внутри окна 14 дней.
+        User user = savedUser(3001L, "UTC");
+        Plant plant = savedPlant(user, "Фикус");
+        // now = 2026-05-25 09:00Z; last transplant = 2025-05-18 → +12мес = 2026-05-18?
+        // Нет: хотим predicted внутри [today; today+14]. today=2026-05-25.
+        // predicted = 2026-06-01 (через 7 дней) → last = 2025-06-01.
+        PlantEvent transplant = savedTransplant(plant, LocalDateTime.of(2025, 6, 1, 12, 0));
+
+        Instant now = Instant.parse("2026-05-25T09:00:00Z");
+
+        // act
+        List<DueSuggestion> due = service.findDueSuggestions(now);
+
+        // assert
+        assertThat(due).hasSize(1);
+        DueSuggestion s = due.get(0);
+        assertThat(s.plantId()).isEqualTo(plant.getId());
+        assertThat(s.plantName()).isEqualTo("Фикус");
+        assertThat(s.sourceEventId()).isEqualTo(transplant.getId());
+        assertThat(s.userId()).isEqualTo(user.getId());
+        assertThat(s.telegramChatId()).isEqualTo(3001L);
+        assertThat(s.predictedTransplantAt()).isEqualTo(LocalDateTime.of(2026, 6, 1, 12, 0));
+    }
+
+    @Test
+    @DisplayName("should_return_due_suggestion_when_predicted_is_exactly_today")
+    void should_return_due_suggestion_when_predicted_is_exactly_today() {
+        // arrange: граница «слева» — predicted ровно сегодня, должно попасть.
+        User user = savedUser(3002L, "UTC");
+        Plant plant = savedPlant(user, "Монстера");
+        savedTransplant(plant, LocalDateTime.of(2025, 5, 25, 8, 0));
+
+        Instant now = Instant.parse("2026-05-25T09:00:00Z");
+
+        // act
+        List<DueSuggestion> due = service.findDueSuggestions(now);
+
+        // assert
+        assertThat(due).hasSize(1);
+        assertThat(due.get(0).plantId()).isEqualTo(plant.getId());
+    }
+
+    @Test
+    @DisplayName("should_return_due_suggestion_when_predicted_on_last_day_of_horizon")
+    void should_return_due_suggestion_when_predicted_on_last_day_of_horizon() {
+        // arrange: граница «справа» — predicted ровно today+14, должно попасть.
+        User user = savedUser(3003L, "UTC");
+        Plant plant = savedPlant(user, "Замиокулькас");
+        // today=2026-05-25, horizon=14 → windowEnd=2026-06-08. predicted=2026-06-08.
+        savedTransplant(plant, LocalDateTime.of(2025, 6, 8, 12, 0));
+
+        Instant now = Instant.parse("2026-05-25T09:00:00Z");
+
+        // act
+        List<DueSuggestion> due = service.findDueSuggestions(now);
+
+        // assert
+        assertThat(due).hasSize(1);
+        assertThat(due.get(0).plantId()).isEqualTo(plant.getId());
+    }
+
+    // ===================== AC: НЕ появляется вне горизонта / без истории =====================
+
+    @Test
+    @DisplayName("should_not_return_suggestion_when_predicted_beyond_horizon")
+    void should_not_return_suggestion_when_predicted_beyond_horizon() {
+        // arrange: predicted = today+15 (на день дальше окна 14) → не подсказываем.
+        User user = savedUser(3004L, "UTC");
+        Plant plant = savedPlant(user, "Кактус");
+        savedTransplant(plant, LocalDateTime.of(2025, 6, 9, 12, 0));
+
+        Instant now = Instant.parse("2026-05-25T09:00:00Z");
+
+        // act
+        List<DueSuggestion> due = service.findDueSuggestions(now);
+
+        // assert
+        assertThat(due).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_not_return_suggestion_when_predicted_is_in_the_past")
+    void should_not_return_suggestion_when_predicted_is_in_the_past() {
+        // arrange: predicted = вчера → пропущенная пересадка, не наша забота здесь.
+        User user = savedUser(3005L, "UTC");
+        Plant plant = savedPlant(user, "Просрочка");
+        savedTransplant(plant, LocalDateTime.of(2025, 5, 24, 12, 0));
+
+        Instant now = Instant.parse("2026-05-25T09:00:00Z");
+
+        // act
+        List<DueSuggestion> due = service.findDueSuggestions(now);
+
+        // assert
+        assertThat(due).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_not_return_suggestion_when_plant_has_no_transplant_history")
+    void should_not_return_suggestion_when_plant_has_no_transplant_history() {
+        // arrange: растение без единой TRANSPLANT-записи (есть другое событие).
+        User user = savedUser(3006L, "UTC");
+        Plant plant = savedPlant(user, "Без пересадок");
+        savedEvent(plant, PlantEventType.PRUNING, LocalDateTime.of(2025, 6, 1, 12, 0));
+
+        Instant now = Instant.parse("2026-05-25T09:00:00Z");
+
+        // act
+        List<DueSuggestion> due = service.findDueSuggestions(now);
+
+        // assert
+        assertThat(due).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_not_return_suggestion_when_plant_is_archived")
+    void should_not_return_suggestion_when_plant_is_archived() {
+        // arrange: пересадка в горизонте, но растение в архиве → исключаем.
+        User user = savedUser(3007L, "UTC");
+        Plant plant = savedPlant(user, "Архивный фикус");
+        savedTransplant(plant, LocalDateTime.of(2025, 6, 1, 12, 0));
+        plant.setArchivedAt(LocalDateTime.now().truncatedTo(ChronoUnit.MICROS));
+        plantRepository.save(plant);
+
+        Instant now = Instant.parse("2026-05-25T09:00:00Z");
+
+        // act
+        List<DueSuggestion> due = service.findDueSuggestions(now);
+
+        // assert
+        assertThat(due).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_use_latest_transplant_when_plant_has_multiple")
+    void should_use_latest_transplant_when_plant_has_multiple() {
+        // arrange: две пересадки. Старая дала бы predicted в прошлом, свежая —
+        // в горизонте. Сервис обязан брать последнюю по event_date.
+        User user = savedUser(3008L, "UTC");
+        Plant plant = savedPlant(user, "Часто пересаживаемый");
+        savedTransplant(plant, LocalDateTime.of(2024, 1, 1, 12, 0));
+        PlantEvent latest = savedTransplant(plant, LocalDateTime.of(2025, 6, 1, 12, 0));
+
+        Instant now = Instant.parse("2026-05-25T09:00:00Z");
+
+        // act
+        List<DueSuggestion> due = service.findDueSuggestions(now);
+
+        // assert
+        assertThat(due).hasSize(1);
+        assertThat(due.get(0).sourceEventId()).isEqualTo(latest.getId());
+    }
+
+    @Test
+    @DisplayName("should_return_single_suggestion_with_latest_id_when_two_transplants_share_event_date")
+    void should_return_single_suggestion_with_latest_id_when_two_transplants_share_event_date() {
+        // arrange: две TRANSPLANT-записи с ИДЕНТИЧНЫМ eventDate (минута в минуту).
+        // predicted = eventDate + 12мес = 2026-06-01 → внутри окна [2026-05-25; 2026-06-08].
+        // Без тай-брейка по id запрос вернул бы обе записи → дубль-подсказка.
+        // С тай-брейком — ровно одна, последняя (с большим id).
+        User user = savedUser(3022L, "UTC");
+        Plant plant = savedPlant(user, "Близнецы по дате");
+        LocalDateTime sameDate = LocalDateTime.of(2025, 6, 1, 12, 0);
+        PlantEvent earlier = savedTransplant(plant, sameDate);
+        PlantEvent later = savedTransplant(plant, sameDate);
+
+        // sanity: даты идентичны, id растут — later строго позже по id
+        assertThat(later.getEventDate()).isEqualTo(earlier.getEventDate());
+        assertThat(later.getId()).isGreaterThan(earlier.getId());
+
+        Instant now = Instant.parse("2026-05-25T09:00:00Z");
+
+        // act
+        List<DueSuggestion> due = service.findDueSuggestions(now);
+
+        // assert: ровно одна подсказка, source — запись с большим id
+        assertThat(due).hasSize(1);
+        DueSuggestion s = due.get(0);
+        assertThat(s.plantId()).isEqualTo(plant.getId());
+        assertThat(s.sourceEventId()).isEqualTo(later.getId());
+    }
+
+    @Test
+    @DisplayName("should_not_return_suggestion_when_user_is_blocked")
+    void should_not_return_suggestion_when_user_is_blocked() {
+        // arrange
+        User user = savedUser(3009L, "UTC");
+        user.setBlocked(true);
+        userRepository.save(user);
+        Plant plant = savedPlant(user, "Заблокированный юзер");
+        savedTransplant(plant, LocalDateTime.of(2025, 6, 1, 12, 0));
+
+        Instant now = Instant.parse("2026-05-25T09:00:00Z");
+
+        // act
+        List<DueSuggestion> due = service.findDueSuggestions(now);
+
+        // assert
+        assertThat(due).isEmpty();
+    }
+
+    // ===================== AC: граница таймзоны (Asia/Almaty, не-UTC) =====================
+
+    @Test
+    @DisplayName("should_return_suggestion_in_almaty_zone_when_utc_date_is_still_before_horizon")
+    void should_return_suggestion_in_almaty_zone_when_utc_date_is_still_before_horizon() {
+        // arrange: юзер в Asia/Almaty (UTC+5). now = 2026-05-25 20:00Z, в Алматы это
+        // уже 2026-05-26 01:00 → today(Almaty)=2026-05-26, windowEnd=2026-06-09.
+        // В UTC же today=2026-05-25, windowEnd=2026-06-08.
+        // predicted = 2026-06-09 12:00Z → локальная дата в Almaty = 2026-06-09 (= windowEnd,
+        // попадает), а в UTC это 2026-06-09 (за окном 2026-06-08, НЕ попало бы).
+        // Тест доказывает, что расчёт ведётся в TZ юзера, а не в UTC.
+        User user = savedUser(3010L, "Asia/Almaty");
+        Plant plant = savedPlant(user, "Алматинский фикус");
+        PlantEvent transplant = savedTransplant(plant, LocalDateTime.of(2025, 6, 9, 12, 0));
+
+        Instant now = Instant.parse("2026-05-25T20:00:00Z");
+
+        // sanity: now «завтра» в Алматы и «сегодня» в UTC
+        assertThat(now.atZone(ZoneOffset.UTC).toLocalDate()).isEqualTo(LocalDate.of(2026, 5, 25));
+        assertThat(now.atZone(ZoneId.of("Asia/Almaty")).toLocalDate()).isEqualTo(LocalDate.of(2026, 5, 26));
+
+        // act
+        List<DueSuggestion> due = service.findDueSuggestions(now);
+
+        // assert: подсказка есть именно из-за расчёта в TZ юзера
+        assertThat(due).hasSize(1);
+        assertThat(due.get(0).sourceEventId()).isEqualTo(transplant.getId());
+    }
+
+    @Test
+    @DisplayName("should_not_return_suggestion_in_almaty_zone_when_predicted_already_yesterday_locally")
+    void should_not_return_suggestion_in_almaty_zone_when_predicted_already_yesterday_locally() {
+        // arrange: зеркальный кейс. now = 2026-05-25 20:00Z → today(Almaty)=2026-05-26.
+        // predicted = 2026-05-25 18:00Z → в Almaty это 2026-05-25 23:00 = вчера локально,
+        // уже before today(Almaty)=2026-05-26 → НЕ подсказываем.
+        // В UTC же predicted-дата (2026-05-25) совпала бы с today(UTC)=2026-05-25 и попала бы.
+        User user = savedUser(3011L, "Asia/Almaty");
+        Plant plant = savedPlant(user, "Алматинская монстера");
+        savedTransplant(plant, LocalDateTime.of(2025, 5, 25, 18, 0));
+
+        Instant now = Instant.parse("2026-05-25T20:00:00Z");
+
+        // act
+        List<DueSuggestion> due = service.findDueSuggestions(now);
+
+        // assert
+        assertThat(due).isEmpty();
+    }
+
+    // ===================== AC: идемпотентность создания (UNIQUE) =====================
+
+    @Test
+    @DisplayName("should_return_empty_when_recordSuggested_called_twice_for_same_event")
+    void should_return_empty_when_recordSuggested_called_twice_for_same_event() {
+        // arrange
+        User user = savedUser(3012L, "UTC");
+        Plant plant = savedPlant(user, "Идемпотентный");
+        savedTransplant(plant, LocalDateTime.of(2025, 6, 1, 12, 0));
+        Instant now = Instant.parse("2026-05-25T09:00:00Z");
+
+        DueSuggestion candidate = service.findDueSuggestions(now).get(0);
+
+        // act: первый recordSuggested создаёт строку и возвращает её id.
+        var firstId = service.recordSuggested(candidate);
+
+        // Повтор по тому же source_event нарушает UNIQUE. По контракту метод
+        // ловит конфликт во вложенной REQUIRES_NEW-транзакции и возвращает
+        // Optional.empty() — без выброса TransactionException/UnexpectedRollbackException.
+        var secondId = service.recordSuggested(candidate);
+
+        // assert: первый — present, второй — empty; на уровне БД ровно одна строка.
+        assertThat(firstId).isPresent();
+        assertThat(secondId).isEmpty();
+        assertThat(suggestionRepository.count()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("should_not_offer_already_recorded_suggestion_on_next_tick")
+    void should_not_offer_already_recorded_suggestion_on_next_tick() {
+        // arrange: эмуляция двух тиков шедулера по одному и тому же source_event.
+        User user = savedUser(3013L, "UTC");
+        Plant plant = savedPlant(user, "Два тика");
+        savedTransplant(plant, LocalDateTime.of(2025, 6, 1, 12, 0));
+        Instant now = Instant.parse("2026-05-25T09:00:00Z");
+
+        // tick 1: нашли кандидата и зафиксировали отправку
+        List<DueSuggestion> firstTick = service.findDueSuggestions(now);
+        assertThat(firstTick).hasSize(1);
+        service.recordSuggested(firstTick.get(0));
+
+        // act tick 2: тот же source_event уже отмечен → не возвращается
+        List<DueSuggestion> secondTick = service.findDueSuggestions(now);
+
+        // assert
+        assertThat(secondTick).isEmpty();
+        assertThat(suggestionRepository.count()).isEqualTo(1L);
+    }
+
+    // ===================== AC: идемпотентность кнопки ADD / SKIP =====================
+
+    @Test
+    @DisplayName("should_add_supplies_and_mark_added_when_add_clicked_first_time")
+    void should_add_supplies_and_mark_added_when_add_clicked_first_time() {
+        // arrange
+        User user = savedUser(3014L, "UTC");
+        Plant plant = savedPlant(user, "Покупки");
+        Long suggestionId = savedSuggestion(user, plant);
+
+        // act
+        ReactionResult result = service.addToShoppingList(user.getId(), suggestionId);
+
+        // assert: статус ADDED, товары (Грунт, Дренаж) добавлены в список покупок
+        assertThat(result).isEqualTo(ReactionResult.OK);
+        assertThat(reloadStatus(suggestionId)).isEqualTo(SuggestionStatus.ADDED);
+        assertThat(shoppingItemRepository.findAllByUserIdOrderByCheckedAscCreatedAtAsc(user.getId()))
+                .extracting(ShoppingItem::getTitle)
+                .containsExactlyInAnyOrder("Грунт", "Дренаж");
+    }
+
+    @Test
+    @DisplayName("should_not_duplicate_supplies_when_add_clicked_twice")
+    void should_not_duplicate_supplies_when_add_clicked_twice() {
+        // arrange
+        User user = savedUser(3015L, "UTC");
+        Plant plant = savedPlant(user, "Двойной тап");
+        Long suggestionId = savedSuggestion(user, plant);
+
+        // act: повторное нажатие — идемпотентный no-op
+        ReactionResult first = service.addToShoppingList(user.getId(), suggestionId);
+        ReactionResult second = service.addToShoppingList(user.getId(), suggestionId);
+
+        // assert: первое OK, второе ALREADY_HANDLED, товаров по-прежнему ровно 2, статус ADDED
+        assertThat(first).isEqualTo(ReactionResult.OK);
+        assertThat(second).isEqualTo(ReactionResult.ALREADY_HANDLED);
+        assertThat(reloadStatus(suggestionId)).isEqualTo(SuggestionStatus.ADDED);
+        assertThat(shoppingItemRepository.findAllByUserIdOrderByCheckedAscCreatedAtAsc(user.getId()))
+                .extracting(ShoppingItem::getTitle)
+                .containsExactlyInAnyOrder("Грунт", "Дренаж");
+    }
+
+    @Test
+    @DisplayName("should_mark_dismissed_when_skip_clicked_and_not_add_supplies")
+    void should_mark_dismissed_when_skip_clicked_and_not_add_supplies() {
+        // arrange
+        User user = savedUser(3016L, "UTC");
+        Plant plant = savedPlant(user, "Не нужно");
+        Long suggestionId = savedSuggestion(user, plant);
+
+        // act
+        ReactionResult result = service.dismiss(user.getId(), suggestionId);
+
+        // assert
+        assertThat(result).isEqualTo(ReactionResult.OK);
+        assertThat(reloadStatus(suggestionId)).isEqualTo(SuggestionStatus.DISMISSED);
+        assertThat(shoppingItemRepository.findAllByUserIdOrderByCheckedAscCreatedAtAsc(user.getId()))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_be_noop_when_dismiss_clicked_twice")
+    void should_be_noop_when_dismiss_clicked_twice() {
+        // arrange
+        User user = savedUser(3017L, "UTC");
+        Plant plant = savedPlant(user, "Двойной skip");
+        Long suggestionId = savedSuggestion(user, plant);
+
+        // act
+        ReactionResult first = service.dismiss(user.getId(), suggestionId);
+        ReactionResult second = service.dismiss(user.getId(), suggestionId);
+
+        // assert: статус остаётся DISMISSED, повтор no-op
+        assertThat(first).isEqualTo(ReactionResult.OK);
+        assertThat(second).isEqualTo(ReactionResult.ALREADY_HANDLED);
+        assertThat(reloadStatus(suggestionId)).isEqualTo(SuggestionStatus.DISMISSED);
+    }
+
+    @Test
+    @DisplayName("should_not_add_supplies_when_add_clicked_after_dismiss")
+    void should_not_add_supplies_when_add_clicked_after_dismiss() {
+        // arrange: сначала отклонили, потом по запоздавшему callback пришёл ADD.
+        User user = savedUser(3018L, "UTC");
+        Plant plant = savedPlant(user, "Сначала skip потом add");
+        Long suggestionId = savedSuggestion(user, plant);
+        service.dismiss(user.getId(), suggestionId);
+
+        // act
+        ReactionResult result = service.addToShoppingList(user.getId(), suggestionId);
+
+        // assert: статус не SUGGESTED → no-op, товары не добавлены, статус остаётся DISMISSED
+        assertThat(result).isEqualTo(ReactionResult.ALREADY_HANDLED);
+        assertThat(reloadStatus(suggestionId)).isEqualTo(SuggestionStatus.DISMISSED);
+        assertThat(shoppingItemRepository.findAllByUserIdOrderByCheckedAscCreatedAtAsc(user.getId()))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_return_not_found_when_suggestion_belongs_to_another_user")
+    void should_return_not_found_when_suggestion_belongs_to_another_user() {
+        // arrange: подсказка юзера A, по ней дёргает юзер B (подделанный callback_data).
+        User owner = savedUser(3019L, "UTC");
+        User attacker = savedUser(3020L, "UTC");
+        Plant plant = savedPlant(owner, "Чужая подсказка");
+        Long suggestionId = savedSuggestion(owner, plant);
+
+        // act
+        ReactionResult result = service.addToShoppingList(attacker.getId(), suggestionId);
+
+        // assert: чужую строку не тронули
+        assertThat(result).isEqualTo(ReactionResult.NOT_FOUND);
+        assertThat(reloadStatus(suggestionId)).isEqualTo(SuggestionStatus.SUGGESTED);
+        assertThat(shoppingItemRepository.findAllByUserIdOrderByCheckedAscCreatedAtAsc(attacker.getId()))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_return_not_found_when_suggestion_does_not_exist")
+    void should_return_not_found_when_suggestion_does_not_exist() {
+        // arrange
+        User user = savedUser(3021L, "UTC");
+
+        // act
+        ReactionResult result = service.addToShoppingList(user.getId(), 999_999L);
+
+        // assert
+        assertThat(result).isEqualTo(ReactionResult.NOT_FOUND);
+    }
+
+    // ===================== helpers =====================
+
+    private User savedUser(Long chatId, String timezone) {
+        return userRepository.save(User.builder()
+                .telegramChatId(chatId)
+                .timezone(timezone)
+                .blocked(false)
+                .build());
+    }
+
+    private Location savedDefaultLocation(User user) {
+        return locationRepository.findByUserIdAndDefaultLocationTrue(user.getId())
+                .orElseGet(() -> locationRepository.save(Location.builder()
+                        .user(user)
+                        .name(Location.DEFAULT_NAME)
+                        .emoji(Location.DEFAULT_EMOJI)
+                        .defaultLocation(true)
+                        .build()));
+    }
+
+    private Plant savedPlant(User user, String name) {
+        return plantRepository.save(Plant.builder()
+                .user(user)
+                .location(savedDefaultLocation(user))
+                .name(name)
+                .acquiredAt(LocalDate.of(2024, 1, 1))
+                .build());
+    }
+
+    private PlantEvent savedTransplant(Plant plant, LocalDateTime eventDate) {
+        return savedEvent(plant, PlantEventType.TRANSPLANT, eventDate);
+    }
+
+    private PlantEvent savedEvent(Plant plant, PlantEventType type, LocalDateTime eventDate) {
+        return plantEventRepository.save(PlantEvent.builder()
+                .plant(plant)
+                .eventType(type)
+                .eventDate(eventDate)
+                .build());
+    }
+
+    /** Создаёт SUGGESTED-подсказку через сервис (как сделал бы шедулер). */
+    private Long savedSuggestion(User user, Plant plant) {
+        PlantEvent transplant = savedTransplant(plant, LocalDateTime.of(2025, 6, 1, 12, 0));
+        DueSuggestion candidate = new DueSuggestion(
+                user.getId(),
+                user.getTelegramChatId(),
+                plant.getId(),
+                plant.getName(),
+                transplant.getId(),
+                LocalDateTime.of(2026, 6, 1, 12, 0)
+        );
+        return service.recordSuggested(candidate).orElseThrow();
+    }
+
+    private SuggestionStatus reloadStatus(Long suggestionId) {
+        return suggestionRepository.findById(suggestionId)
+                .map(TransplantSupplySuggestion::getStatus)
+                .orElseThrow();
+    }
+}


### PR DESCRIPTION
Closes #141

## Что сделано
- Шедулер `TransplantSuggestionScheduler` (cron `0 0 9 * * *` UTC) раз в день вычисляет «предстоящую пересадку» как **дату последней `TRANSPLANT` из журнала `plant_events` (#76) + `interval-months`** (дефолт 12). Если она попадает в горизонт `horizon-days` (дефолт 14) в **таймзоне пользователя** и вне quiet hours — отправляется мягкая нотификация с кнопками «➕ В список покупок» / «Не нужно».
- Нажатие «В список покупок» добавляет расходники (дефолт «Грунт», «Дренаж») в `shopping_items` (#136). Идемпотентно: повторное нажатие не дублирует товары (статусный переход `SUGGESTED→ADDED`), повторное срабатывание шедулера по тому же событию не дублирует подсказку (UNIQUE `(user_id, plant_id, source_event_id)` + вставка трекера в `REQUIRES_NEW`-транзакции, конфликт → no-op).
- Подсказка появляется **только** для растений, у которых уже есть пересадка в журнале (источника «запланированной» пересадки в системе нет — см. ниже).
- Конфиг через `@ConfigurationProperties` (`plants.transplant-suggestion.*`): `enabled`, `horizon-days`, `interval-months`, `supplies`, `message-template`.

## Решение по источнику «пересадки» (важно для ревью)
Issue предполагал источник «запланированная пересадка из #76», но `plant_events` хранит **только свершившиеся** события — будущих/запланированных пересадок в системе нет (`TaskType` тоже без `TRANSPLANT`, ADR-004). Из вариантов выбран **A**: предстоящая пересадка = последняя `TRANSPLANT` + интервал из конфига, без изменения схемы пересадок. Канал — отдельная мягкая нотификация (не дайджест #50). Решение согласовано с владельцем.

## Миграции
`V30__create_transplant_supply_suggestions.sql` — таблица-трекер подсказок (`status` SUGGESTED/ADDED/DISMISSED, `predicted_transplant_at`, FK на users/plants/plant_events `ON DELETE CASCADE`, UNIQUE `(user_id, plant_id, source_event_id)` = идемпотентность на уровне БД).
> Исходно была `V29`, переименована в `V30` после ребейза на `develop` (там появилась `V29__seed_species_facts` из #132/#131) — коллизию номера ловил reviewer.

## Backward-compat риски
**Safe / один релиз.** Только новая таблица (аддитивно), невидима для старого кода; FK с CASCADE, без бэкфила и сидинга. Безопасно для rolling deploy.

## Тесты
`env TESTCONTAINERS_REUSE_ENABLE=false mvn verify` — **зелёное, 1233 теста, 0 failures** (чистый Testcontainers Postgres). Покрыто:
- `TransplantSuggestionServiceTest` (21): горизонт (внутри/границы/вне), нет истории пересадок, архивное растение, заблокированный юзер; **граница таймзоны Asia/Almaty** (два зеркальных кейса на стыке суток); идемпотентность создания и кнопок ADD/SKIP; тай-брейк при двух `TRANSPLANT` с идентичным `event_date` (одна подсказка, с бóльшим id).
- `TransplantSuggestionSchedulerTest` (7): отправка/quiet-hours/`enabled=false`/изоляция падения одного кандидата.

## Чек
- [x] `mvn verify` зелёное (1233 теста; чистый контейнер — shared reused на машине загрязнён посторонней V29 соседней ветки)
- [x] reviewer прошёл: 🔴 коллизия миграции V29 → исправлено (rebase + переименование в V30); 🟡 дубль-кандидат при равном `event_date` → исправлен тай-брейком по id; 🟡 гонка двойного ADD → задокументирована (callback'и одного юзера сериализуются единственным поллинг-потоком), без изменения логики

🤖 Generated with [Claude Code](https://claude.com/claude-code)
