### PR TITLE
feat: рекомендация по освещению вида в flow добавления и карточке (#135)

### DIFF
--- a/src/main/java/com/plantcare/bot/service/LightPreferenceText.java
+++ b/src/main/java/com/plantcare/bot/service/LightPreferenceText.java
@@ -1,0 +1,31 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.core.domain.enums.LightPreference;
+
+/**
+ * Presentation-хелпер человекочитаемых фраз освещения по {@link LightPreference}.
+ * Единый источник текста для рекомендации в flow добавления растения (#9)
+ * и для строки в детальной карточке (#26), чтобы не было копипасты.
+ * Presentation-логике не место в core-enum, поэтому фразы живут здесь, в bot-слое.
+ */
+public final class LightPreferenceText {
+
+    private LightPreferenceText() {
+    }
+
+    /**
+     * Человекочитаемая фраза освещения. Для {@code null} возвращает пустую строку,
+     * чтобы вызывающий код не падал и мог безопасно проверить {@code isBlank()}.
+     */
+    public static String phrase(LightPreference preference) {
+        if (preference == null) {
+            return "";
+        }
+        return switch (preference) {
+            case SHADE -> "тень";
+            case PARTIAL -> "полутень, рассеянный свет";
+            case BRIGHT -> "яркий рассеянный свет";
+            case DIRECT -> "прямые солнечные лучи";
+        };
+    }
+}

--- a/src/main/java/com/plantcare/bot/service/PlantCardService.java
+++ b/src/main/java/com/plantcare/bot/service/PlantCardService.java
@@ -1422,6 +1422,9 @@ public class PlantCardService {
             sb.append("\n📝 _").append(escapeMd(plant.getNotes().trim())).append("_\n");
         }
 
+        // issue #135: рекомендация по освещению вида.
+        appendLightLine(sb, plant.getSpecies());
+
         // issue #130: блок токсичности вида. Показываем только флаги == true.
         appendToxicityBlock(sb, plant.getSpecies());
 
@@ -1463,6 +1466,21 @@ public class PlantCardService {
         }
 
         return sb.toString();
+    }
+
+    /**
+     * Дописывает строку освещения вида (issue #135). Показывается только если у вида
+     * задан {@code lightPreference}; для {@code null} строка отсутствует.
+     */
+    private void appendLightLine(StringBuilder sb, com.plantcare.core.domain.Species species) {
+        if (species == null) {
+            return;
+        }
+        String lightPhrase = LightPreferenceText.phrase(species.getLightPreference());
+        if (lightPhrase.isBlank()) {
+            return;
+        }
+        sb.append("\n☀️ Освещение: ").append(lightPhrase).append("\n");
     }
 
     /**

--- a/src/main/java/com/plantcare/bot/service/SpeciesPreviewText.java
+++ b/src/main/java/com/plantcare/bot/service/SpeciesPreviewText.java
@@ -1,0 +1,36 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.core.domain.enums.LightPreference;
+
+/**
+ * Presentation-хелпер превью-сообщения вида в flow добавления растения (#9).
+ * Единый источник текста для двух хендлеров (выбор из популярных и из поиска),
+ * чтобы не дублировать формат «✨ name / Полив... / 💡 ... / Тебе подходит?».
+ */
+public final class SpeciesPreviewText {
+
+    private SpeciesPreviewText() {
+    }
+
+    /**
+     * Собирает превью вида. Строка-рекомендация по освещению добавляется только
+     * если {@code lightPreference != null}; иначе превью остаётся без неё.
+     */
+    public static String build(String speciesName, Integer wateringDays, LightPreference lightPreference) {
+        var wateringText = wateringDays != null
+                ? String.format("Полив: раз в %d дней", wateringDays)
+                : "Полив: по необходимости";
+
+        var sb = new StringBuilder();
+        sb.append("✨ *").append(speciesName).append("*\n\n");
+        sb.append(wateringText);
+
+        var lightPhrase = LightPreferenceText.phrase(lightPreference);
+        if (!lightPhrase.isBlank()) {
+            sb.append("\n💡 Для этого вида лучше: ").append(lightPhrase);
+        }
+
+        sb.append("\n\nТебе подходит?");
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/plantcare/bot/state/impl/AwaitingPlantSpeciesChoiceStateHandler.java
+++ b/src/main/java/com/plantcare/bot/state/impl/AwaitingPlantSpeciesChoiceStateHandler.java
@@ -1,6 +1,8 @@
 package com.plantcare.bot.state.impl;
 
+import com.plantcare.bot.service.SpeciesPreviewText;
 import com.plantcare.core.domain.PlantTemplate;
+import com.plantcare.core.domain.Species;
 import com.plantcare.core.domain.User;
 import com.plantcare.core.domain.enums.ConversationState;
 import com.plantcare.core.service.PlantService;
@@ -85,7 +87,7 @@ public class AwaitingPlantSpeciesChoiceStateHandler implements StateHandler {
                 species -> {
                     Integer interval = species.getWateringDays() != null ? species.getWateringDays() : 7;
                     userService.setStateData(user, "interval_days", interval.toString());
-                    showPreview(user, species.getName(), species.getWateringDays(), client);
+                    showPreview(user, species, client);
                 },
                 () -> sendError(user, client)
         );
@@ -128,21 +130,12 @@ public class AwaitingPlantSpeciesChoiceStateHandler implements StateHandler {
         }
     }
 
-    private void showPreview(User user, String speciesName, Integer wateringDays, TelegramClient client) {
-        String wateringText = wateringDays != null
-                ? String.format("Полив: раз в %d дней", wateringDays)
-                : "Полив: по необходимости";
-
+    private void showPreview(User user, Species species, TelegramClient client) {
         SendMessage message = SendMessage.builder()
                 .chatId(user.getTelegramChatId().toString())
-                .text(String.format(
-                        "✨ *%s*\n\n" +
-                                "%s\n\n" +
-                                "Тебе подходит?",
-                        speciesName, wateringText
-                ))
+                .text(SpeciesPreviewText.build(species.getName(), species.getWateringDays(), species.getLightPreference()))
                 .parseMode("Markdown")
-                .replyMarkup(buildPreviewKeyboard(wateringDays))
+                .replyMarkup(buildPreviewKeyboard(species.getWateringDays()))
                 .build();
         userService.updateState(user, ConversationState.AWAITING_PLANT_WATERING_INTERVAL);
         try {

--- a/src/main/java/com/plantcare/bot/state/impl/AwaitingPlantSpeciesSearchStateHandler.java
+++ b/src/main/java/com/plantcare/bot/state/impl/AwaitingPlantSpeciesSearchStateHandler.java
@@ -1,5 +1,6 @@
 package com.plantcare.bot.state.impl;
 
+import com.plantcare.bot.service.SpeciesPreviewText;
 import com.plantcare.core.domain.Species;
 import com.plantcare.core.domain.User;
 import com.plantcare.core.domain.enums.ConversationState;
@@ -167,22 +168,12 @@ public class AwaitingPlantSpeciesSearchStateHandler implements StateHandler {
 
         plantService.getSpeciesById(speciesId).ifPresentOrElse(
                 species -> {
-                    String wateringText = species.getWateringDays() != null
-                            ? String.format("Полив: раз в %d дней", species.getWateringDays())
-                            : "Полив: по необходимости";
-
                     int interval = species.getWateringDays() != null ? species.getWateringDays() : 7;
                     userService.setStateData(user, "interval_days", Integer.toString(interval));
 
-
                     SendMessage message = SendMessage.builder()
                             .chatId(user.getTelegramChatId().toString())
-                            .text(String.format(
-                                    "✨ *%s*\n\n" +
-                                            "%s\n\n" +
-                                            "Тебе подходит?",
-                                    species.getName(), wateringText
-                            ))
+                            .text(SpeciesPreviewText.build(species.getName(), species.getWateringDays(), species.getLightPreference()))
                             .parseMode("Markdown")
                             .replyMarkup(buildConfirmKeyboard())
                             .build();

--- a/src/test/java/com/plantcare/bot/service/LightPreferenceTextTest.java
+++ b/src/test/java/com/plantcare/bot/service/LightPreferenceTextTest.java
@@ -1,0 +1,51 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.core.domain.enums.LightPreference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Юнит-тесты презентационного хелпера {@link LightPreferenceText} (issue #135).
+ * Чистая presentation-логика без Spring/БД — обычный unit.
+ */
+class LightPreferenceTextTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "SHADE,тень",
+            "PARTIAL,'полутень, рассеянный свет'",
+            "BRIGHT,яркий рассеянный свет",
+            "DIRECT,прямые солнечные лучи"
+    })
+    void should_return_expected_phrase_when_light_preference_given(
+            LightPreference preference, String expected) {
+        // act
+        String phrase = LightPreferenceText.phrase(preference);
+
+        // assert
+        assertThat(phrase).isEqualTo(expected);
+    }
+
+    @Test
+    void should_return_empty_string_when_preference_is_null() {
+        // act
+        String phrase = LightPreferenceText.phrase(null);
+
+        // assert
+        assertThat(phrase).isEmpty();
+    }
+
+    @Test
+    void should_return_non_blank_phrase_for_every_enum_value() {
+        // arrange / act / assert — гарантия, что новый enum-кейс не останется
+        // без текста (switch исчерпывающий, но фраза не должна быть пустой/null)
+        for (LightPreference preference : LightPreference.values()) {
+            assertThat(LightPreferenceText.phrase(preference))
+                    .as("phrase for %s", preference)
+                    .isNotBlank();
+        }
+    }
+}

--- a/src/test/java/com/plantcare/bot/service/PlantCardLightTest.java
+++ b/src/test/java/com/plantcare/bot/service/PlantCardLightTest.java
@@ -1,0 +1,149 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.core.service.CareHistoryService;
+import com.plantcare.core.service.HealthScoreService;
+import com.plantcare.core.service.PlantEventService;
+import com.plantcare.core.service.PlantService;
+import com.plantcare.core.service.SpeciesFactService;
+import com.plantcare.core.service.UserService;
+
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.Species;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.LightPreference;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.seasonal.service.SeasonalIntervalService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * Юнит-тесты строки освещения вида в детальной карточке растения (issue #135,
+ * рендер в {@code buildDetailedCardText}).
+ *
+ * <p>Seam повторяет {@link PlantCardToxicityTest}: приватный метод рендера
+ * тестируется через публичный {@code showPlantCard}, Telegram-клиент мокается,
+ * перехватывается отправленное {@link SendMessage} и инспектируется его текст.
+ * Инкапсуляция не ломается — используем уже принятый в проекте подход.
+ */
+@ExtendWith(MockitoExtension.class)
+class PlantCardLightTest {
+
+    private static final String LIGHT_PREFIX = "☀️ Освещение: ";
+
+    @Mock private PlantService plantService;
+    @Mock private PlantRepository plantRepository;
+    @Mock private com.plantcare.core.repository.CareScheduleRepository careScheduleRepository;
+    @Mock private MainMenuService mainMenuService;
+    @Mock private UserService userService;
+    @Mock private CareHistoryService careHistoryService;
+    @Mock private HealthScoreService healthScoreService;
+    @Mock private PlantEventService plantEventService;
+    @Mock private SpeciesFactService speciesFactService;
+    @Mock private SeasonalIntervalService seasonalIntervalService;
+
+    @Mock private TelegramClient client;
+
+    private PlantCardService cardService;
+
+    @BeforeEach
+    void setUp() {
+        cardService = new PlantCardService(
+                plantService, plantRepository, careScheduleRepository, mainMenuService, userService,
+                careHistoryService, healthScoreService, plantEventService, speciesFactService,
+                seasonalIntervalService);
+
+        // health-score не важен для строки освещения — возвращаем «мало данных».
+        lenient().when(healthScoreService.computeForPlant(any()))
+                .thenReturn(HealthScoreService.HealthScore.insufficient());
+    }
+
+    @Test
+    void should_show_light_line_with_phrase_when_species_has_light_preference() throws Exception {
+        // arrange
+        Species species = givenSpecies(100L);
+        species.setLightPreference(LightPreference.BRIGHT);
+        givenCardFor(species);
+
+        // act
+        cardService.showPlantCard(givenUser(1L, 555L), 10L, null, PlantCardService.BACK_TO_LIST, client);
+
+        // assert
+        assertThat(cardText())
+                .contains(LIGHT_PREFIX + LightPreferenceText.phrase(LightPreference.BRIGHT));
+    }
+
+    @Test
+    void should_not_show_light_line_when_species_light_preference_is_null() throws Exception {
+        // arrange — освещение неизвестно: строки быть не должно
+        Species species = givenSpecies(100L);
+        species.setLightPreference(null);
+        givenCardFor(species);
+
+        // act
+        cardService.showPlantCard(givenUser(1L, 555L), 10L, null, PlantCardService.BACK_TO_LIST, client);
+
+        // assert
+        assertThat(cardText()).doesNotContain(LIGHT_PREFIX);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private void givenCardFor(Species species) {
+        Plant plant = givenPlant(10L, givenUser(1L, 555L), species);
+        lenient().when(plantRepository.findByUserIdAndIdAndArchivedAtIsNull(1L, 10L))
+                .thenReturn(Optional.of(plant));
+        lenient().when(plantService.getActiveSchedules(10L)).thenReturn(List.of());
+    }
+
+    private String cardText() throws Exception {
+        var captor = ArgumentCaptor.forClass(SendMessage.class);
+        org.mockito.Mockito.verify(client).execute(captor.capture());
+        return captor.getValue().getText();
+    }
+
+    private User givenUser(Long id, Long chatId) {
+        var u = User.builder().telegramChatId(chatId).build();
+        setId(u, id);
+        return u;
+    }
+
+    private Species givenSpecies(Long id) {
+        var s = new Species();
+        s.setName("Монстера");
+        setId(s, id);
+        return s;
+    }
+
+    private Plant givenPlant(Long id, User user, Species species) {
+        var p = new Plant();
+        p.setName("Моя монстера");
+        p.setUser(user);
+        p.setSpecies(species);
+        setId(p, id);
+        return p;
+    }
+
+    private static void setId(Object entity, Long id) {
+        try {
+            Field f = com.plantcare.core.domain.base.BaseEntity.class.getDeclaredField("id");
+            f.setAccessible(true);
+            f.set(entity, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/plantcare/bot/service/SpeciesPreviewTextTest.java
+++ b/src/test/java/com/plantcare/bot/service/SpeciesPreviewTextTest.java
@@ -1,0 +1,84 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.core.domain.enums.LightPreference;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Юнит-тесты превью-сообщения вида {@link SpeciesPreviewText} (issue #135 / #9).
+ * Чистая presentation-логика — обычный unit без Spring.
+ */
+class SpeciesPreviewTextTest {
+
+    private static final String LIGHT_PREFIX = "💡 Для этого вида лучше: ";
+
+    @Test
+    void should_include_light_recommendation_when_light_preference_given() {
+        // arrange
+        var light = LightPreference.BRIGHT;
+
+        // act
+        String preview = SpeciesPreviewText.build("Монстера", 7, light);
+
+        // assert
+        assertThat(preview)
+                .contains(LIGHT_PREFIX)
+                .contains(LightPreferenceText.phrase(light))
+                .contains("✨ *Монстера*")
+                .contains("Полив: раз в 7 дней")
+                .contains("Тебе подходит?");
+    }
+
+    @Test
+    void should_omit_light_recommendation_but_stay_valid_when_light_preference_is_null() {
+        // arrange / act — null освещение не должно ломать превью
+        String preview = SpeciesPreviewText.build("Фикус", 5, null);
+
+        // assert
+        assertThat(preview).doesNotContain("💡");
+        assertThat(preview)
+                .contains("✨ *Фикус*")
+                .contains("Полив: раз в 5 дней")
+                .contains("Тебе подходит?");
+    }
+
+    @Test
+    void should_render_watering_by_need_when_watering_days_is_null() {
+        // act
+        String preview = SpeciesPreviewText.build("Кактус", null, LightPreference.DIRECT);
+
+        // assert
+        assertThat(preview)
+                .contains("Полив: по необходимости")
+                .doesNotContain("раз в")
+                .contains(LIGHT_PREFIX + LightPreferenceText.phrase(LightPreference.DIRECT))
+                .contains("Тебе подходит?");
+    }
+
+    @Test
+    void should_render_watering_by_need_and_no_light_when_both_null() {
+        // arrange / act — оба опциональных поля null: минимальное валидное превью
+        String preview = SpeciesPreviewText.build("Неизвестный вид", null, null);
+
+        // assert
+        assertThat(preview)
+                .contains("✨ *Неизвестный вид*")
+                .contains("Полив: по необходимости")
+                .contains("Тебе подходит?")
+                .doesNotContain("💡");
+    }
+
+    @Test
+    void should_use_exact_phrase_from_light_preference_text_for_each_value() {
+        // arrange / act / assert — единый источник текста: фраза в превью совпадает
+        // с LightPreferenceText, чтобы рекомендация не разъезжалась с карточкой
+        for (LightPreference preference : LightPreference.values()) {
+            String preview = SpeciesPreviewText.build("Вид", 3, preference);
+
+            assertThat(preview)
+                    .as("preview for %s", preference)
+                    .contains(LIGHT_PREFIX + LightPreferenceText.phrase(preference));
+        }
+    }
+}


### PR DESCRIPTION
Closes #135

## Что сделано
- Бот показывает рекомендацию по освещению вида при добавлении растения (flow #9): после выбора вида с заданным освещением в превью появляется строка «💡 Для этого вида лучше: <фраза>».
- В детальной карточке растения (#26) появляется строка «☀️ Освещение: <фраза>», если у вида задано освещение.
- При отсутствии данных об освещении (`null`) строки не показываются — flow не ломается.
- Дублирование сборки превью между двумя хендлерами выбора вида устранено (общий `SpeciesPreviewText`).

## ⚠️ Отклонение от формулировки issue (согласовано с владельцем)
Issue просил **новую** колонку `species.light_requirement` + enum `LightRequirement{DIRECT_SUN,BRIGHT_INDIRECT,SHADE}`. Но в `Species` **уже есть** машинно-читаемое поле освещения — `light_preference VARCHAR(16)` (с `V1`, `CHECK chk_light`) + enum `LightPreference{SHADE,PARTIAL,BRIGHT,DIRECT}`, заведённое в admin и api/web. Создавать второй параллельный столбец = второй источник правды.

Решение (одобрено владельцем): **переиспользовать существующий `light_preference`**, реализовать только реально отсутствующую пользовательскую часть (рекомендация в flow + строка в карточке). Поэтому:
- AC про миграцию `V{N}__add_species_light_requirement.sql` и CHECK-констрейнт — **N/A** (схема не меняется).
- AC про enum `LightRequirement` — **N/A** (используется существующий `LightPreference`).
- Простановка значений видам (сид) — вне scope, отдельная задача (как и указано в issue).

## Миграции
Нет (по дизайну — переиспользуется существующая колонка).

## Backward-compat риски
Нет. Изменения чисто presentation-слоя бота; схема БД и публичные API не тронуты.

## Тесты
- `LightPreferenceTextTest` — фразы для всех значений enum + `null`→пусто.
- `SpeciesPreviewTextTest` — превью с освещением/без, варианты `wateringDays`.
- `PlantCardLightTest` — строка освещения в карточке показывается при заданном значении и отсутствует при `null` (seam через `showPlantCard` + `ArgumentCaptor`, как в `PlantCardToxicityTest`).

## Чек
- [x] reviewer прошёл (LGTM, 0 blocking, 0 should-fix; 2 косметических nit — один применён)
- [ ] `mvn verify` локально **не прогонялось**: в офлайн-окружении в `~/.m2` отсутствует `com.tngtech.archunit:archunit-junit5:1.3.0` (новая зависимость с #127, тянет `LayeredArchitectureTest`), Maven Central недоступен. Прод-код компилируется офлайн (`mvn -o compile` зелёный). **Зелёный гейт — на CI.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
