### PR TITLE
feat: speciesId в PlantCreateRequest (POST /plants) — mobile gap G13

### DIFF
--- a/src/main/java/com/plantcare/api/v1/PlantController.java
+++ b/src/main/java/com/plantcare/api/v1/PlantController.java
@@ -51,7 +51,8 @@ public class PlantController implements PlantsApi {
     @Override
     public PlantDto createPlant(PlantCreateRequest request) {
         User user = userService.getByIdOrThrow(currentUserProvider.currentUserId());
-        Plant plant = plantService.createPlant(user, request.getName(), request.getNotes(), request.getLocationId());
+        Plant plant = plantService.createPlant(
+                user, request.getName(), request.getNotes(), request.getLocationId(), request.getSpeciesId());
         return toDto(plant);
     }
 

--- a/src/main/java/com/plantcare/core/service/PlantService.java
+++ b/src/main/java/com/plantcare/core/service/PlantService.java
@@ -81,21 +81,28 @@ public class PlantService {
     }
 
     @Transactional
-    public Plant createPlant(User user, String name, String notes, Long locationId) {
+    public Plant createPlant(User user, String name, String notes, Long locationId, Long speciesId) {
         Location location;
         if (locationId != null) {
             location = locationService.getUserLocationOrThrow(user.getId(), locationId);
         } else {
             location = locationService.getOrCreateDefaultLocation(user);
         }
+        Species species = null;
+        if (speciesId != null) {
+            species = speciesRepository.findById(speciesId)
+                    .orElseThrow(() -> new EntityNotFoundException("Species not found: " + speciesId));
+        }
         Plant plant = Plant.builder()
                 .user(user)
                 .location(location)
                 .name(name)
                 .notes(notes)
+                .species(species)
                 .build();
         Plant saved = plantRepository.save(plant);
-        log.info("Created plant '{}' (id={}) via REST API for user {}", name, saved.getId(), user.getId());
+        log.info("Created plant '{}' (id={}, speciesId={}) via REST API for user {}",
+                name, saved.getId(), speciesId, user.getId());
         return saved;
     }
 

--- a/src/main/resources/openapi/resources/plants.yaml
+++ b/src/main/resources/openapi/resources/plants.yaml
@@ -251,6 +251,15 @@ schemas:
         format: int64
         nullable: true
         description: Идентификатор локации. Если не задан, используется дефолтная локация пользователя.
+      speciesId:
+        type: integer
+        format: int64
+        nullable: true
+        description: |
+          Идентификатор вида растения (`Species.id`). Опционально. Если задан —
+          растение связывается с видом (mobile gap G13); вид должен существовать,
+          иначе `404 NOT_FOUND`. Расписания ухода при этом **не** создаются
+          автоматически (отдельная задача G14).
 
   PlantUpdateRequest:
     type: object

--- a/src/test/java/com/plantcare/api/v1/PlantControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/PlantControllerTest.java
@@ -5,6 +5,7 @@ import com.plantcare.api.ApiExceptionHandler;
 import com.plantcare.api.CurrentUserProvider;
 import com.plantcare.core.domain.Location;
 import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.Species;
 import com.plantcare.core.domain.User;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.security.access.AccessDeniedException;
@@ -171,7 +172,7 @@ class PlantControllerTest {
         Plant plant = mockPlant(10L, 1L, "Ficus");
 
         when(userService.getByIdOrThrow(1L)).thenReturn(user);
-        when(plantService.createPlant(eq(user), eq("Ficus"), isNull(), isNull()))
+        when(plantService.createPlant(eq(user), eq("Ficus"), isNull(), isNull(), isNull()))
                 .thenReturn(plant);
 
         String body = """
@@ -185,6 +186,34 @@ class PlantControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(10))
                 .andExpect(jsonPath("$.name").value("Ficus"));
+    }
+
+    @Test
+    void should_create_plant_with_speciesId() throws Exception {
+        // arrange — клиент передаёт speciesId (mobile gap G13)
+        User user = User.builder().telegramChatId(1L).build();
+        Plant plant = mockPlant(11L, 1L, "Монстера");
+        Species species = mock(Species.class);
+        when(species.getId()).thenReturn(7L);
+        when(species.getName()).thenReturn("Monstera deliciosa");
+        when(plant.getSpecies()).thenReturn(species);
+
+        when(userService.getByIdOrThrow(1L)).thenReturn(user);
+        when(plantService.createPlant(eq(user), eq("Монстера"), isNull(), isNull(), eq(7L)))
+                .thenReturn(plant);
+
+        String body = """
+                {"name": "Монстера", "speciesId": 7}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/plants")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(11))
+                .andExpect(jsonPath("$.speciesId").value(7))
+                .andExpect(jsonPath("$.speciesName").value("Monstera deliciosa"));
     }
 
     @Test

--- a/src/test/java/com/plantcare/core/service/PlantServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/PlantServiceTest.java
@@ -12,6 +12,7 @@ import com.plantcare.core.repository.PlantRepository;
 import com.plantcare.core.repository.SpeciesRepository;
 import com.plantcare.core.repository.UserRepository;
 import com.plantcare.bot.support.IntegrationTestBase;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +24,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Интеграционные тесты PlantService — создание растения")
 class PlantServiceTest extends IntegrationTestBase {
@@ -154,6 +156,43 @@ class PlantServiceTest extends IntegrationTestBase {
 
         Plant reloaded = plantRepository.findById(plant.getId()).orElseThrow();
         assertThat(reloaded.getName()).isEqualTo(specialName);
+    }
+
+    // ==================== createPlant (REST, mobile gap G13) ====================
+
+    @Test
+    @DisplayName("createPlant с speciesId связывает растение с видом и НЕ создаёт расписаний")
+    void createPlantViaApi_withSpecies_linksSpeciesAndNoSchedule() {
+        Plant plant = plantService.createPlant(
+                testUser, "Монстера у окна", "заметка", null, monstera.getId());
+
+        assertThat(plant.getId()).isNotNull();
+        assertThat(plant.getSpecies()).isNotNull();
+        assertThat(plant.getSpecies().getId()).isEqualTo(monstera.getId());
+        // G14 ещё не реализован — расписания при создании через REST не появляются
+        assertThat(scheduleRepository.findAllByPlantId(plant.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("createPlant без speciesId оставляет species = NULL")
+    void createPlantViaApi_withoutSpecies_speciesNull() {
+        Plant plant = plantService.createPlant(
+                testUser, "Безымянное", null, null, null);
+
+        assertThat(plant.getSpecies()).isNull();
+    }
+
+    @Test
+    @DisplayName("createPlant с несуществующим speciesId → EntityNotFoundException (404)")
+    void createPlantViaApi_withUnknownSpecies_throwsNotFound() {
+        assertThatThrownBy(() -> plantService.createPlant(
+                testUser, "Растение", null, null, 999_999L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("999999");
+
+        // растение НЕ должно сохраниться (создание атомарно отвалилось до save)
+        assertThat(plantRepository.findAllByUserIdAndArchivedAtIsNullOrderByNameAsc(testUser.getId()))
+                .isEmpty();
     }
 
     // ==================== getPopularSpecies ====================


### PR DESCRIPTION
## Что и зачем

Мобильный гэп **G13**: при создании растения нельзя задать вид. `GET /plants` возвращает `PlantDto.speciesId`, но `PlantCreateRequest` его не принимал (`name/notes/locationId`) — асимметрия контракта. Мастеру добавления (шаг «Выбор вида») это нужно для иллюстрации и плана ухода.

## Изменения

- **`plants.yaml`**: добавлен nullable `speciesId: int64` в `PlantCreateRequest` (spec-first, DTO генерится).
- **`PlantService.createPlant`**: новый параметр `speciesId`. Если задан → `speciesRepository.findById(...).orElseThrow(EntityNotFoundException)` (→ `404 NOT_FOUND`), связь проставляется. Резолв **до** `save` + `@Transactional` → невалидный `speciesId` не оставляет растение в БД. Виды глобальные, ownership-проверка не нужна.
- **`PlantController`**: пробрасывает `request.getSpeciesId()`; `toDto` уже маппит `speciesId`/`speciesName` в ответ.
- ⚠️ Расписания ухода при создании **не** создаются — это отдельная задача (gap **G14**).

## Тесты

- Слайс `PlantControllerTest`: создание с `speciesId` → проброс в сервис + `speciesId`/`speciesName` в ответе.
- Сервисные `PlantServiceTest` (Testcontainers): валидный вид связывается и расписаний не появляется; `null` → `species == null`; несуществующий `speciesId` → `EntityNotFoundException` и растение не сохранено.
- `mvn verify` (Java 21, чистый контейнер): **1301 run, 0 errors**; 3 падения — только pre-existing `PrometheusEndpointIntegrationTest` (observability #114/#133), не связаны с этим PR.

## Совместимость

Аддитивно: `speciesId` nullable, `NOT_REQUIRED`, без Bean Validation. Старые клиенты не ломаются. Backward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)