### PR TITLE
tech(metrics): покрыть callback-ветки #118 метриками recordCallback (#126)

### DIFF
--- a/src/main/java/com/plantcare/bot/service/BackdatedCareCallbackService.java
+++ b/src/main/java/com/plantcare/bot/service/BackdatedCareCallbackService.java
@@ -1,5 +1,7 @@
 package com.plantcare.bot.service;
 
+import com.plantcare.core.metrics.MetricsService;
+import com.plantcare.core.metrics.MetricsService.CallbackOutcome;
 import com.plantcare.core.service.BackdatedCareService;
 import com.plantcare.core.service.PlantService;
 import com.plantcare.core.service.UserService;
@@ -75,6 +77,7 @@ public class BackdatedCareCallbackService {
     private final PlantService plantService;
     private final UserService userService;
     private final BackdatedCareService backdatedCareService;
+    private final MetricsService metricsService;
     private final Clock clock;
 
     /**
@@ -102,6 +105,7 @@ public class BackdatedCareCallbackService {
     ) {
         if (parts.length != 3) {
             answerCallback(client, callbackId, "❌ Неверный формат");
+            metricsService.recordCallback("back_care", CallbackOutcome.ERROR);
             return;
         }
         Long plantId;
@@ -109,18 +113,21 @@ public class BackdatedCareCallbackService {
             plantId = Long.parseLong(parts[2]);
         } catch (NumberFormatException e) {
             answerCallback(client, callbackId, "❌ Неверный ID");
+            metricsService.recordCallback("back_care", CallbackOutcome.ERROR);
             return;
         }
 
         User user = userService.findByChatId(chatId).orElse(null);
         if (user == null) {
             answerCallback(client, callbackId, "❌ Сначала /start");
+            metricsService.recordCallback("back_care", CallbackOutcome.ERROR);
             return;
         }
 
         Plant plant = plantService.getPlantForUser(user.getId(), plantId).orElse(null);
         if (plant == null) {
             answerCallback(client, callbackId, "❌ Растение не найдено");
+            metricsService.recordCallback("back_care", CallbackOutcome.ERROR);
             return;
         }
 
@@ -129,6 +136,8 @@ public class BackdatedCareCallbackService {
             editMessage(client, chatId, messageId,
                     "У этого растения нет активных задач ухода — отмечать нечего.");
             answerCallback(client, callbackId, "");
+            // Клик корректно обработан, просто отмечать нечего — это не ошибка.
+            metricsService.recordCallback("back_care", CallbackOutcome.OK);
             return;
         }
 
@@ -138,6 +147,7 @@ public class BackdatedCareCallbackService {
             showTaskTypeChoice(plantId, careTypes, chatId, messageId, client);
         }
         answerCallback(client, callbackId, "");
+        metricsService.recordCallback("back_care", CallbackOutcome.OK);
     }
 
     /**
@@ -216,6 +226,7 @@ public class BackdatedCareCallbackService {
     ) {
         if (parts.length != 5) {
             answerCallback(client, callbackId, "❌ Неверный формат");
+            metricsService.recordCallback("back_pick", CallbackOutcome.ERROR);
             return;
         }
         Long plantId;
@@ -227,17 +238,20 @@ public class BackdatedCareCallbackService {
             daysAgo = Integer.parseInt(parts[4]);
         } catch (IllegalArgumentException e) {
             answerCallback(client, callbackId, "❌ Неверные параметры");
+            metricsService.recordCallback("back_pick", CallbackOutcome.ERROR);
             return;
         }
 
         User user = userService.findByChatId(chatId).orElse(null);
         if (user == null) {
             answerCallback(client, callbackId, "❌ Сначала /start");
+            metricsService.recordCallback("back_pick", CallbackOutcome.ERROR);
             return;
         }
         Plant plant = plantService.getPlantForUser(user.getId(), plantId).orElse(null);
         if (plant == null) {
             answerCallback(client, callbackId, "❌ Растение не найдено");
+            metricsService.recordCallback("back_pick", CallbackOutcome.ERROR);
             return;
         }
 
@@ -245,10 +259,13 @@ public class BackdatedCareCallbackService {
         if (daysAgo < 0) {
             showDateChoice(plantId, taskType, chatId, messageId, client);
             answerCallback(client, callbackId, "");
+            // Навигация (показали выбор даты) — клик корректно обработан.
+            metricsService.recordCallback("back_pick", CallbackOutcome.OK);
             return;
         }
         if (daysAgo > BackdatedCareService.MAX_BACKDATE_DAYS) {
             answerCallback(client, callbackId, "❌ Слишком давно");
+            metricsService.recordCallback("back_pick", CallbackOutcome.ERROR);
             return;
         }
 
@@ -256,7 +273,22 @@ public class BackdatedCareCallbackService {
         LocalDate today = LocalDate.now(clock.withZone(zone));
         LocalDate doneDate = today.minusDays(daysAgo);
 
-        applyResult(user, plant, taskType, doneDate, chatId, messageId, callbackId, client);
+        BackdatedCareService.BackdatedCareResult result =
+                applyResult(user, plant, taskType, doneDate, chatId, messageId, callbackId, client);
+        metricsService.recordCallback("back_pick", outcomeOf(result.outcome()));
+    }
+
+    /**
+     * Маппинг доменного исхода ретро-отметки на {@link CallbackOutcome} метрики:
+     * созданная запись — OK, повтор за тот же день — идемпотентный no-op,
+     * слишком старая или будущая дата — ошибка ввода.
+     */
+    private CallbackOutcome outcomeOf(BackdatedCareService.Outcome outcome) {
+        return switch (outcome) {
+            case CREATED          -> CallbackOutcome.OK;
+            case ALREADY_RECORDED -> CallbackOutcome.IDEMPOTENT;
+            case TOO_OLD, IN_FUTURE -> CallbackOutcome.ERROR;
+        };
     }
 
     // ====================================================================
@@ -269,6 +301,7 @@ public class BackdatedCareCallbackService {
     ) {
         if (parts.length != 4) {
             answerCallback(client, callbackId, "❌ Неверный формат");
+            metricsService.recordCallback("back_custom", CallbackOutcome.ERROR);
             return;
         }
         Long plantId;
@@ -278,17 +311,20 @@ public class BackdatedCareCallbackService {
             taskType = TaskType.valueOf(parts[3]);
         } catch (IllegalArgumentException e) {
             answerCallback(client, callbackId, "❌ Неверные параметры");
+            metricsService.recordCallback("back_custom", CallbackOutcome.ERROR);
             return;
         }
 
         User user = userService.findByChatId(chatId).orElse(null);
         if (user == null) {
             answerCallback(client, callbackId, "❌ Сначала /start");
+            metricsService.recordCallback("back_custom", CallbackOutcome.ERROR);
             return;
         }
         Plant plant = plantService.getPlantForUser(user.getId(), plantId).orElse(null);
         if (plant == null) {
             answerCallback(client, callbackId, "❌ Растение не найдено");
+            metricsService.recordCallback("back_custom", CallbackOutcome.ERROR);
             return;
         }
 
@@ -302,6 +338,7 @@ public class BackdatedCareCallbackService {
                 + "Можно не больше " + BackdatedCareService.MAX_BACKDATE_DAYS + " дней назад.\n"
                 + "/cancel — отменить.");
         answerCallback(client, callbackId, "");
+        metricsService.recordCallback("back_custom", CallbackOutcome.OK);
     }
 
     // ====================================================================
@@ -316,9 +353,15 @@ public class BackdatedCareCallbackService {
      *
      * <p>Метод сам выбирает: editMessage (если есть messageId — кнопочный flow)
      * или sendMessage (если messageId == null — flow через текстовый ввод).
+     *
+     * <p>Возвращает доменный {@link BackdatedCareService.BackdatedCareResult},
+     * чтобы кнопочный вызыватель ({@link #handleBackPickPreset}) мог записать
+     * метрику callback'а по исходу. Текстовый flow
+     * ({@code AwaitingCareDateStateHandler}) возврат игнорирует — это не callback
+     * и в scope метрики #126 не входит.
      */
     @Transactional
-    public void applyResult(
+    public BackdatedCareService.BackdatedCareResult applyResult(
             User user, Plant plant, TaskType taskType, LocalDate doneDate,
             Long chatId, Integer messageId, String callbackId, TelegramClient client
     ) {
@@ -350,6 +393,7 @@ public class BackdatedCareCallbackService {
         if (callbackId != null) {
             answerCallback(client, callbackId, result.isCreated() ? "Записано" : "");
         }
+        return result;
     }
 
     // ====================================================================

--- a/src/main/java/com/plantcare/bot/service/NotificationCallbackService.java
+++ b/src/main/java/com/plantcare/bot/service/NotificationCallbackService.java
@@ -767,6 +767,7 @@ public class NotificationCallbackService {
     ) {
         if (parts.length != 4) {
             answerCallback(client, callbackId, "❌ Неверный формат");
+            metricsService.recordCallback("snooze_pick", CallbackOutcome.ERROR);
             return;
         }
         Long scheduleId;
@@ -774,6 +775,7 @@ public class NotificationCallbackService {
             scheduleId = Long.parseLong(parts[2]);
         } catch (NumberFormatException e) {
             answerCallback(client, callbackId, "❌ Неверный ID");
+            metricsService.recordCallback("snooze_pick", CallbackOutcome.ERROR);
             return;
         }
         String option = parts[3];
@@ -781,6 +783,7 @@ public class NotificationCallbackService {
         Optional<CareSchedule> opt = careScheduleRepository.findById(scheduleId);
         if (opt.isEmpty()) {
             answerCallback(client, callbackId, "❌ Расписание не найдено");
+            metricsService.recordCallback("snooze_pick", CallbackOutcome.ERROR);
             return;
         }
         CareSchedule schedule = opt.get();
@@ -790,12 +793,16 @@ public class NotificationCallbackService {
         if (!schedule.isActive()) {
             editMessage(client, chatId, messageId, "Это расписание отключено");
             answerCallback(client, callbackId, "Расписание отключено");
+            metricsService.recordCallback("snooze_pick", CallbackOutcome.ERROR);
             return;
         }
         Plant plant = schedule.getPlant();
         if (plant.isArchived()) {
             editMessage(client, chatId, messageId, "Растение уже удалено");
             answerCallback(client, callbackId, "Растение удалено");
+            // Архив трактуем как «уже не актуально», не ошибка — зеркалит
+            // обработку архива в основном switch (см. case "done").
+            metricsService.recordCallback("snooze_pick", CallbackOutcome.IDEMPOTENT);
             return;
         }
 
@@ -811,6 +818,7 @@ public class NotificationCallbackService {
         };
         if (target == null) {
             answerCallback(client, callbackId, "❌ Неизвестный вариант");
+            metricsService.recordCallback("snooze_pick", CallbackOutcome.ERROR);
             return;
         }
 
@@ -826,6 +834,7 @@ public class NotificationCallbackService {
                 + (wasShifted ? " (сдвинуто из тихих часов)" : ".");
         editMessage(client, chatId, messageId, confirm);
         answerCallback(client, callbackId, "Отложено");
+        metricsService.recordCallback("snooze_pick", CallbackOutcome.OK);
 
         log.info("Snooze picked: schedule={} option={} target={} shifted={} wasShifted={}",
                 scheduleId, option, target, shifted, wasShifted);
@@ -857,6 +866,7 @@ public class NotificationCallbackService {
     ) {
         if (parts.length != 3) {
             answerCallback(client, callbackId, "❌ Неверный формат");
+            metricsService.recordCallback("snooze_back", CallbackOutcome.ERROR);
             return;
         }
         Long scheduleId;
@@ -864,12 +874,14 @@ public class NotificationCallbackService {
             scheduleId = Long.parseLong(parts[2]);
         } catch (NumberFormatException e) {
             answerCallback(client, callbackId, "❌ Неверный ID");
+            metricsService.recordCallback("snooze_back", CallbackOutcome.ERROR);
             return;
         }
 
         Optional<CareSchedule> opt = careScheduleRepository.findById(scheduleId);
         if (opt.isEmpty()) {
             answerCallback(client, callbackId, "❌ Расписание не найдено");
+            metricsService.recordCallback("snooze_back", CallbackOutcome.ERROR);
             return;
         }
         CareSchedule schedule = opt.get();
@@ -880,6 +892,7 @@ public class NotificationCallbackService {
         if (!schedule.isActive()) {
             editMessage(client, chatId, messageId, "Расписание уже отключено");
             answerCallback(client, callbackId, "Расписание отключено");
+            metricsService.recordCallback("snooze_back", CallbackOutcome.ERROR);
             return;
         }
 
@@ -897,6 +910,7 @@ public class NotificationCallbackService {
             log.error("Failed to restore reminder keyboard: {}", e.getMessage(), e);
         }
         answerCallback(client, callbackId, "");
+        metricsService.recordCallback("snooze_back", CallbackOutcome.OK);
     }
 
     // ====================================================================

--- a/src/main/java/com/plantcare/core/metrics/MetricsService.java
+++ b/src/main/java/com/plantcare/core/metrics/MetricsService.java
@@ -77,7 +77,11 @@ public class MetricsService {
             // акклиматизация (#75)
             "accl_soil", "accl_snooze", "accl_checkin",
             // дайджест (#50)
-            "digest_done_all", "digest_expand", "digest_unknown"
+            "digest_done_all", "digest_expand", "digest_unknown",
+            // отложить напоминание: выбор варианта и возврат (#118)
+            "snooze_pick", "snooze_back",
+            // ретро-отметка ухода «Я уже ухаживал» (#118)
+            "back_care", "back_pick", "back_custom"
     );
 
     /** Значение тэга {@code action}, если переданная строка не в whitelist'е. */

--- a/src/test/java/com/plantcare/bot/service/BackdatedCareCallbackServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/BackdatedCareCallbackServiceTest.java
@@ -1,5 +1,7 @@
 package com.plantcare.bot.service;
 
+import com.plantcare.core.metrics.MetricsService;
+import com.plantcare.core.metrics.MetricsService.CallbackOutcome;
 import com.plantcare.core.service.BackdatedCareService;
 import com.plantcare.core.service.PlantService;
 import com.plantcare.core.service.UserService;
@@ -59,6 +61,7 @@ class BackdatedCareCallbackServiceTest {
     @Mock private PlantService plantService;
     @Mock private UserService userService;
     @Mock private BackdatedCareService backdatedCareService;
+    @Mock private MetricsService metricsService;
     @Mock private TelegramClient client;
 
     private static final Instant FIXED_NOW = Instant.parse("2026-05-24T10:00:00Z");
@@ -73,6 +76,7 @@ class BackdatedCareCallbackServiceTest {
                 plantService,
                 userService,
                 backdatedCareService,
+                metricsService,
                 Clock.fixed(FIXED_NOW, ZoneOffset.UTC)
         );
 
@@ -411,6 +415,124 @@ class BackdatedCareCallbackServiceTest {
             // today=2026-05-24, ввод 07.06 — ~14 дней вперёд, в пределах 30-дневного порога
             Optional<LocalDate> got = service.parseCareDate("07.06", user);
             assertThat(got).contains(LocalDate.of(2026, 6, 7));
+        }
+    }
+
+    // ====================================================================
+    // Метрики callbacks (#126) — маппинг исходов flow #118 на CallbackOutcome.
+    // back_* живут здесь (а не в NotificationCallbackServiceTest$CallbackMetrics),
+    // потому что в NCS-тесте backdatedCareCallbackService — мок, и реальную запись
+    // метрики через NCS проверить нельзя.
+    // ====================================================================
+
+    @Nested
+    @DisplayName("Метрики callbacks (#126)")
+    class CallbackMetrics {
+
+        @Test
+        @DisplayName("back_care с активным типом ухода: recordCallback(back_care, ok)")
+        void should_record_back_care_ok_when_active_care_type_present() throws TelegramApiException {
+            when(plantService.getActiveSchedules(7L)).thenReturn(List.of(scheduleFor(TaskType.WATERING)));
+
+            service.handleCallback("back_care", new String[]{"v1", "back_care", "7"},
+                    100L, 555, "cb-1", client);
+
+            verify(metricsService).recordCallback("back_care", CallbackOutcome.OK);
+        }
+
+        @Test
+        @DisplayName("back_care неизвестный пользователь: recordCallback(back_care, error)")
+        void should_record_back_care_error_when_user_unknown() throws TelegramApiException {
+            when(userService.findByChatId(100L)).thenReturn(Optional.empty());
+
+            service.handleCallback("back_care", new String[]{"v1", "back_care", "7"},
+                    100L, 555, "cb-1", client);
+
+            verify(metricsService).recordCallback("back_care", CallbackOutcome.ERROR);
+        }
+
+        @Test
+        @DisplayName("back_pick CREATED: recordCallback(back_pick, ok)")
+        void should_record_back_pick_ok_when_outcome_created() throws TelegramApiException {
+            LocalDate yesterday = LocalDate.of(2026, 5, 23);
+            when(backdatedCareService.recordBackdatedCare(any(), any(), any()))
+                    .thenReturn(new BackdatedCareService.BackdatedCareResult(
+                            BackdatedCareService.Outcome.CREATED, yesterday,
+                            java.time.LocalDateTime.of(2026, 5, 30, 12, 0)));
+
+            service.handleCallback("back_pick",
+                    new String[]{"v1", "back_pick", "7", "WATERING", "1"},
+                    100L, 555, "cb-1", client);
+
+            verify(metricsService).recordCallback("back_pick", CallbackOutcome.OK);
+        }
+
+        @Test
+        @DisplayName("back_pick ALREADY_RECORDED: recordCallback(back_pick, idempotent)")
+        void should_record_back_pick_idempotent_when_outcome_already_recorded() throws TelegramApiException {
+            LocalDate yesterday = LocalDate.of(2026, 5, 23);
+            when(backdatedCareService.recordBackdatedCare(any(), any(), any()))
+                    .thenReturn(new BackdatedCareService.BackdatedCareResult(
+                            BackdatedCareService.Outcome.ALREADY_RECORDED, yesterday, null));
+
+            service.handleCallback("back_pick",
+                    new String[]{"v1", "back_pick", "7", "WATERING", "1"},
+                    100L, 555, "cb-1", client);
+
+            verify(metricsService).recordCallback("back_pick", CallbackOutcome.IDEMPOTENT);
+        }
+
+        @Test
+        @DisplayName("back_pick TOO_OLD: recordCallback(back_pick, error)")
+        void should_record_back_pick_error_when_outcome_too_old() throws TelegramApiException {
+            LocalDate yesterday = LocalDate.of(2026, 5, 23);
+            when(backdatedCareService.recordBackdatedCare(any(), any(), any()))
+                    .thenReturn(new BackdatedCareService.BackdatedCareResult(
+                            BackdatedCareService.Outcome.TOO_OLD, yesterday, null));
+
+            service.handleCallback("back_pick",
+                    new String[]{"v1", "back_pick", "7", "WATERING", "1"},
+                    100L, 555, "cb-1", client);
+
+            verify(metricsService).recordCallback("back_pick", CallbackOutcome.ERROR);
+        }
+
+        @Test
+        @DisplayName("back_pick IN_FUTURE: recordCallback(back_pick, error)")
+        void should_record_back_pick_error_when_outcome_in_future() throws TelegramApiException {
+            LocalDate today = LocalDate.of(2026, 5, 24);
+            when(backdatedCareService.recordBackdatedCare(any(), any(), any()))
+                    .thenReturn(new BackdatedCareService.BackdatedCareResult(
+                            BackdatedCareService.Outcome.IN_FUTURE, today, null));
+
+            service.handleCallback("back_pick",
+                    new String[]{"v1", "back_pick", "7", "WATERING", "0"},
+                    100L, 555, "cb-1", client);
+
+            verify(metricsService).recordCallback("back_pick", CallbackOutcome.ERROR);
+        }
+
+        @Test
+        @DisplayName("back_pick растение не найдено (early-return): recordCallback(back_pick, error)")
+        void should_record_back_pick_error_when_plant_not_found() throws TelegramApiException {
+            when(plantService.getPlantForUser(42L, 7L)).thenReturn(Optional.empty());
+
+            service.handleCallback("back_pick",
+                    new String[]{"v1", "back_pick", "7", "WATERING", "1"},
+                    100L, 555, "cb-1", client);
+
+            verify(backdatedCareService, never()).recordBackdatedCare(any(), any(), any());
+            verify(metricsService).recordCallback("back_pick", CallbackOutcome.ERROR);
+        }
+
+        @Test
+        @DisplayName("back_custom выставляет state: recordCallback(back_custom, ok)")
+        void should_record_back_custom_ok_when_state_set() throws TelegramApiException {
+            service.handleCallback("back_custom",
+                    new String[]{"v1", "back_custom", "7", "WATERING"},
+                    100L, 555, "cb-1", client);
+
+            verify(metricsService).recordCallback("back_custom", CallbackOutcome.OK);
         }
     }
 

--- a/src/test/java/com/plantcare/bot/service/NotificationCallbackServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/NotificationCallbackServiceTest.java
@@ -831,5 +831,83 @@ class NotificationCallbackServiceTest {
 
             verify(metricsService).recordCallback("bulk_done", CallbackOutcome.IDEMPOTENT);
         }
+
+        // ----- snooze_pick (выбор интервала, #118) ----------------------
+
+        @Test
+        @DisplayName("snooze_pick tomorrow на активном расписании: recordCallback(snooze_pick, ok)")
+        void should_record_snooze_pick_ok_when_active_schedule_and_valid_option() throws TelegramApiException {
+            // quiet-hours policy не сдвигает — возвращает переданный instant как есть.
+            when(quietHoursPolicy.shiftOutOfQuietHours(any(), any()))
+                    .thenAnswer(inv -> inv.getArgument(1));
+            when(callbackQuery.getData()).thenReturn("v1:snooze_pick:1:tomorrow");
+            when(careScheduleRepository.findById(1L)).thenReturn(Optional.of(schedule));
+
+            service.handleCallback(callbackQuery, telegramClient);
+
+            verify(metricsService).recordCallback("snooze_pick", CallbackOutcome.OK);
+        }
+
+        @Test
+        @DisplayName("snooze_pick: schedule не найден: recordCallback(snooze_pick, error)")
+        void should_record_snooze_pick_error_when_schedule_not_found() throws TelegramApiException {
+            when(callbackQuery.getData()).thenReturn("v1:snooze_pick:9999:tomorrow");
+            when(careScheduleRepository.findById(9999L)).thenReturn(Optional.empty());
+
+            service.handleCallback(callbackQuery, telegramClient);
+
+            verify(metricsService).recordCallback("snooze_pick", CallbackOutcome.ERROR);
+        }
+
+        @Test
+        @DisplayName("snooze_pick: расписание неактивно: recordCallback(snooze_pick, error)")
+        void should_record_snooze_pick_error_when_schedule_inactive() throws TelegramApiException {
+            schedule.setActive(false);
+            when(callbackQuery.getData()).thenReturn("v1:snooze_pick:1:tomorrow");
+            when(careScheduleRepository.findById(1L)).thenReturn(Optional.of(schedule));
+
+            service.handleCallback(callbackQuery, telegramClient);
+
+            verify(metricsService).recordCallback("snooze_pick", CallbackOutcome.ERROR);
+        }
+
+        // ----- snooze_back (возврат к reminder-клавиатуре, #118) --------
+
+        @Test
+        @DisplayName("snooze_back на активном расписании: recordCallback(snooze_back, ok)")
+        void should_record_snooze_back_ok_when_active_schedule() throws TelegramApiException {
+            when(reminderKeyboardFactory.buildReminderKeyboard(eq(1L), any()))
+                    .thenReturn(org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup
+                            .builder().keyboard(java.util.List.of()).build());
+            when(callbackQuery.getData()).thenReturn("v1:snooze_back:1");
+            when(careScheduleRepository.findById(1L)).thenReturn(Optional.of(schedule));
+
+            service.handleCallback(callbackQuery, telegramClient);
+
+            verify(metricsService).recordCallback("snooze_back", CallbackOutcome.OK);
+        }
+
+        @Test
+        @DisplayName("snooze_back: schedule не найден: recordCallback(snooze_back, error)")
+        void should_record_snooze_back_error_when_schedule_not_found() throws TelegramApiException {
+            when(callbackQuery.getData()).thenReturn("v1:snooze_back:9999");
+            when(careScheduleRepository.findById(9999L)).thenReturn(Optional.empty());
+
+            service.handleCallback(callbackQuery, telegramClient);
+
+            verify(metricsService).recordCallback("snooze_back", CallbackOutcome.ERROR);
+        }
+
+        @Test
+        @DisplayName("snooze_back: расписание неактивно: recordCallback(snooze_back, error)")
+        void should_record_snooze_back_error_when_schedule_inactive() throws TelegramApiException {
+            schedule.setActive(false);
+            when(callbackQuery.getData()).thenReturn("v1:snooze_back:1");
+            when(careScheduleRepository.findById(1L)).thenReturn(Optional.of(schedule));
+
+            service.handleCallback(callbackQuery, telegramClient);
+
+            verify(metricsService).recordCallback("snooze_back", CallbackOutcome.ERROR);
+        }
     }
 }

--- a/src/test/java/com/plantcare/core/metrics/MetricsServiceTest.java
+++ b/src/test/java/com/plantcare/core/metrics/MetricsServiceTest.java
@@ -228,6 +228,31 @@ class MetricsServiceTest {
             assertThat(unknownCounter.count()).isEqualTo(1.0);
             assertThat(garbageCounter).isNull();
         }
+
+        @Test
+        @DisplayName("flow #118 actions в whitelist'е: счётчик с собственным тэгом, не unknown")
+        void should_keep_flow_118_actions_as_own_tag_not_unknown() {
+            // Без добавления в KNOWN_CALLBACK_ACTIONS эти 5 санитайзились бы в "unknown"
+            // и метрика по веткам #118 была бы слепой.
+            for (String action : new String[]{
+                    "snooze_pick", "snooze_back", "back_care", "back_pick", "back_custom"}) {
+                metricsService.recordCallback(action, CallbackOutcome.OK);
+
+                Counter counter = registry.find(MetricsService.CALLBACKS_PROCESSED)
+                        .tag("action", action)
+                        .tag("outcome", "ok")
+                        .counter();
+
+                assertThat(counter)
+                        .as("action '%s' должен иметь собственный counter, а не unknown", action)
+                        .isNotNull();
+                assertThat(counter.count()).isEqualTo(1.0);
+            }
+
+            // и в "unknown" ничего не утекло
+            assertThat(registry.find(MetricsService.CALLBACKS_PROCESSED)
+                    .tag("action", "unknown").counter()).isNull();
+        }
     }
 
     @Nested


### PR DESCRIPTION
Closes #126

## Что сделано
- 5 callback-веток flow #118 (`snooze_pick`, `snooze_back`, `back_care`, `back_pick`, `back_custom`) теперь пишут `metricsService.recordCallback(action, outcome)` — раньше они диспатчились до главного `switch` и молча не попадали в Prometheus/Grafana (#115/#122).
- В `BackdatedCareCallbackService` добавлен инжект `MetricsService`; для `back_pick` исход `BackdatedCareService.Outcome` маппится в `CallbackOutcome`: `CREATED→OK`, `ALREADY_RECORDED→IDEMPOTENT`, `TOO_OLD/IN_FUTURE→ERROR`.
- `snooze_pick`/`snooze_back`: метрика во всех точках выхода — ошибки валидации (формат/ID/расписание не найдено/неактивно/неизвестный вариант) → `ERROR`, архив растения → `IDEMPOTENT` (зеркало основного switch), happy → `OK`.
- 5 action добавлены в whitelist `MetricsService.KNOWN_CALLBACK_ACTIONS` — иначе тег `action` санитайзился бы в `"unknown"`. Имена взяты **as-is**, без переименования.
- `applyResult(...)` сменил возврат `void → BackdatedCareResult`: метрика `back_pick` пишется в кнопочном flow (`handleBackPickPreset`), но НЕ в текстовом (`AwaitingCareDateStateHandler` — это ввод даты, не callback, вне scope #126).

## Миграции
Нет.

## Backward-compat риски
Нет. Изменения наблюдаемости + расширение whitelist. Схема БД, публичные HTTP/SDK API и набор метрик не меняются — добавляются только новые значения существующего тега `action` (Grafana подхватывает их автоматически, дашборд группирует `by (action)`).

## Тесты
- `NotificationCallbackServiceTest$CallbackMetrics` (+6): `snooze_pick` ok/not-found/inactive, `snooze_back` ok/not-found/inactive.
- `BackdatedCareCallbackServiceTest$CallbackMetrics` (+8): `back_care` ok/unknown-user, `back_pick` CREATED→OK / ALREADY_RECORDED→IDEMPOTENT / TOO_OLD→ERROR / IN_FUTURE→ERROR / plant-not-found→ERROR, `back_custom` ok. (back_* вынесены сюда, а не в NCS-тест: там `backdatedCareCallbackService` — мок, реальную запись метрики через NCS не проверить.)
- `MetricsServiceTest$Callback` (+1): 5 новых action НЕ санитайзятся в `"unknown"` (реальный `SimpleMeterRegistry`).
- Итого 15 кейсов; каждый ловит регрессию (убрать `recordCallback` из ветки → падает соответствующий `verify`).

## Чек
- [x] reviewer прошёл (LGTM, 0 BLOCKING, 0 SHOULD-FIX; 1 косметический nit — trailing newline, исправлен)
- [ ] `mvn verify` локально **не прогонялось**: офлайн-окружение, в `~/.m2` нет `com.tngtech.archunit:archunit-junit5:1.3.0` (тянет `LayeredArchitectureTest`), Maven Central недоступен. Прод-код компилируется офлайн (`mvn -o compile` зелёный); тест-код провалидирован ручным `javac` против реальных сигнатур. **Зелёный гейт — на CI** (на develop-раннере archunit резолвится, прошлые прогоны зелёные).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
