### PR TITLE
feat: REST CRUD списка покупок /api/v1/shopping (#196)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 | `PUT` | `/api/v1/locations/{id}` | Обновить имя и/или emoji |
 | `DELETE` | `/api/v1/locations/{id}` | Удалить локацию. Если в ней есть растения, обязателен параметр `targetLocationId` — растения переносятся в указанную локацию перед удалением |
 
+### Shopping (issue #196)
+
+Персональный список покупок пользователя. Все эндпоинты user-scoped.
+
+| Метод | Путь | Статус ответа | Описание |
+|---|---|---|---|
+| `GET` | `/api/v1/shopping` | 200 | Список позиций: `{ "items": [{ "id", "title", "checked", "createdAt" }] }` |
+| `POST` | `/api/v1/shopping` | 201 | Добавить позицию. Тело: `{ "title" }` |
+| `PATCH` | `/api/v1/shopping/{id}` | 200 | Частичное обновление: передаются только изменяемые поля (`checked`, `title`) |
+| `DELETE` | `/api/v1/shopping/{id}` | 204 | Удалить позицию |
+
 ### Формат ошибок
 
 Все ошибки `/api/**` возвращаются в едином формате:

--- a/http/api.http
+++ b/http/api.http
@@ -140,6 +140,34 @@ Content-Type: application/json
 DELETE {{baseUrl}}/api/v1/care-events/1
 Authorization: Bearer {{token}}
 
+### --- Shopping (список покупок) ---
+
+### Список позиций
+GET {{baseUrl}}/api/v1/shopping
+Authorization: Bearer {{token}}
+
+### Добавить позицию
+POST {{baseUrl}}/api/v1/shopping
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+  "title": "удобрение для монстеры"
+}
+
+### Обновить позицию (частично: checked и/или title)
+PATCH {{baseUrl}}/api/v1/shopping/1
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+  "checked": true
+}
+
+### Удалить позицию
+DELETE {{baseUrl}}/api/v1/shopping/1
+Authorization: Bearer {{token}}
+
 ### --- Справочники (публично) ---
 
 ### Поиск/список видов

--- a/src/main/java/com/plantcare/api/v1/ShoppingController.java
+++ b/src/main/java/com/plantcare/api/v1/ShoppingController.java
@@ -1,0 +1,90 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.api.generated.ShoppingApi;
+import com.plantcare.api.generated.model.ShoppingItemCreateRequest;
+import com.plantcare.api.generated.model.ShoppingItemDto;
+import com.plantcare.api.generated.model.ShoppingItemUpdateRequest;
+import com.plantcare.api.generated.model.ShoppingListResponse;
+import com.plantcare.core.domain.ShoppingItem;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.service.ShoppingListService;
+import com.plantcare.core.service.UserService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.ZoneOffset;
+
+/**
+ * REST API для персонального списка покупок (issue #196).
+ *
+ * <p>Документация и mapping живут в сгенерированном {@link ShoppingApi} (см. openapi.yaml).
+ */
+@RestController
+@RequiredArgsConstructor
+public class ShoppingController implements ShoppingApi {
+
+    private final ShoppingListService shoppingListService;
+    private final UserService userService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    public ShoppingListResponse listShoppingItems() {
+        Long userId = currentUserProvider.currentUserId();
+        return new ShoppingListResponse(
+                shoppingListService.list(userId).stream()
+                        .map(ShoppingController::toDto)
+                        .toList()
+        );
+    }
+
+    @Override
+    public ShoppingItemDto createShoppingItem(ShoppingItemCreateRequest request) {
+        User user = userService.getByIdOrThrow(currentUserProvider.currentUserId());
+        return toDto(shoppingListService.add(user, request.getTitle()));
+    }
+
+    @Override
+    public ShoppingItemDto updateShoppingItem(Long id, ShoppingItemUpdateRequest request) {
+        Long userId = currentUserProvider.currentUserId();
+        try {
+            ShoppingItem updated = shoppingListService.update(
+                    userId, id, request.getChecked(), request.getTitle());
+            return toDto(updated);
+        } catch (IllegalArgumentException e) {
+            // update() валидирует title ДО поиска, поэтому not-found — единственный
+            // случай с этим сообщением; его маппим в 404. Ошибки валидации title
+            // несут другое сообщение и пробрасываются дальше → 400.
+            throw toNotFoundOrRethrow(e, id);
+        }
+    }
+
+    @Override
+    public void deleteShoppingItem(Long id) {
+        Long userId = currentUserProvider.currentUserId();
+        try {
+            shoppingListService.delete(userId, id);
+        } catch (IllegalArgumentException e) {
+            throw toNotFoundOrRethrow(e, id);
+        }
+    }
+
+    private static RuntimeException toNotFoundOrRethrow(IllegalArgumentException e, Long id) {
+        if (ShoppingListService.ITEM_NOT_FOUND.equals(e.getMessage())) {
+            return new EntityNotFoundException("Shopping item not found: " + id);
+        }
+        return e;
+    }
+
+    private static ShoppingItemDto toDto(ShoppingItem item) {
+        ShoppingItemDto dto = new ShoppingItemDto()
+                .id(item.getId())
+                .title(item.getTitle())
+                .checked(item.isChecked());
+        if (item.getCreatedAt() != null) {
+            dto.createdAt(item.getCreatedAt().atOffset(ZoneOffset.UTC));
+        }
+        return dto;
+    }
+}

--- a/src/main/java/com/plantcare/core/domain/ShoppingItem.java
+++ b/src/main/java/com/plantcare/core/domain/ShoppingItem.java
@@ -45,4 +45,11 @@ public class ShoppingItem extends BaseEntity {
     public void setChecked(boolean checked) {
         this.checked = checked;
     }
+
+    /**
+     * Меняет текст позиции. Валидация (не пусто, не длиннее лимита) — на сервисе.
+     */
+    public void setTitle(String title) {
+        this.title = title;
+    }
 }

--- a/src/main/java/com/plantcare/core/service/ShoppingListService.java
+++ b/src/main/java/com/plantcare/core/service/ShoppingListService.java
@@ -23,6 +23,7 @@ import java.util.List;
 public class ShoppingListService {
 
     private static final int MAX_TITLE_LENGTH = 160;
+    public static final String ITEM_NOT_FOUND = "Позиция не найдена";
 
     private final ShoppingItemRepository shoppingItemRepository;
 
@@ -33,17 +34,7 @@ public class ShoppingListService {
 
     @Transactional
     public ShoppingItem add(User user, String rawTitle) {
-        String title = rawTitle == null ? "" : rawTitle.trim();
-
-        if (title.isBlank()) {
-            throw new IllegalArgumentException("Текст позиции не может быть пустым");
-        }
-
-        if (title.length() > MAX_TITLE_LENGTH) {
-            throw new IllegalArgumentException(
-                    "Слишком длинно — максимум " + MAX_TITLE_LENGTH + " символов"
-            );
-        }
+        String title = normalizeTitle(rawTitle);
 
         ShoppingItem saved = shoppingItemRepository.save(new ShoppingItem(user, title));
 
@@ -52,10 +43,51 @@ public class ShoppingListService {
         return saved;
     }
 
+    /**
+     * Частичное обновление позиции, скоупленной по владельцу. Передаются только
+     * меняемые поля: {@code checked} и/или {@code title} (null = «не трогать»).
+     * Возвращает обновлённую сущность.
+     */
+    @Transactional
+    public ShoppingItem update(Long userId, Long itemId, Boolean checked, String title) {
+        // Валидируем title ДО поиска, чтобы битый ввод всегда давал 400 (а не 404),
+        // независимо от существования позиции.
+        String normalizedTitle = title == null ? null : normalizeTitle(title);
+
+        ShoppingItem item = shoppingItemRepository.findByUserIdAndId(userId, itemId)
+                .orElseThrow(() -> new IllegalArgumentException(ITEM_NOT_FOUND));
+
+        if (checked != null) {
+            item.setChecked(checked);
+        }
+
+        if (normalizedTitle != null) {
+            item.setTitle(normalizedTitle);
+        }
+
+        log.info("Updated shopping item {} of user {}", itemId, userId);
+
+        return item;
+    }
+
+    /**
+     * Удаляет одну позицию пользователя. Чужая или несуществующая позиция —
+     * IllegalArgumentException (маппится в 404 на REST-слое).
+     */
+    @Transactional
+    public void delete(Long userId, Long itemId) {
+        ShoppingItem item = shoppingItemRepository.findByUserIdAndId(userId, itemId)
+                .orElseThrow(() -> new IllegalArgumentException(ITEM_NOT_FOUND));
+
+        shoppingItemRepository.delete(item);
+
+        log.info("Deleted shopping item {} of user {}", itemId, userId);
+    }
+
     @Transactional
     public void toggle(Long userId, Long itemId, boolean targetChecked) {
         ShoppingItem item = shoppingItemRepository.findByUserIdAndId(userId, itemId)
-                .orElseThrow(() -> new IllegalArgumentException("Позиция не найдена"));
+                .orElseThrow(() -> new IllegalArgumentException(ITEM_NOT_FOUND));
 
         item.setChecked(targetChecked);
 
@@ -69,5 +101,21 @@ public class ShoppingListService {
         log.info("Cleared {} checked shopping items for user {}", removed, userId);
 
         return removed;
+    }
+
+    private static String normalizeTitle(String rawTitle) {
+        String title = rawTitle == null ? "" : rawTitle.trim();
+
+        if (title.isBlank()) {
+            throw new IllegalArgumentException("Текст позиции не может быть пустым");
+        }
+
+        if (title.length() > MAX_TITLE_LENGTH) {
+            throw new IllegalArgumentException(
+                    "Слишком длинно — максимум " + MAX_TITLE_LENGTH + " символов"
+            );
+        }
+
+        return title;
     }
 }

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -82,6 +82,8 @@ tags:
     description: Публичный справочник видов растений. Без авторизации.
   - name: Care Types
     description: Публичный справочник типов ухода (полив, опрыскивание, и т.п.). Без авторизации.
+  - name: Shopping
+    description: Персональный список покупок пользователя — расходники для ухода за растениями.
 
 paths:
   /api/v1/auth/apple:
@@ -136,6 +138,11 @@ paths:
 
   /api/v1/care-types:
     $ref: './resources/care-types.yaml#/paths/Collection'
+
+  /api/v1/shopping:
+    $ref: './resources/shopping.yaml#/paths/Collection'
+  /api/v1/shopping/{id}:
+    $ref: './resources/shopping.yaml#/paths/Item'
 
 components:
   securitySchemes:
@@ -239,6 +246,15 @@ components:
 
     CareTypeDto:
       $ref: './resources/care-types.yaml#/schemas/CareTypeDto'
+
+    ShoppingItemDto:
+      $ref: './resources/shopping.yaml#/schemas/ShoppingItemDto'
+    ShoppingListResponse:
+      $ref: './resources/shopping.yaml#/schemas/ShoppingListResponse'
+    ShoppingItemCreateRequest:
+      $ref: './resources/shopping.yaml#/schemas/ShoppingItemCreateRequest'
+    ShoppingItemUpdateRequest:
+      $ref: './resources/shopping.yaml#/schemas/ShoppingItemUpdateRequest'
 
     ApiErrorResponse:
       $ref: './_common/errors.yaml#/schemas/ApiErrorResponse'

--- a/src/main/resources/openapi/resources/shopping.yaml
+++ b/src/main/resources/openapi/resources/shopping.yaml
@@ -1,0 +1,154 @@
+# CRUD персонального списка покупок пользователя (issue #196, mobile G27).
+
+paths:
+  Collection:
+    get:
+      tags: [Shopping]
+      operationId: listShoppingItems
+      summary: Список покупок пользователя
+      description: |
+        Возвращает все позиции списка покупок текущего пользователя
+        (`sub` из bearer-токена). Сначала ещё не купленные, затем купленные.
+        Без пагинации — список обычно короткий.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Список покупок.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/ShoppingListResponse'
+    post:
+      tags: [Shopping]
+      operationId: createShoppingItem
+      summary: Добавить позицию в список покупок
+      description: Создаёт позицию от имени пользователя. Пустой или слишком длинный текст — 400.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/ShoppingItemCreateRequest'
+            example:
+              title: Грунт для суккулентов
+      responses:
+        '201':
+          description: Позиция создана.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/ShoppingItemDto'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+
+  Item:
+    patch:
+      tags: [Shopping]
+      operationId: updateShoppingItem
+      summary: Обновить позицию списка покупок
+      description: PATCH-семантика — обновляются только переданные поля.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Идентификатор позиции.
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/ShoppingItemUpdateRequest'
+      responses:
+        '200':
+          description: Позиция обновлена.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/ShoppingItemDto'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+    delete:
+      tags: [Shopping]
+      operationId: deleteShoppingItem
+      summary: Удалить позицию списка покупок
+      description: Удаляет позицию, принадлежащую пользователю. Чужая или несуществующая — 404.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Идентификатор позиции.
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '204':
+          description: Позиция удалена.
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+schemas:
+  ShoppingItemDto:
+    type: object
+    description: Позиция персонального списка покупок.
+    required: [id, title, checked]
+    properties:
+      id:
+        type: integer
+        format: int64
+      title:
+        type: string
+        example: Грунт для суккулентов
+      checked:
+        type: boolean
+        description: Куплено ли уже.
+        example: false
+      createdAt:
+        type: string
+        format: date-time
+        nullable: true
+
+  ShoppingListResponse:
+    type: object
+    description: Обёртка над списком позиций покупок.
+    required: [items]
+    properties:
+      items:
+        type: array
+        items:
+          $ref: '#/schemas/ShoppingItemDto'
+
+  ShoppingItemCreateRequest:
+    type: object
+    required: [title]
+    properties:
+      title:
+        type: string
+        minLength: 1
+        maxLength: 160
+        example: Грунт для суккулентов
+
+  ShoppingItemUpdateRequest:
+    type: object
+    description: Все поля опциональны.
+    properties:
+      title:
+        type: string
+        maxLength: 160
+        nullable: true
+      checked:
+        type: boolean
+        nullable: true

--- a/src/test/java/com/plantcare/api/v1/ShoppingControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/ShoppingControllerTest.java
@@ -1,0 +1,329 @@
+package com.plantcare.api.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.core.domain.ShoppingItem;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.service.ShoppingListService;
+import com.plantcare.core.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * {@code @WebMvcTest} для {@link ShoppingController} — list/create/update/delete,
+ * валидация (400), not-found (404) и cross-user-скоупинг (404) для shopping-list API (issue #196).
+ *
+ * <p>Зеркалит {@link LocationControllerTest}: фильтры выключены, {@link ApiExceptionHandler}
+ * импортируется, {@link CurrentUserProvider} застаблен на user id = 1.
+ */
+@WebMvcTest(ShoppingController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ShoppingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private ShoppingListService shoppingListService;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    @BeforeEach
+    void stubCurrentUser() {
+        when(currentUserProvider.currentUserId()).thenReturn(1L);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private ShoppingItem mockItem(long id, String title, boolean checked) {
+        ShoppingItem item = mock(ShoppingItem.class);
+        when(item.getId()).thenReturn(id);
+        when(item.getTitle()).thenReturn(title);
+        when(item.isChecked()).thenReturn(checked);
+        when(item.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 5, 25, 10, 0, 0));
+        return item;
+    }
+
+    // ------------------------------------------------------------------ GET list
+
+    @Test
+    void should_return_items_wrapped_under_items_when_listing() throws Exception {
+        // arrange
+        ShoppingItem unchecked = mockItem(1L, "Грунт", false);
+        ShoppingItem checked = mockItem(2L, "Горшок", true);
+
+        when(shoppingListService.list(1L)).thenReturn(List.of(unchecked, checked));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/shopping"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items").isArray())
+                .andExpect(jsonPath("$.items.length()").value(2))
+                .andExpect(jsonPath("$.items[0].id").value(1))
+                .andExpect(jsonPath("$.items[0].title").value("Грунт"))
+                .andExpect(jsonPath("$.items[0].checked").value(false))
+                .andExpect(jsonPath("$.items[1].id").value(2))
+                .andExpect(jsonPath("$.items[1].checked").value(true));
+    }
+
+    @Test
+    void should_return_empty_items_array_when_user_has_no_items() throws Exception {
+        // arrange
+        when(shoppingListService.list(1L)).thenReturn(List.of());
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/shopping"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items").isArray())
+                .andExpect(jsonPath("$.items.length()").value(0));
+    }
+
+    // ------------------------------------------------------------------ POST create
+
+    @Test
+    void should_create_item_and_return_201_when_title_valid() throws Exception {
+        // arrange
+        User user = User.builder().telegramChatId(1L).build();
+        ShoppingItem created = mockItem(5L, "Удобрение", false);
+
+        when(userService.getByIdOrThrow(1L)).thenReturn(user);
+        when(shoppingListService.add(eq(user), eq("Удобрение"))).thenReturn(created);
+
+        String body = """
+                {"title": "Удобрение"}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/shopping")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(5))
+                .andExpect(jsonPath("$.title").value("Удобрение"))
+                .andExpect(jsonPath("$.checked").value(false));
+    }
+
+    @Test
+    void should_return_400_when_create_title_blank() throws Exception {
+        // arrange — @Size(min = 1) on ShoppingItemCreateRequest.title rejects ""
+        String body = """
+                {"title": ""}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/shopping")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.error.details[0].field").value("title"));
+    }
+
+    @Test
+    void should_return_400_when_create_title_missing() throws Exception {
+        // arrange — @NotNull on title
+        String body = "{}";
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/shopping")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void should_return_400_when_create_title_exceeds_160_chars() throws Exception {
+        // arrange — @Size(max = 160) on title
+        String body = "{\"title\": \"" + "a".repeat(161) + "\"}";
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/shopping")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.error.details[0].field").value("title"));
+    }
+
+    // ------------------------------------------------------------------ PATCH update
+
+    @Test
+    void should_update_checked_only_and_return_200_when_patching() throws Exception {
+        // arrange
+        ShoppingItem updated = mockItem(3L, "Лейка", true);
+
+        when(shoppingListService.update(eq(1L), eq(3L), eq(true), isNull())).thenReturn(updated);
+
+        String body = """
+                {"checked": true}
+                """;
+
+        // act + assert
+        mockMvc.perform(patch("/api/v1/shopping/3")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(3))
+                .andExpect(jsonPath("$.checked").value(true));
+    }
+
+    @Test
+    void should_update_title_only_and_return_200_when_patching() throws Exception {
+        // arrange
+        ShoppingItem updated = mockItem(3L, "Новый текст", false);
+
+        when(shoppingListService.update(eq(1L), eq(3L), isNull(), eq("Новый текст"))).thenReturn(updated);
+
+        String body = """
+                {"title": "Новый текст"}
+                """;
+
+        // act + assert
+        mockMvc.perform(patch("/api/v1/shopping/3")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Новый текст"));
+    }
+
+    @Test
+    void should_return_404_when_patching_unknown_id() throws Exception {
+        // arrange — service throws not-found IllegalArgumentException → controller maps to 404
+        when(shoppingListService.update(eq(1L), eq(999L), eq(true), isNull()))
+                .thenThrow(new IllegalArgumentException(ShoppingListService.ITEM_NOT_FOUND));
+
+        String body = """
+                {"checked": true}
+                """;
+
+        // act + assert
+        mockMvc.perform(patch("/api/v1/shopping/999")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void should_return_400_when_patch_title_blank() throws Exception {
+        // arrange — blank title passes @Size(max=160) bean validation, service rejects with
+        // a non-not-found IllegalArgumentException → controller rethrows → 400 BAD_REQUEST.
+        when(shoppingListService.update(eq(1L), eq(3L), isNull(), eq("   ")))
+                .thenThrow(new IllegalArgumentException("Текст позиции не может быть пустым"));
+
+        String body = """
+                {"title": "   "}
+                """;
+
+        // act + assert
+        mockMvc.perform(patch("/api/v1/shopping/3")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("BAD_REQUEST"));
+    }
+
+    @Test
+    void should_return_400_when_patch_title_exceeds_160_chars() throws Exception {
+        // arrange — @Size(max = 160) on update title rejects via bean validation
+        String body = "{\"title\": \"" + "a".repeat(161) + "\"}";
+
+        // act + assert
+        mockMvc.perform(patch("/api/v1/shopping/3")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.error.details[0].field").value("title"));
+    }
+
+    @Test
+    void should_return_404_when_patching_item_of_other_user() throws Exception {
+        // arrange — update() is userId-scoped; another user's item is "not found" for user 1
+        when(shoppingListService.update(eq(1L), eq(42L), eq(true), isNull()))
+                .thenThrow(new IllegalArgumentException(ShoppingListService.ITEM_NOT_FOUND));
+
+        String body = """
+                {"checked": true}
+                """;
+
+        // act + assert
+        mockMvc.perform(patch("/api/v1/shopping/42")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // ------------------------------------------------------------------ DELETE
+
+    @Test
+    void should_delete_item_and_return_204() throws Exception {
+        // arrange
+        doNothing().when(shoppingListService).delete(1L, 3L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/shopping/3"))
+                .andExpect(status().isNoContent());
+
+        verify(shoppingListService).delete(1L, 3L);
+    }
+
+    @Test
+    void should_return_404_when_deleting_unknown_id() throws Exception {
+        // arrange — service throws not-found → controller maps to 404
+        doThrow(new IllegalArgumentException(ShoppingListService.ITEM_NOT_FOUND))
+                .when(shoppingListService).delete(1L, 999L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/shopping/999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void should_return_404_when_deleting_item_of_other_user() throws Exception {
+        // arrange — delete() is userId-scoped; another user's item is "not found" for user 1
+        doThrow(new IllegalArgumentException(ShoppingListService.ITEM_NOT_FOUND))
+                .when(shoppingListService).delete(1L, 42L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/shopping/42"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+}

--- a/src/test/java/com/plantcare/core/service/ShoppingListServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/ShoppingListServiceTest.java
@@ -299,6 +299,153 @@ class ShoppingListServiceTest extends IntegrationTestBase {
                 .containsExactly("Вторая", "Третья", "Первая");
     }
 
+    // --- AC 10: update — partial field updates persist ---
+
+    @Test
+    void should_set_checked_only_when_updating_with_checked() {
+        ShoppingItem item = shoppingListService.add(userA, "Грунт");
+
+        shoppingListService.update(userA.getId(), item.getId(), true, null);
+
+        ShoppingItem reloaded = shoppingItemRepository.findById(item.getId()).orElseThrow();
+        assertThat(reloaded.isChecked()).isTrue();
+        assertThat(reloaded.getTitle()).isEqualTo("Грунт");
+    }
+
+    @Test
+    void should_set_title_only_when_updating_with_title() {
+        ShoppingItem item = shoppingListService.add(userA, "Старый текст");
+        shoppingListService.toggle(userA.getId(), item.getId(), true);
+
+        shoppingListService.update(userA.getId(), item.getId(), null, "Новый текст");
+
+        ShoppingItem reloaded = shoppingItemRepository.findById(item.getId()).orElseThrow();
+        assertThat(reloaded.getTitle()).isEqualTo("Новый текст");
+        assertThat(reloaded.isChecked()).isTrue();
+    }
+
+    @Test
+    void should_set_both_checked_and_title_when_updating_with_both() {
+        ShoppingItem item = shoppingListService.add(userA, "Старый текст");
+
+        shoppingListService.update(userA.getId(), item.getId(), true, "Новый текст");
+
+        ShoppingItem reloaded = shoppingItemRepository.findById(item.getId()).orElseThrow();
+        assertThat(reloaded.isChecked()).isTrue();
+        assertThat(reloaded.getTitle()).isEqualTo("Новый текст");
+    }
+
+    @Test
+    void should_trim_title_when_updating() {
+        ShoppingItem item = shoppingListService.add(userA, "Старый текст");
+
+        shoppingListService.update(userA.getId(), item.getId(), null, "   Керамзит   ");
+
+        ShoppingItem reloaded = shoppingItemRepository.findById(item.getId()).orElseThrow();
+        assertThat(reloaded.getTitle()).isEqualTo("Керамзит");
+    }
+
+    @Test
+    void should_keep_fields_unchanged_when_updating_with_both_null() {
+        ShoppingItem item = shoppingListService.add(userA, "Грунт");
+
+        shoppingListService.update(userA.getId(), item.getId(), null, null);
+
+        ShoppingItem reloaded = shoppingItemRepository.findById(item.getId()).orElseThrow();
+        assertThat(reloaded.getTitle()).isEqualTo("Грунт");
+        assertThat(reloaded.isChecked()).isFalse();
+    }
+
+    // --- AC 11: update — not-found / cross-user scope ---
+
+    @Test
+    void should_throw_not_found_when_updating_missing_item() {
+        assertThatThrownBy(() -> shoppingListService.update(userA.getId(), 999_999L, true, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(ShoppingListService.ITEM_NOT_FOUND);
+    }
+
+    @Test
+    void should_throw_not_found_when_updating_item_of_another_user() {
+        ShoppingItem itemOfB = shoppingListService.add(userB, "Позиция B");
+
+        assertThatThrownBy(() -> shoppingListService.update(userA.getId(), itemOfB.getId(), true, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(ShoppingListService.ITEM_NOT_FOUND);
+
+        ShoppingItem reloaded = shoppingItemRepository.findById(itemOfB.getId()).orElseThrow();
+        assertThat(reloaded.isChecked()).isFalse();
+        assertThat(reloaded.getTitle()).isEqualTo("Позиция B");
+    }
+
+    // --- AC 12: update — title validation (400-path, NOT the not-found message) ---
+
+    @Test
+    void should_reject_blank_title_with_validation_message_when_updating() {
+        ShoppingItem item = shoppingListService.add(userA, "Грунт");
+
+        assertThatThrownBy(() -> shoppingListService.update(userA.getId(), item.getId(), null, "   "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("не может быть пустым")
+                .hasMessageNotContaining(ShoppingListService.ITEM_NOT_FOUND);
+
+        ShoppingItem reloaded = shoppingItemRepository.findById(item.getId()).orElseThrow();
+        assertThat(reloaded.getTitle()).isEqualTo("Грунт");
+    }
+
+    @Test
+    void should_reject_too_long_title_with_validation_message_when_updating() {
+        ShoppingItem item = shoppingListService.add(userA, "Грунт");
+        String tooLong = "а".repeat(161);
+
+        assertThatThrownBy(() -> shoppingListService.update(userA.getId(), item.getId(), null, tooLong))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("160")
+                .hasMessageNotContaining(ShoppingListService.ITEM_NOT_FOUND);
+
+        ShoppingItem reloaded = shoppingItemRepository.findById(item.getId()).orElseThrow();
+        assertThat(reloaded.getTitle()).isEqualTo("Грунт");
+    }
+
+    @Test
+    void should_validate_title_before_lookup_when_updating_missing_item() {
+        // Невалидный title на несуществующей позиции должен давать ошибку валидации (→ 400),
+        // а не not-found (→ 404): валидация в update() идёт ДО поиска.
+        assertThatThrownBy(() -> shoppingListService.update(userA.getId(), 999_999L, null, "   "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("не может быть пустым")
+                .hasMessageNotContaining(ShoppingListService.ITEM_NOT_FOUND);
+    }
+
+    // --- AC 13: delete — own / not-found / cross-user scope ---
+
+    @Test
+    void should_delete_own_item_when_deleting() {
+        ShoppingItem item = shoppingListService.add(userA, "Грунт");
+
+        shoppingListService.delete(userA.getId(), item.getId());
+
+        assertThat(shoppingItemRepository.findById(item.getId())).isEmpty();
+    }
+
+    @Test
+    void should_throw_not_found_when_deleting_missing_item() {
+        assertThatThrownBy(() -> shoppingListService.delete(userA.getId(), 999_999L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(ShoppingListService.ITEM_NOT_FOUND);
+    }
+
+    @Test
+    void should_throw_not_found_and_keep_row_when_deleting_item_of_another_user() {
+        ShoppingItem itemOfB = shoppingListService.add(userB, "Позиция B");
+
+        assertThatThrownBy(() -> shoppingListService.delete(userA.getId(), itemOfB.getId()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(ShoppingListService.ITEM_NOT_FOUND);
+
+        assertThat(shoppingItemRepository.findById(itemOfB.getId())).isPresent();
+    }
+
     private void setCreatedAt(Long itemId, LocalDateTime createdAt) {
         entityManager.createNativeQuery("UPDATE shopping_items SET created_at = :createdAt WHERE id = :id")
                 .setParameter("createdAt", createdAt)


### PR DESCRIPTION
Closes #196

## Что сделано
- **REST CRUD `/api/v1/shopping`** поверх уже существующего домена `shopping_items` (#136, миграция V27 — новой миграции нет):
  - `GET /api/v1/shopping` → `{ "items": [ {id, title, checked, createdAt} ] }` (непросмотренные сначала, затем купленные).
  - `POST /api/v1/shopping {title}` → `201 ShoppingItemDto`.
  - `PATCH /api/v1/shopping/{id} {checked?, title?}` → `200`, partial-update (пропущенное поле не трогается).
  - `DELETE /api/v1/shopping/{id}` → `204`.
- **Spec-first**: добавлен `resources/shopping.yaml` и регистрация в `openapi.yaml` (tag `Shopping`, paths, schemas) → эндпоинты в `/v3/api-docs` и в генерируемых client SDK.
- **Scope по пользователю**: все запросы скоуплены по `userId` из JWT `sub` (`CurrentUserProvider`). Чужой/несуществующий item → `404` (не раскрываем существование чужих ID).
- `ShoppingListService` расширен методами `update(...)` (partial) и `delete(...)`; добавлен `ShoppingItem.setTitle`. Валидация title (пусто/>160) выполняется **до** lookup, поэтому плохой title на отсутствующем item корректно даёт `400`, а не `404`.

## Миграции
Нет. Таблица `shopping_items` уже создана в `V27__create_shopping_items.sql` (#136).

## Backward-compat риски
safe — только аддитивные изменения: новые эндпоинты, новый файл спеки, новые методы сервиса. Существующая бот-логика (`add`/`toggle`/`clearChecked`) не тронута по семантике.

## Тесты
- `src/test/java/com/plantcare/api/v1/ShoppingControllerTest.java` (15, `@WebMvcTest`): GET-обёртка `items`, POST 201 + 400 (blank/missing/>160), PATCH 200 partial + 404 (unknown/чужой) + 400 (bad title), DELETE 204 + 404 (unknown/чужой).
- `src/test/java/com/plantcare/core/service/ShoppingListServiceTest.java` (+15, Testcontainers Postgres): `update` partial (checked/title/оба/trim/оба-null no-op), cross-user scope для `update`/`delete`, валидация title до lookup.
- Финальный `mvn verify` (Java 21, чистые TC-контейнеры): **1349 tests, 0 failures, 0 errors, BUILD SUCCESS**.

## Чек
- [x] `mvn verify` зелёное (1349/0/0)
- [x] reviewer прошёл — 🔴 BLOCKING нет

### Принятые SHOULD-FIX (не блокирующие, поведение корректно и покрыто тестами)
1. Маршрутизация 404/400 в контроллере опирается на сравнение с константой-сообщением `ShoppingListService.ITEM_NOT_FOUND` (а не на отдельный тип исключения). Тот же паттерн мягче, чем в `LocationController` (там любой `IllegalArgumentException` → 404), и константа общая. Чистый вариант — выделить `ShoppingItemNotFoundException`; отложено, т.к. цепляет проходящие сервис-тесты.
2. В `ShoppingItemUpdateRequest` явный `null` и отсутствие поля неотличимы (оба = «не трогать»). Для текущих полей это корректно (title не-nullable в сущности, checked — boolean без tri-state).
