### PR TITLE
feat: dev-сид + HTTP-коллекция (#171)

### DIFF
--- a/http/api.http
+++ b/http/api.http
@@ -1,0 +1,152 @@
+### Plants Care API — коллекция запросов (issue #171)
+#
+# Формат совместим с JetBrains HTTP Client и VS Code REST Client.
+# Локально auth обычно выключен (AUTH_ENABLED=false) → токен не нужен,
+# все запросы идут от dev-пользователя (id=1), засеянного DevDataInitializer.
+# Для прод/secured-режима задай {{token}} (см. блок Auth ниже).
+
+@baseUrl = http://localhost:8080
+@token =
+
+### Health (публично)
+GET {{baseUrl}}/api/v1/health
+
+### --- Auth (публично) ---
+
+### Вход через Apple
+POST {{baseUrl}}/api/v1/auth/apple
+Content-Type: application/json
+
+{ "identityToken": "<apple-identity-token>" }
+
+### Вход через Google
+POST {{baseUrl}}/api/v1/auth/google
+Content-Type: application/json
+
+{ "idToken": "<google-id-token>" }
+
+### Запросить magic link на email
+POST {{baseUrl}}/api/v1/auth/email/request
+Content-Type: application/json
+
+{ "email": "user@example.com" }
+
+### Обменять magic-link токен на пару токенов
+POST {{baseUrl}}/api/v1/auth/email/verify
+Content-Type: application/json
+
+{ "token": "<token-из-письма>" }
+
+### Ротация пары токенов
+POST {{baseUrl}}/api/v1/auth/refresh
+Content-Type: application/json
+
+{ "refreshToken": "<refresh-token>" }
+
+### --- Today / Calendar / Stats ---
+
+### Задачи на сегодня
+GET {{baseUrl}}/api/v1/today
+Authorization: Bearer {{token}}
+
+### Календарь задач
+GET {{baseUrl}}/api/v1/calendar
+Authorization: Bearer {{token}}
+
+### Стрик растения
+GET {{baseUrl}}/api/v1/stats/streak?plantId=1
+Authorization: Bearer {{token}}
+
+### --- Plants ---
+
+### Список растений
+GET {{baseUrl}}/api/v1/plants?offset=0&limit=20
+Authorization: Bearer {{token}}
+
+### Список растений в локации
+GET {{baseUrl}}/api/v1/plants?locationId=1
+Authorization: Bearer {{token}}
+
+### Создать растение
+POST {{baseUrl}}/api/v1/plants
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{ "name": "Monstera", "locationId": 1, "notes": "Любит свет" }
+
+### Получить растение
+GET {{baseUrl}}/api/v1/plants/1
+Authorization: Bearer {{token}}
+
+### Обновить растение (PATCH-семантика: только name/notes/locationId)
+PUT {{baseUrl}}/api/v1/plants/1
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{ "notes": "Переставил ближе к окну" }
+
+### Архивировать растение (soft-delete)
+DELETE {{baseUrl}}/api/v1/plants/1
+Authorization: Bearer {{token}}
+
+### История ухода за растением
+GET {{baseUrl}}/api/v1/plants/1/history?offset=0&limit=20
+Authorization: Bearer {{token}}
+
+### --- Locations ---
+
+### Список локаций
+GET {{baseUrl}}/api/v1/locations
+Authorization: Bearer {{token}}
+
+### Создать локацию
+POST {{baseUrl}}/api/v1/locations
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{ "name": "Подоконник", "emoji": "🪟" }
+
+### Получить локацию
+GET {{baseUrl}}/api/v1/locations/1
+Authorization: Bearer {{token}}
+
+### Обновить локацию
+PUT {{baseUrl}}/api/v1/locations/1
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{ "emoji": "🌿" }
+
+### Удалить локацию (409 LOCATION_NOT_EMPTY, если в ней есть растения)
+DELETE {{baseUrl}}/api/v1/locations/1
+Authorization: Bearer {{token}}
+
+### --- Care events ---
+
+### Зарегистрировать уход (type: WATER | SPRAY | FERTILIZE)
+POST {{baseUrl}}/api/v1/care-events
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+  "plantId": 1,
+  "type": "WATER",
+  "performedAt": "2026-05-28T08:30:00Z",
+  "note": "полил обильно",
+  "clientId": "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+}
+
+### Отменить уход (компенсирующая запись)
+DELETE {{baseUrl}}/api/v1/care-events/1
+Authorization: Bearer {{token}}
+
+### --- Справочники (публично) ---
+
+### Поиск/список видов
+GET {{baseUrl}}/api/v1/species?q=monstera&offset=0&limit=20
+
+### Детали вида
+GET {{baseUrl}}/api/v1/species/1
+
+### Справочник типов ухода
+GET {{baseUrl}}/api/v1/care-types

--- a/src/main/java/com/plantcare/core/config/DevDataInitializer.java
+++ b/src/main/java/com/plantcare/core/config/DevDataInitializer.java
@@ -1,0 +1,82 @@
+package com.plantcare.core.config;
+
+import com.plantcare.core.domain.Location;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.repository.UserRepository;
+import com.plantcare.core.service.BackdatedCareService;
+import com.plantcare.core.service.LocationService;
+import com.plantcare.core.service.PlantService;
+import com.plantcare.core.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * Сид тестовых данных для локальной мобильной разработки (issue #171).
+ *
+ * <p>Активен только в профиле {@code dev} — на {@code prod} (Railway) не подключается.
+ * Создаёт одного dev-пользователя с парой локаций, растениями (с расписанием полива)
+ * и историей ухода, чтобы свежий локальный бэкенд не был пустым.
+ *
+ * <p>Сидим только когда таблица {@code users} пуста: тогда первый вставленный
+ * пользователь получает {@code id = 1}, под который маппит auth dev-bypass
+ * ({@code plantcare.auth.dev-user-id}, см. {@code ApiSecurityConfig}). Если в БД
+ * уже есть пользователи — ничего не делаем (идемпотентно, без дублей).
+ */
+@Slf4j
+@Component
+@Profile("dev")
+@RequiredArgsConstructor
+public class DevDataInitializer implements ApplicationRunner {
+
+    /** Синтетический telegram chat id для dev-пользователя. */
+    private static final long DEV_CHAT_ID = 999_000_001L;
+
+    private final UserRepository userRepository;
+    private final UserService userService;
+    private final LocationService locationService;
+    private final PlantService plantService;
+    private final BackdatedCareService backdatedCareService;
+    private final Clock clock;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (userRepository.count() > 0) {
+            log.info("[dev-seed] users table not empty — пропускаю сид тестовых данных");
+            return;
+        }
+
+        log.info("[dev-seed] пустая БД — создаю dev-пользователя и тестовые растения");
+
+        User user = userService.findOrCreate(DEV_CHAT_ID, "dev");
+
+        Location windowsill = locationService.createLocation(user, "Подоконник", "🪟");
+        Location balcony = locationService.createLocation(user, "Балкон", "🌿");
+
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        // Растение с просроченным поливом — попадёт в /today сразу.
+        Plant monstera = plantService.createPlantWithWateringSchedule(
+                user, null, "Monstera", 7, now.minusDays(1), windowsill.getId());
+
+        // Растение с поливом через несколько дней.
+        plantService.createPlantWithWateringSchedule(
+                user, null, "Фикус", 10, now.plusDays(3), balcony.getId());
+
+        // Немного истории ухода, чтобы стрик/история были не пустыми.
+        LocalDate today = LocalDate.now(clock);
+        backdatedCareService.recordBackdatedCare(monstera, TaskType.WATERING, today.minusDays(8));
+        backdatedCareService.recordBackdatedCare(monstera, TaskType.WATERING, today.minusDays(1));
+
+        log.info("[dev-seed] готово: user id={}, локаций=2, растений=2", user.getId());
+    }
+}


### PR DESCRIPTION
Closes #171

## Что
Разгоняет старт локальной мобильной разработки: при пустой БД появляется готовый аккаунт с данными, и есть коллекция запросов.

- **`DevDataInitializer`** (`core.config`, `@Profile("dev")`, `ApplicationRunner`): засевает dev-пользователя (`id=1`, под него маппит auth dev-bypass), 2 локации, 2 растения с расписанием полива (одно с просроченным поливом → сразу в `/today`) и пару записей истории ухода. Сидит **только при пустой таблице `users`** (идемпотентно, без дублей). На `prod` не активен.
- **`http/api.http`**: все REST-эндпоинты в формате JetBrains/VS Code HTTP Client, переменные `{{baseUrl}}`/`{{token}}`.

## Проверка
`mvn -DskipTests compile` — зелёно (использует существующие сервисы `UserService`/`LocationService`/`PlantService`/`BackdatedCareService`, без ручной сборки entity).

## Заметки
- Сид опирается на то, что первый вставленный пользователь получает `id=1` (пустая БД) — этого достаточно для dev-bypass. Если в локальной БД уже есть юзеры, сид пропускается.
- How-to в wiki добавлю отдельно (вики — отдельный репозиторий).

🤖 Generated with [Claude Code](https://claude.com/claude-code)