### PR TITLE
feat: GET /plants/{id}/health — health-score растения (mobile gap G1)

### DIFF
--- a/src/main/java/com/plantcare/api/v1/PlantController.java
+++ b/src/main/java/com/plantcare/api/v1/PlantController.java
@@ -4,10 +4,12 @@ import com.plantcare.api.generated.PlantsApi;
 import com.plantcare.api.generated.model.PageResponsePlantDto;
 import com.plantcare.api.generated.model.PlantCreateRequest;
 import com.plantcare.api.generated.model.PlantDto;
+import com.plantcare.api.generated.model.PlantHealthDto;
 import com.plantcare.api.generated.model.PlantUpdateRequest;
 import com.plantcare.api.CurrentUserProvider;
 import com.plantcare.core.domain.Plant;
 import com.plantcare.core.domain.User;
+import com.plantcare.core.service.HealthScoreService;
 import com.plantcare.core.service.PlantService;
 import com.plantcare.core.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -66,6 +68,19 @@ public class PlantController implements PlantsApi {
     @Override
     public void deletePlant(Long id) {
         plantService.archivePlant(currentUserProvider.currentUserId(), id);
+    }
+
+    @Override
+    public PlantHealthDto getPlantHealth(Long id) {
+        Long userId = currentUserProvider.currentUserId();
+        HealthScoreService.HealthScore health = plantService.getPlantHealth(userId, id);
+
+        PlantHealthDto dto = new PlantHealthDto(health.insufficientData());
+        if (!health.insufficientData()) {
+            dto.score(health.score())
+                    .zone(PlantHealthDto.ZoneEnum.fromValue(health.zone().name()));
+        }
+        return dto;
     }
 
     private static PlantDto toDto(Plant plant) {

--- a/src/main/java/com/plantcare/core/service/PlantService.java
+++ b/src/main/java/com/plantcare/core/service/PlantService.java
@@ -38,6 +38,7 @@ public class PlantService {
     private final SpeciesRepository speciesRepository;
     private final LocationService locationService;
     private final com.plantcare.core.seasonal.service.SeasonalIntervalService seasonalIntervalService;
+    private final HealthScoreService healthScoreService;
 
     // =================================================================
     // REST API CRUD (issue #85)
@@ -57,6 +58,18 @@ public class PlantService {
                     userId, locationId, pageable);
         }
         return plantRepository.findAllByUserIdAndArchivedAtIsNullOrderByNameAsc(userId, pageable);
+    }
+
+    /**
+     * Health-score растения для REST API (mobile gap G1, issue #138).
+     * Ownership/архив-проверки — те же, что в {@link #getPlantOrThrow}. Расчёт
+     * идёт в этой же read-only транзакции, поэтому lazy {@code plant.user}
+     * (нужен для TZ) инициализируется без LazyInitializationException.
+     */
+    @Transactional(readOnly = true)
+    public HealthScoreService.HealthScore getPlantHealth(Long userId, Long plantId) {
+        Plant plant = getPlantOrThrow(userId, plantId);
+        return healthScoreService.computeForPlant(plant);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -104,6 +104,8 @@ paths:
     $ref: './resources/plants.yaml#/paths/Item'
   /api/v1/plants/{id}/history:
     $ref: './resources/plant-history.yaml#/paths/ItemHistory'
+  /api/v1/plants/{id}/health:
+    $ref: './resources/plants.yaml#/paths/ItemHealth'
 
   /api/v1/locations:
     $ref: './resources/locations.yaml#/paths/Collection'

--- a/src/main/resources/openapi/resources/plants.yaml
+++ b/src/main/resources/openapi/resources/plants.yaml
@@ -171,7 +171,65 @@ paths:
         '404':
           $ref: '../_common/responses.yaml#/NotFound'
 
+  ItemHealth:
+    get:
+      tags: [Plants]
+      operationId: getPlantHealth
+      summary: Health-score растения
+      description: |
+        Возвращает числовой балл здоровья растения 0–100 и цветовую зону
+        (mobile gap G1, issue #138). Балл считается поверх истории ухода за
+        окно 30 дней в таймзоне пользователя плюс бонусы за фото/заметки.
+
+        Если активных записей ухода меньше порога (`< 3`), балл не
+        вычисляется: `insufficientData = true`, а `score`/`zone` приходят
+        `null` (клиент рисует кольцо нейтральным / «Пока мало данных»).
+
+        Доступ только к своему неархивированному растению (как `GET /plants/{id}`).
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '../_common/parameters.yaml#/PlantIdPath'
+      responses:
+        '200':
+          description: Health-score растения.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/PlantHealthDto'
+        '403':
+          $ref: '../_common/responses.yaml#/Forbidden'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
 schemas:
+  PlantHealthDto:
+    type: object
+    description: |
+      Health-score растения (mobile gap G1). При `insufficientData = true`
+      поля `score` и `zone` равны `null`.
+    required: [insufficientData]
+    properties:
+      insufficientData:
+        type: boolean
+        description: |
+          `true` — данных мало (`< 3` активных записей ухода), балл не
+          вычислялся; `score`/`zone` будут `null`.
+      score:
+        type: integer
+        format: int32
+        minimum: 0
+        maximum: 100
+        nullable: true
+        description: Балл 0–100. `null`, если `insufficientData = true`.
+      zone:
+        type: string
+        enum: [GREEN, YELLOW, RED]
+        nullable: true
+        description: |
+          Цветовая зона по порогам (`GREEN`/`YELLOW`/`RED`). `null`, если
+          `insufficientData = true`.
+
   PlantDto:
     type: object
     description: |

--- a/src/test/java/com/plantcare/api/v1/PlantControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/PlantControllerTest.java
@@ -7,8 +7,10 @@ import com.plantcare.core.domain.Location;
 import com.plantcare.core.domain.Plant;
 import com.plantcare.core.domain.Species;
 import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.HealthZone;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.security.access.AccessDeniedException;
+import com.plantcare.core.service.HealthScoreService;
 import com.plantcare.core.service.LocationService;
 import com.plantcare.core.service.PlantService;
 import com.plantcare.core.service.UserService;
@@ -299,5 +301,47 @@ class PlantControllerTest {
         mockMvc.perform(get("/api/v1/plants/1"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.error.code").value("ACCESS_DENIED"));
+    }
+
+    // ------------------------------------------------------------- health (G1)
+
+    @Test
+    void should_return_health_score_when_sufficient_data() throws Exception {
+        // arrange
+        when(plantService.getPlantHealth(1L, 1L))
+                .thenReturn(HealthScoreService.HealthScore.of(82, HealthZone.GREEN));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants/1/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.insufficientData").value(false))
+                .andExpect(jsonPath("$.score").value(82))
+                .andExpect(jsonPath("$.zone").value("GREEN"));
+    }
+
+    @Test
+    void should_return_insufficient_health_when_little_data() throws Exception {
+        // arrange — данных мало → score/zone null
+        when(plantService.getPlantHealth(1L, 1L))
+                .thenReturn(HealthScoreService.HealthScore.insufficient());
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants/1/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.insufficientData").value(true))
+                .andExpect(jsonPath("$.score").isEmpty())
+                .andExpect(jsonPath("$.zone").isEmpty());
+    }
+
+    @Test
+    void should_return_404_for_health_of_missing_plant() throws Exception {
+        // arrange — ownership/not-found пробрасывается из сервиса
+        when(plantService.getPlantHealth(1L, 999L))
+                .thenThrow(new EntityNotFoundException("Plant not found: 999"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants/999/health"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
     }
 }

--- a/src/test/java/com/plantcare/core/service/PlantServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/PlantServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -193,6 +194,35 @@ class PlantServiceTest extends IntegrationTestBase {
         // растение НЕ должно сохраниться (создание атомарно отвалилось до save)
         assertThat(plantRepository.findAllByUserIdAndArchivedAtIsNullOrderByNameAsc(testUser.getId()))
                 .isEmpty();
+    }
+
+    // ==================== getPlantHealth (REST, mobile gap G1) ====================
+
+    @Test
+    @DisplayName("getPlantHealth: для растения без истории ухода → insufficientData")
+    void getPlantHealth_insufficientForPlantWithoutHistory() {
+        Plant plant = plantService.createPlant(
+                testUser, "Свежее растение", null, null, null);
+
+        HealthScoreService.HealthScore health = plantService.getPlantHealth(
+                testUser.getId(), plant.getId());
+
+        assertThat(health.insufficientData()).isTrue();
+    }
+
+    @Test
+    @DisplayName("getPlantHealth: чужое растение → AccessDeniedException (как getPlantOrThrow)")
+    void getPlantHealth_foreignPlant_throwsAccessDenied() {
+        Plant plant = plantService.createPlant(
+                testUser, "Моё растение", null, null, null);
+
+        User otherUser = userRepository.save(User.builder()
+                .telegramChatId(801L)
+                .username("other_user")
+                .build());
+
+        assertThatThrownBy(() -> plantService.getPlantHealth(otherUser.getId(), plant.getId()))
+                .isInstanceOf(AccessDeniedException.class);
     }
 
     // ==================== getPopularSpecies ====================


### PR DESCRIPTION
## Что и зачем

Мобильный гэп **G1**: клиенту нужен числовой health-score (0–100) для кольца на Home и бейджа в карточке. `HealthScoreService` (#138) уже считает балл, но наружу был доступен только Telegram-боту.

## Изменения

- **`plants.yaml` / `openapi.yaml`**: `GET /api/v1/plants/{id}/health` → `PlantHealthDto { insufficientData: bool, score: int 0–100 (nullable), zone: GREEN|YELLOW|RED (nullable) }`. При `< 3` действий ухода `insufficientData = true`, `score`/`zone` = `null`.
- **`PlantService.getPlantHealth(userId, id)`** (`@Transactional(readOnly)`): ownership/архив как у `getPlantOrThrow`, расчёт в той же транзакции → lazy `user`/TZ без `LazyInitializationException`.
- **`PlantController.getPlantHealth`**: маппинг `HealthScore` → `PlantHealthDto`.

### Почему отдельный эндпоинт, а не поле в списке `PlantDto`
`computeForPlant` = до 3 count-запросов на растение → поле в списке дало бы N+1 (3×N). Эндпоинт по `{id}` этого избегает и соответствует api-contract §12.4. Батч-поле для грида Home — возможный follow-up.

## Тесты

- Слайс `PlantControllerTest`: sufficient → score+zone; insufficient → null/null; 404.
- Сервисный `PlantServiceTest` (Testcontainers): insufficient для растения без истории; чужое растение → `AccessDeniedException`. Скоринг покрыт тестами #138.
- `mvn verify` (Java 21): **1310 run, 0 errors**; 3 падения — только pre-existing `PrometheusEndpointIntegrationTest` (#114/#133), не связаны с PR.

## Совместимость

Аддитивно — новый эндпоинт. Ветка пересобрана поверх актуального `develop` (после мерджа G6 #164 и G13 #165).

🤖 Generated with [Claude Code](https://claude.com/claude-code)