### PR TITLE
feat: done-фид для /today — doneAt в TaskDto + summary (#184)

### DIFF
--- a/src/main/java/com/plantcare/api/v1/TodayController.java
+++ b/src/main/java/com/plantcare/api/v1/TodayController.java
@@ -3,19 +3,22 @@ package com.plantcare.api.v1;
 import com.plantcare.api.generated.TodayApi;
 import com.plantcare.api.generated.model.TaskDto;
 import com.plantcare.api.generated.model.TodayResponse;
+import com.plantcare.api.generated.model.TodaySummary;
 import com.plantcare.api.CurrentUserProvider;
 import com.plantcare.core.domain.CareSchedule;
 import com.plantcare.core.domain.User;
 import com.plantcare.core.service.TodayApiService;
+import com.plantcare.core.service.TodayApiService.TodayTask;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 
 /**
- * REST API для получения задач ухода на сегодня (issue #86).
+ * REST API для получения задач ухода на сегодня (issue #86, #184).
  *
  * <p>Документация и mapping живут в сгенерированном {@link TodayApi}.
  */
@@ -32,20 +35,37 @@ public class TodayController implements TodayApi {
         User user = currentUserProvider.currentUser();
         log.info("GET /api/v1/today: userId={}, timezone={}", user.getId(), user.getTimezone());
 
-        List<CareSchedule> schedules = todayApiService.getTodaySchedules(user.getId(), user.getTimezone());
+        List<TodayTask> todayTasks = todayApiService.getTodayTasks(user.getId(), user.getTimezone());
+        LocalDateTime now = todayApiService.nowUtc();
 
-        List<TaskDto> tasks = schedules.stream()
-                .map(TodayController::toTaskDto)
+        List<TaskDto> tasks = todayTasks.stream()
+                .map(t -> toTaskDto(t.schedule(), t.doneAt()))
                 .toList();
 
-        return new TodayResponse(tasks, tasks.size());
+        int total = tasks.size();
+        int done = (int) todayTasks.stream().filter(t -> t.doneAt() != null).count();
+        int overdue = (int) todayTasks.stream()
+                .filter(t -> t.doneAt() == null && t.schedule().getNextDueAt().isBefore(now))
+                .count();
+        int remaining = total - done;
+
+        TodaySummary summary = new TodaySummary(total, done, remaining, overdue);
+        return new TodayResponse(tasks, total, summary);
     }
 
     /**
-     * Маппинг расписания → DTO задачи. Используется также из
+     * Маппинг расписания → DTO задачи без отметки «сделано». Используется из
      * {@link CalendarController}, поэтому вынесен в общедоступный helper.
      */
     static TaskDto toTaskDto(CareSchedule schedule) {
+        return toTaskDto(schedule, null);
+    }
+
+    /**
+     * Маппинг расписания → DTO задачи с опциональным моментом отметки «сделано»
+     * ({@code doneAt}, issue #184). {@code null} — pending.
+     */
+    static TaskDto toTaskDto(CareSchedule schedule, LocalDateTime doneAt) {
         TaskDto dto = new TaskDto(
                 schedule.getId(),
                 schedule.getPlant().getId(),
@@ -59,6 +79,9 @@ public class TodayController implements TodayApi {
         if (schedule.getPlant().getSpecies() != null) {
             dto.speciesId(schedule.getPlant().getSpecies().getId());
             dto.speciesName(schedule.getPlant().getSpecies().getName());
+        }
+        if (doneAt != null) {
+            dto.doneAt(doneAt.atOffset(ZoneOffset.UTC));
         }
         return dto;
     }

--- a/src/main/java/com/plantcare/core/repository/CareHistoryRepository.java
+++ b/src/main/java/com/plantcare/core/repository/CareHistoryRepository.java
@@ -209,6 +209,36 @@ public interface CareHistoryRepository extends JpaRepository<CareHistory, Long> 
             Limit limit
     );
 
+    // ===== Done-фид для /today (issue #184, ADR-014) =====
+
+    /**
+     * Ключи задач, отмеченных «сделано» за окно сегодняшнего дня (issue #184).
+     * Возвращает по одной строке на пару (plantId, taskType) с максимальным
+     * {@code doneAt} в окне — берётся самый поздний момент отметки.
+     *
+     * <p>Только активные (не-cancelled) записи неархивных растений юзера.
+     * Границы окна {@code [from; to]} — UTC LocalDateTime, передаёт сервис
+     * (начало/конец локального дня в TZ юзера, сконвертированные в UTC).
+     */
+    @Query("SELECT h.plant.id AS plantId, h.taskType AS taskType, MAX(h.doneAt) AS doneAt " +
+            "FROM CareHistory h " +
+            "WHERE h.plant.user.id = :userId AND h.cancelledBy IS NULL " +
+            "AND h.plant.archivedAt IS NULL " +
+            "AND h.doneAt >= :from AND h.doneAt <= :to " +
+            "GROUP BY h.plant.id, h.taskType")
+    List<DoneTaskKey> findDoneTaskKeysInRange(
+            @Param("userId") Long userId,
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to
+    );
+
+    /** Проекция «(plant, taskType) → момент отметки» для done-фида /today (issue #184). */
+    interface DoneTaskKey {
+        Long getPlantId();
+        TaskType getTaskType();
+        LocalDateTime getDoneAt();
+    }
+
     /** Проекция «тип ухода → количество» для разбивки месячного отчёта (issue #137). */
     interface TaskTypeCount {
         TaskType getTaskType();

--- a/src/main/java/com/plantcare/core/service/TodayApiService.java
+++ b/src/main/java/com/plantcare/core/service/TodayApiService.java
@@ -1,6 +1,8 @@
 package com.plantcare.core.service;
 
 import com.plantcare.core.domain.CareSchedule;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.repository.CareHistoryRepository;
 import com.plantcare.core.repository.CareScheduleRepository;
 import com.plantcare.core.util.TimeUtils;
 import lombok.RequiredArgsConstructor;
@@ -10,13 +12,24 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
- * Сервис для REST API «сегодняшних» задач ухода (issue #86).
+ * Сервис для REST API «сегодняшних» задач ухода (issue #86, #184).
  *
  * <p>Вынесен из {@link com.plantcare.api.v1.TodayController},
  * чтобы репозиторий не был виден контроллеру напрямую (CLAUDE.md: «никаких репозиториев в хендлерах»).
+ *
+ * <p>Done-фид (issue #184, ADR-014): выдача = UNION (а) pending — активные
+ * расписания с {@code nextDueAt} до конца сегодняшнего дня в TZ юзера;
+ * (б) done-сегодня — активные расписания, по которым есть активная (не-cancelled)
+ * запись {@code care_history} в окне сегодняшнего дня. Дедуп по (plantId, taskType)
+ * в пользу done.
  */
 @Slf4j
 @Service
@@ -25,19 +38,63 @@ import java.util.List;
 public class TodayApiService {
 
     private final CareScheduleRepository careScheduleRepository;
+    private final CareHistoryRepository careHistoryRepository;
     private final Clock clock;
 
     /**
-     * Расписания ухода, дедлайн которых наступает до конца сегодняшнего дня
-     * в таймзоне пользователя.
+     * Задачи ухода на сегодня в таймзоне пользователя: pending (дедлайн до конца дня)
+     * и выполненные сегодня. Дедуп по (plantId, taskType) — done перекрывает pending.
      *
      * @param userId   внутренний id пользователя
      * @param timezone строка таймзоны пользователя
-     * @return список расписаний, отсортированный по nextDueAt ASC
+     * @return задачи, отсортированные pending (по nextDueAt ASC), затем done
      */
-    public List<CareSchedule> getTodaySchedules(Long userId, String timezone) {
+    public List<TodayTask> getTodayTasks(Long userId, String timezone) {
+        LocalDateTime startOfToday = TimeUtils.startOfTodayInUtc(timezone, clock);
         LocalDateTime endOfToday = TimeUtils.endOfTodayInUtc(timezone, clock);
-        log.debug("getTodaySchedules: userId={}, timezone={}, endOfToday={}", userId, timezone, endOfToday);
-        return careScheduleRepository.findUserSchedulesDueBefore(userId, endOfToday);
+        log.debug("getTodayTasks: userId={}, timezone={}, startOfToday={}, endOfToday={}",
+                userId, timezone, startOfToday, endOfToday);
+
+        Map<TaskKey, LocalDateTime> doneByKey = new HashMap<>();
+        for (CareHistoryRepository.DoneTaskKey key :
+                careHistoryRepository.findDoneTaskKeysInRange(userId, startOfToday, endOfToday)) {
+            doneByKey.put(new TaskKey(key.getPlantId(), key.getTaskType()), key.getDoneAt());
+        }
+
+        List<CareSchedule> schedules = careScheduleRepository.findActiveSchedulesByUserId(userId);
+
+        List<TodayTask> tasks = new ArrayList<>();
+        for (CareSchedule schedule : schedules) {
+            TaskKey key = new TaskKey(schedule.getPlant().getId(), schedule.getTaskType());
+            LocalDateTime doneAt = doneByKey.get(key);
+            boolean pending = !schedule.getNextDueAt().isAfter(endOfToday);
+            if (pending || doneAt != null) {
+                tasks.add(new TodayTask(schedule, doneAt));
+            }
+        }
+
+        // pending (doneAt == null) сначала, по nextDueAt ASC; done — в конце, по doneAt ASC.
+        tasks.sort(Comparator
+                .comparing((TodayTask t) -> t.doneAt() != null)
+                .thenComparing(t -> t.doneAt() != null ? t.doneAt() : t.schedule().getNextDueAt()));
+
+        return tasks;
+    }
+
+    /**
+     * Текущий момент в UTC wall-clock — граница для расчёта overdue.
+     */
+    public LocalDateTime nowUtc() {
+        return LocalDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
+    }
+
+    /**
+     * Задача на сегодня: расписание + опциональный момент отметки «сделано».
+     * {@code doneAt == null} — pending.
+     */
+    public record TodayTask(CareSchedule schedule, LocalDateTime doneAt) {
+    }
+
+    private record TaskKey(Long plantId, TaskType taskType) {
     }
 }

--- a/src/main/java/com/plantcare/core/util/TimeUtils.java
+++ b/src/main/java/com/plantcare/core/util/TimeUtils.java
@@ -39,6 +39,24 @@ public final class TimeUtils {
     }
 
     /**
+     * Начало текущего дня (00:00:00) в UTC, вычисленное относительно таймзоны пользователя.
+     *
+     * <p>Зеркало {@link #endOfTodayInUtc(String, Clock)} — даёт нижнюю границу
+     * окна «сегодня» в TZ юзера, сконвертированную в UTC.
+     *
+     * @param timezone строка таймзоны (например, "Europe/Moscow", "Asia/Almaty")
+     * @param clock    инжектируемый Clock-бин
+     * @return начало сегодняшнего дня в UTC
+     */
+    public static LocalDateTime startOfTodayInUtc(String timezone, Clock clock) {
+        ZoneId userZone = safeZone(timezone);
+        LocalDate todayInUserTz = clock.instant().atZone(userZone).toLocalDate();
+        ZonedDateTime startOfDay = todayInUserTz
+                .atStartOfDay(userZone);
+        return startOfDay.withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+    }
+
+    /**
      * Безопасное получение {@link ZoneId} по строке: при неверном значении
      * логирует предупреждение и возвращает UTC.
      *

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -224,6 +224,8 @@ components:
 
     TodayResponse:
       $ref: './resources/today.yaml#/schemas/TodayResponse'
+    TodaySummary:
+      $ref: './resources/today.yaml#/schemas/TodaySummary'
 
     StreakResponse:
       $ref: './resources/stats.yaml#/schemas/StreakResponse'

--- a/src/main/resources/openapi/resources/calendar.yaml
+++ b/src/main/resources/openapi/resources/calendar.yaml
@@ -81,6 +81,14 @@ schemas:
         type: string
         format: date-time
         description: Ближайший дедлайн (UTC).
+      doneAt:
+        type: string
+        format: date-time
+        nullable: true
+        description: |
+          Момент отметки «сделано» (UTC), если задача выполнена сегодня
+          (mobile gap G11, ADR-014). `null` — задача ещё не выполнена (pending).
+          В выдаче `/calendar` всегда `null`.
 
   CalendarResponse:
     type: object

--- a/src/main/resources/openapi/resources/today.yaml
+++ b/src/main/resources/openapi/resources/today.yaml
@@ -26,7 +26,7 @@ schemas:
   TodayResponse:
     type: object
     description: Ответ `GET /api/v1/today`.
-    required: [tasks, count]
+    required: [tasks, count, summary]
     properties:
       tasks:
         type: array
@@ -36,3 +36,29 @@ schemas:
         type: integer
         format: int32
         description: Длина `tasks` (дублируется для удобства клиента).
+      summary:
+        $ref: '#/schemas/TodaySummary'
+
+  TodaySummary:
+    type: object
+    description: |
+      Сводка по сегодняшним задачам (mobile gap G11, ADR-014).
+      `total == count ==` длине `tasks`. `done + remaining == total`.
+    required: [total, done, remaining, overdue]
+    properties:
+      total:
+        type: integer
+        format: int32
+        description: Всего задач в выдаче (= `count`).
+      done:
+        type: integer
+        format: int32
+        description: Задачи, отмеченные сегодня (`doneAt != null`).
+      remaining:
+        type: integer
+        format: int32
+        description: Невыполненные задачи (`total - done`).
+      overdue:
+        type: integer
+        format: int32
+        description: Невыполненные задачи, дедлайн которых уже прошёл (`nextDueAt < now`).

--- a/src/test/java/com/plantcare/api/v1/TodayControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/TodayControllerTest.java
@@ -71,8 +71,9 @@ class TodayControllerTest {
 
         CareSchedule schedule = mockSchedule(10L, 100L, "Монстера", TaskType.WATERING,
                 LocalDateTime.now().plusHours(1));
-        when(todayApiService.getTodaySchedules(anyLong(), anyString()))
-                .thenReturn(List.of(schedule));
+        when(todayApiService.getTodayTasks(anyLong(), anyString()))
+                .thenReturn(List.of(new TodayApiService.TodayTask(schedule, null)));
+        when(todayApiService.nowUtc()).thenReturn(LocalDateTime.now());
 
         // act + assert
         mockMvc.perform(get("/api/v1/today"))
@@ -90,8 +91,9 @@ class TodayControllerTest {
         // arrange
         User user = mockUserWithTimezone(2L, 2L, "UTC");
         when(currentUserProvider.currentUser()).thenReturn(user);
-        when(todayApiService.getTodaySchedules(anyLong(), anyString()))
+        when(todayApiService.getTodayTasks(anyLong(), anyString()))
                 .thenReturn(List.of());
+        when(todayApiService.nowUtc()).thenReturn(LocalDateTime.now());
 
         // act + assert
         mockMvc.perform(get("/api/v1/today"))
@@ -159,8 +161,11 @@ class TodayControllerTest {
                 LocalDateTime.now().plusHours(2));
         CareSchedule misting = mockSchedule(12L, 102L, "Орхидея", TaskType.MISTING,
                 LocalDateTime.now().plusHours(3));
-        when(todayApiService.getTodaySchedules(anyLong(), anyString()))
-                .thenReturn(List.of(watering, misting));
+        when(todayApiService.getTodayTasks(anyLong(), anyString()))
+                .thenReturn(List.of(
+                        new TodayApiService.TodayTask(watering, null),
+                        new TodayApiService.TodayTask(misting, null)));
+        when(todayApiService.nowUtc()).thenReturn(LocalDateTime.now());
 
         // act + assert
         mockMvc.perform(get("/api/v1/today"))
@@ -181,8 +186,9 @@ class TodayControllerTest {
         when(species.getId()).thenReturn(77L);
         when(species.getName()).thenReturn("Monstera deliciosa");
         when(schedule.getPlant().getSpecies()).thenReturn(species);
-        when(todayApiService.getTodaySchedules(anyLong(), anyString()))
-                .thenReturn(List.of(schedule));
+        when(todayApiService.getTodayTasks(anyLong(), anyString()))
+                .thenReturn(List.of(new TodayApiService.TodayTask(schedule, null)));
+        when(todayApiService.nowUtc()).thenReturn(LocalDateTime.now());
 
         // act + assert
         mockMvc.perform(get("/api/v1/today"))
@@ -200,14 +206,43 @@ class TodayControllerTest {
         CareSchedule schedule = mockSchedule(14L, 104L, "Безымянное", TaskType.MISTING,
                 LocalDateTime.now().plusHours(1));
         // getSpecies() не застаблен → null
-        when(todayApiService.getTodaySchedules(anyLong(), anyString()))
-                .thenReturn(List.of(schedule));
+        when(todayApiService.getTodayTasks(anyLong(), anyString()))
+                .thenReturn(List.of(new TodayApiService.TodayTask(schedule, null)));
+        when(todayApiService.nowUtc()).thenReturn(LocalDateTime.now());
 
         // act + assert
         mockMvc.perform(get("/api/v1/today"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.tasks[0].speciesId").isEmpty())
                 .andExpect(jsonPath("$.tasks[0].speciesName").isEmpty());
+    }
+
+    @Test
+    void should_compute_summary_with_done_and_overdue() throws Exception {
+        // arrange — одна просроченная pending + одна выполненная сегодня (mobile gap G11)
+        User user = mockUserWithTimezone(6L, 6L, "UTC");
+        when(currentUserProvider.currentUser()).thenReturn(user);
+
+        LocalDateTime now = LocalDateTime.of(2026, 5, 25, 12, 0);
+        CareSchedule overdue = mockSchedule(15L, 105L, "Фикус", TaskType.WATERING, now.minusHours(2));
+        CareSchedule doneSched = mockSchedule(16L, 106L, "Монстера", TaskType.MISTING, now.plusDays(3));
+        LocalDateTime doneAt = LocalDateTime.of(2026, 5, 25, 7, 42);
+        when(todayApiService.getTodayTasks(anyLong(), anyString()))
+                .thenReturn(List.of(
+                        new TodayApiService.TodayTask(overdue, null),
+                        new TodayApiService.TodayTask(doneSched, doneAt)));
+        when(todayApiService.nowUtc()).thenReturn(now);
+
+        // act + assert — overdue pending (doneAt null) + done; summary считается контроллером
+        mockMvc.perform(get("/api/v1/today"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.count").value(2))
+                .andExpect(jsonPath("$.summary.total").value(2))
+                .andExpect(jsonPath("$.summary.done").value(1))
+                .andExpect(jsonPath("$.summary.remaining").value(1))
+                .andExpect(jsonPath("$.summary.overdue").value(1))
+                .andExpect(jsonPath("$.tasks[0].doneAt").isEmpty())
+                .andExpect(jsonPath("$.tasks[1].doneAt").value("2026-05-25T07:42:00Z"));
     }
 
     // ===================== helpers =====================

--- a/src/test/java/com/plantcare/core/service/TodayApiServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/TodayApiServiceTest.java
@@ -1,0 +1,258 @@
+package com.plantcare.core.service;
+
+import com.plantcare.core.domain.CareHistory;
+import com.plantcare.core.domain.CareSchedule;
+import com.plantcare.core.domain.Location;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.repository.CareHistoryRepository;
+import com.plantcare.core.repository.CareScheduleRepository;
+import com.plantcare.core.repository.LocationRepository;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.UserRepository;
+import com.plantcare.core.service.TodayApiService.TodayTask;
+import com.plantcare.bot.support.IntegrationTestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+/**
+ * Интеграционные тесты done-фида {@code /today} (issue #184, ADR-014) на реальном
+ * Postgres через Testcontainers — выборка UNION pending+done и матчинг
+ * {@code care_history} ↔ {@code care_schedules} проверяются на настоящих записях,
+ * а не на моках репозитория.
+ *
+ * <p>{@link Clock}-бин подменён фиксированным {@link #FIXED_NOW}, чтобы границы окна
+ * «сегодня» в TZ юзера были детерминированными.
+ *
+ * <p>Покрывает AC #184: pending; done-сегодня (с уехавшим вперёд nextDueAt);
+ * дедуп pending+done; ретро-отметка (вчера) не считается сегодня; cancelled не
+ * считается; пустой день; не-UTC TZ на границе суток.
+ */
+@DisplayName("TodayApiService — done-фид /today (issue #184)")
+@Import(TodayApiServiceTest.FixedClockConfig.class)
+class TodayApiServiceTest extends IntegrationTestBase {
+
+    /**
+     * Фиксированный «сейчас» 00:30 UTC: для восточных TZ (Almaty UTC+5) локальная
+     * дата уже «сегодня», а UTC-полночь окна и локальная-полночь расходятся на день —
+     * это проверяет TZ-кейс на границе суток.
+     */
+    static final Instant FIXED_NOW = Instant.parse("2026-05-25T00:30:00Z");
+
+    @TestConfiguration
+    static class FixedClockConfig {
+        @Bean
+        @Primary
+        Clock fixedClock() {
+            return Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+        }
+    }
+
+    @Autowired private TodayApiService service;
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private LocationRepository locationRepository;
+    @Autowired private PlantRepository plantRepository;
+    @Autowired private CareScheduleRepository careScheduleRepository;
+    @Autowired private CareHistoryRepository careHistoryRepository;
+
+    @AfterEach
+    void cleanup() {
+        careHistoryRepository.deleteAll();
+        careScheduleRepository.deleteAll();
+        plantRepository.deleteAll();
+        locationRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("should_return_pending_task_without_doneAt_when_due_today_and_no_history")
+    void should_return_pending_task_without_doneAt_when_due_today_and_no_history() {
+        // arrange — расписание с дедлайном сегодня, без записей в care_history
+        User user = savedUser(9001L, "UTC");
+        Plant plant = savedPlant(user, "Монстера");
+        savedSchedule(plant, TaskType.WATERING, utc("2026-05-25T10:00:00"));
+
+        // act
+        List<TodayTask> tasks = service.getTodayTasks(user.getId(), "UTC");
+
+        // assert
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).doneAt()).isNull();
+        assertThat(tasks.get(0).schedule().getTaskType()).isEqualTo(TaskType.WATERING);
+    }
+
+    @Test
+    @DisplayName("should_include_done_today_even_when_nextDueAt_moved_to_future")
+    void should_include_done_today_even_when_nextDueAt_moved_to_future() {
+        // arrange — отметили сегодня, markCareDone сдвинул nextDueAt вперёд (выпал из pending),
+        // но done-запись за сегодня обязана вернуть задачу с doneAt (ключевой кейс G11)
+        User user = savedUser(9002L, "UTC");
+        Plant plant = savedPlant(user, "Фикус");
+        savedSchedule(plant, TaskType.WATERING, utc("2026-05-30T10:00:00")); // в будущем
+        savedCare(plant, TaskType.WATERING, utc("2026-05-25T07:42:00"), null);
+
+        // act
+        List<TodayTask> tasks = service.getTodayTasks(user.getId(), "UTC");
+
+        // assert
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).doneAt()).isEqualTo(utc("2026-05-25T07:42:00"));
+    }
+
+    @Test
+    @DisplayName("should_dedup_pending_and_done_into_single_done_task")
+    void should_dedup_pending_and_done_into_single_done_task() {
+        // arrange — задача и в pending (дедлайн сегодня), и с done-записью за сегодня
+        User user = savedUser(9003L, "UTC");
+        Plant plant = savedPlant(user, "Орхидея");
+        savedSchedule(plant, TaskType.MISTING, utc("2026-05-25T08:00:00"));
+        savedCare(plant, TaskType.MISTING, utc("2026-05-25T09:00:00"), null);
+
+        // act
+        List<TodayTask> tasks = service.getTodayTasks(user.getId(), "UTC");
+
+        // assert — одна запись, в пользу done
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).doneAt()).isEqualTo(utc("2026-05-25T09:00:00"));
+    }
+
+    @Test
+    @DisplayName("should_not_count_retro_done_from_yesterday_as_done_today")
+    void should_not_count_retro_done_from_yesterday_as_done_today() {
+        // arrange — отметка задним числом за вчера; nextDueAt в будущем (не pending)
+        User user = savedUser(9004L, "UTC");
+        Plant plant = savedPlant(user, "Кактус");
+        savedSchedule(plant, TaskType.WATERING, utc("2026-05-30T10:00:00"));
+        savedCare(plant, TaskType.WATERING, utc("2026-05-24T12:00:00"), null); // вчера
+
+        // act
+        List<TodayTask> tasks = service.getTodayTasks(user.getId(), "UTC");
+
+        // assert — вчерашняя отметка не делает задачу done-сегодня, и pending нет → пусто
+        assertThat(tasks).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_not_count_cancelled_history_as_done")
+    void should_not_count_cancelled_history_as_done() {
+        // arrange — done-запись за сегодня, но отменённая (cancelledBy != null)
+        User user = savedUser(9005L, "UTC");
+        Plant plant = savedPlant(user, "Спатифиллум");
+        savedSchedule(plant, TaskType.FERTILIZING, utc("2026-05-30T10:00:00")); // не pending
+        CareHistory compensating = savedCare(plant, TaskType.FERTILIZING, utc("2026-05-20T10:00:00"), null);
+        savedCare(plant, TaskType.FERTILIZING, utc("2026-05-25T11:00:00"), compensating); // cancelled
+
+        // act
+        List<TodayTask> tasks = service.getTodayTasks(user.getId(), "UTC");
+
+        // assert — отменённая запись не считается done, pending нет → пусто
+        assertThat(tasks).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_return_empty_when_user_has_no_schedules")
+    void should_return_empty_when_user_has_no_schedules() {
+        // arrange
+        User user = savedUser(9006L, "UTC");
+
+        // act
+        List<TodayTask> tasks = service.getTodayTasks(user.getId(), "UTC");
+
+        // assert
+        assertThat(tasks).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_match_done_on_day_boundary_in_user_timezone_not_utc")
+    void should_match_done_on_day_boundary_in_user_timezone_not_utc() {
+        // arrange — юзер в Asia/Almaty (UTC+5). FIXED_NOW = 2026-05-25 00:30 UTC = 05:30 Алматы.
+        // Окно «сегодня» по Алматы: [2026-05-24 19:00 UTC; 2026-05-25 18:59:59 UTC].
+        // done_at = 2026-05-24 20:00 UTC = 2026-05-25 01:00 Алматы → «сегодня» локально, в окне;
+        // при наивном UTC-расчёте (граница 2026-05-25 00:00 UTC) выпало бы. nextDueAt в будущем.
+        User user = savedUser(9007L, "Asia/Almaty");
+        Plant plant = savedPlant(user, "Алматинская монстера");
+        savedSchedule(plant, TaskType.WATERING, utc("2026-05-30T10:00:00"));
+        savedCare(plant, TaskType.WATERING, utc("2026-05-24T20:00:00"), null);
+
+        // act
+        List<TodayTask> tasks = service.getTodayTasks(user.getId(), "Asia/Almaty");
+
+        // assert — отметка засчитана как done сегодня по TZ юзера
+        assertSoftly(softly -> {
+            softly.assertThat(tasks).hasSize(1);
+            softly.assertThat(tasks.get(0).doneAt()).isEqualTo(utc("2026-05-24T20:00:00"));
+        });
+    }
+
+    // ===================== helpers =====================
+
+    private User savedUser(Long chatId, String timezone) {
+        return userRepository.save(User.builder()
+                .telegramChatId(chatId)
+                .timezone(timezone)
+                .blocked(false)
+                .build());
+    }
+
+    private Location savedDefaultLocation(User user) {
+        return locationRepository.findByUserIdAndDefaultLocationTrue(user.getId())
+                .orElseGet(() -> locationRepository.save(Location.builder()
+                        .user(user)
+                        .name(Location.DEFAULT_NAME)
+                        .emoji(Location.DEFAULT_EMOJI)
+                        .defaultLocation(true)
+                        .build()));
+    }
+
+    private Plant savedPlant(User user, String name) {
+        return plantRepository.save(Plant.builder()
+                .user(user)
+                .location(savedDefaultLocation(user))
+                .name(name)
+                .acquiredAt(LocalDate.of(2024, 1, 1))
+                .build());
+    }
+
+    private CareSchedule savedSchedule(Plant plant, TaskType type, LocalDateTime nextDueAt) {
+        return careScheduleRepository.save(CareSchedule.builder()
+                .plant(plant)
+                .taskType(type)
+                .intervalDays(7)
+                .nextDueAt(nextDueAt)
+                .active(true)
+                .build());
+    }
+
+    private CareHistory savedCare(Plant plant, TaskType type, LocalDateTime doneAt, CareHistory cancelledBy) {
+        return careHistoryRepository.save(CareHistory.builder()
+                .plant(plant)
+                .taskType(type)
+                .doneAt(doneAt)
+                .onTime(true)
+                .cancelledBy(cancelledBy)
+                .build());
+    }
+
+    private static LocalDateTime utc(String isoLocal) {
+        return LocalDateTime.parse(isoLocal).truncatedTo(ChronoUnit.MICROS);
+    }
+}


### PR DESCRIPTION
Closes #184

## Что сделано
- `TaskDto += doneAt: string?` (nullable) — момент отметки «сделано» (UTC); `null` = pending.
- `TodayResponse += summary { total, done, remaining, overdue }` — прогресс дня без клиентского пересчёта.
- `/today` теперь включает **выполненные сегодня**: UNION pending-расписаний (дедлайн ≤ конца дня в TZ юзера) и расписаний с активной done-записью `care_history` за сегодня; дедуп по `(plantId, taskType)` в пользу done. Закрывает дыру, когда `markCareDone` сдвигал `nextDueAt` вперёд и выполненная задача исчезала из выдачи.
- `TimeUtils.startOfTodayInUtc` (зеркало `endOfTodayInUtc`); `CareHistoryRepository.findDoneTaskKeysInRange` (проекция `(plantId, taskType, MAX(doneAt))`, только не-cancelled, неархивные).
- Матчинг history↔schedule по равенству `TaskType` (без алиаса WATER/SPRAY); `SOIL_CHECK` наравне. Ретро-отметка засчитывается в свой день (по `done_at`).
- `toTaskDto` перегружен совместимо — `/calendar` не затронут (это отдельный issue #190).

## Миграции
Нет — данные уже в `care_history` (ADR-014 §7).

## Backward-compat риски
Safe / аддитивно: `doneAt` nullable; `summary` — новое поле; `count` == длине `tasks` (== `summary.total`). Единственный консьюмер `/today` — мобильный REST (Telegram-бот ходит через отдельный `CalendarService`).

## Тесты
- `TodayApiServiceTest` (Testcontainers, фикс. Clock): не-UTC TZ на границе суток (Asia/Almaty), дедуп pending+done, ретро-done не считается сегодня, cancelled не считается, done-сегодня при уехавшем вперёд `nextDueAt`, пустой день.
- `TodayControllerTest`: расчёт `summary` (done/remaining/overdue), сериализация `doneAt`.

## Чек
- [x] `mvn verify` зелёное на Java 21 (1321 run, 0 fail; чистый Testcontainers-контейнер)
- [x] reviewer-проверка пройдена (само-ревью: overdue/дедуп/N+1/TZ — без блокеров)

> База PR — `develop` (флоу проекта; #184 строится на TaskDto с G6/G13, которые в develop). ADR-014 — Proposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)