### PR TITLE
ci: API contract — spectral lint + Swift/Kotlin SDK + drift (#170)

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -1,0 +1,82 @@
+name: API contract
+
+# Контракт REST API для мобильных клиентов (issue #170): линт OpenAPI-спеки,
+# генерация Swift/Kotlin SDK как артефактов, и drift-гейт (спека ↔ серверные
+# интерфейсы). Запускается только при изменении спеки или pom.
+on:
+  push:
+    paths:
+      - 'src/main/resources/openapi/**'
+      - 'pom.xml'
+      - '.github/workflows/api-contract.yml'
+      - '.spectral.yaml'
+  pull_request:
+    paths:
+      - 'src/main/resources/openapi/**'
+      - 'pom.xml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  SPEC: src/main/resources/openapi/openapi.yaml
+  OPENAPI_GENERATOR_VERSION: v7.10.0  # совпадает с openapi-generator.version в pom
+
+jobs:
+  lint:
+    name: Spectral lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      # Линтуем СОБРАННУЮ спеку: bundle инлайнит root-зарегистрированные схемы,
+      # благодаря чему резолвится bundle-путь #/components/schemas/TaskDto в
+      # calendar.yaml (см. комментарий в .spectral.yaml). --force: redocly
+      # ругается на этот ref при сборке, но бандл создаётся корректным.
+      - name: Bundle OpenAPI spec
+        run: npx -y @redocly/cli@1 bundle "$SPEC" -o openapi.bundled.yaml --force
+      - name: Lint bundled spec
+        run: npx -y @stoplight/spectral-cli@6 lint openapi.bundled.yaml --ruleset .spectral.yaml --fail-severity error
+
+  clients:
+    name: Generate ${{ matrix.generator }} client
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - generator: swift5
+            artifact: client-swift
+          - generator: kotlin
+            artifact: client-kotlin
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate client SDK
+        run: |
+          docker run --rm -v "$PWD:/work" \
+            "openapitools/openapi-generator-cli:${OPENAPI_GENERATOR_VERSION}" \
+            generate -i "/work/${SPEC}" -g ${{ matrix.generator }} \
+            -o "/work/clients/${{ matrix.generator }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: clients/${{ matrix.generator }}
+
+  drift:
+    name: Contract drift (спека ↔ контроллеры)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      # Контроллеры реализуют сгенерированные из спеки *Api-интерфейсы.
+      # Если спека и код разошлись (метод в спеке без реализации и т.п.) —
+      # compile упадёт. Это и есть drift-гейт.
+      - name: Compile against generated server interfaces
+        run: mvn -B -DskipTests compile

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,14 @@
+# Spectral-правила для OpenAPI-спеки Plants Care (issue #170).
+# Линтуется СОБРАННАЯ (bundled) спека — см. воркфлоу api-contract.yml: спека
+# разбита по resources/*.yaml, а calendar.yaml ссылается на bundle-путь
+# `#/components/schemas/TaskDto` (обход бага openapi-generator 7.10 с типизацией
+# items в additionalProperties). В бандле root инлайнит TaskDto в
+# components.schemas, поэтому ссылка резолвится и invalid-ref не срабатывает.
+#
+# В CI падаем только на severity=error (--fail-severity error); warn'ы — информативны.
+extends: ["spectral:oas"]
+
+rules:
+  # Часть схем подключается из root через components.$ref «про запас» —
+  # штатная проверка неиспользуемых компонентов даёт ложные срабатывания.
+  oas3-unused-component: off


### PR DESCRIPTION
Closes #170

## Что
Воркфлоу `.github/workflows/api-contract.yml` (триггер только на изменения `src/main/resources/openapi/**` и `pom.xml`):

1. **Spectral-линт** — линтует *собранную* (`redocly bundle --force`) спеку набором `spectral:oas`, падает на `severity=error`. Бандл нужен, чтобы резолвился намеренный bundle-путь `#/components/schemas/TaskDto` в `calendar.yaml` (обход бага openapi-generator 7.10).
2. **Клиентские SDK** — генерация **Swift5** и **Kotlin** через `openapi-generator` (docker, версия 7.10.0 как в pom), публикуются как build artifacts (`client-swift` / `client-kotlin`).
3. **Drift-гейт** — `mvn -DskipTests compile`: контроллеры реализуют сгенерированные из спеки `*Api`-интерфейсы, поэтому рассинхрон спеки и кода ломает компиляцию.

`.spectral.yaml` — ruleset.

## Проверка (локально)
- `redocly bundle --force` + spectral на бандле → **exit 0, 0 errors**.
- `openapi-generator` swift5 → 54 файла, kotlin → 99 файлов.

## Заметки
- `pom.xml` **не менялся** — генерация клиентов живёт в CI, обычная сборка не затронута.
- Активируется после мержа в `main` для push-триггера; PR-триггер и `workflow_dispatch` работают сразу.
- Ссылку на артефакты SDK в wiki ([Mobile-REST-API]) добавлю отдельно (вики — отдельный репозиторий).

🤖 Generated with [Claude Code](https://claude.com/claude-code)