### PR TITLE
feat: месячный отчёт GET /reports/monthly (#192)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 | `/api/v1/today` | `GET` | 200 | Задачи ухода на сегодня в таймзоне пользователя |
 | `/api/v1/calendar` | `GET` | 200 | Расписание за произвольный период. Query params: `from`, `to` (ISO date). Диапазон не более 60 дней. Дни без задач в ответ не включаются |
 | `/api/v1/stats/streak` | `GET` | 200 | Текущий стрик растения (последовательные выполнения без пропусков). Query param: `plantId` |
+| `/api/v1/reports/monthly` | `GET` | 200 | Сводный отчёт по уходу за месяц текущего пользователя: `done`, `overdue` (выполнено с опозданием), `byType` (по всем типам ухода), `streak`, `healthTrend` (понедельные ISO-бакеты качества). Query param `month` обязателен, формат `YYYY-MM`. Границы месяца считаются в таймзоне пользователя. Невалидный `month` → 400 |
 
 ### Формат ошибок
 

--- a/http/api.http
+++ b/http/api.http
@@ -57,6 +57,10 @@ Authorization: Bearer {{token}}
 GET {{baseUrl}}/api/v1/stats/streak?plantId=1
 Authorization: Bearer {{token}}
 
+### Месячный отчёт по уходу (month обязателен, формат YYYY-MM)
+GET {{baseUrl}}/api/v1/reports/monthly?month=2026-05
+Authorization: Bearer {{token}}
+
 ### --- Plants ---
 
 ### Список растений

--- a/src/main/java/com/plantcare/api/ApiExceptionHandler.java
+++ b/src/main/java/com/plantcare/api/ApiExceptionHandler.java
@@ -5,6 +5,7 @@ import com.plantcare.api.auth.exception.RateLimitExceededException;
 import com.plantcare.api.dto.ApiErrorResponse;
 import com.plantcare.api.dto.FieldError;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.ConstraintViolationException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -13,6 +14,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 
 /**
  * Глобальный обработчик ошибок REST API ({@code /api/**}).
@@ -29,6 +31,12 @@ public class ApiExceptionHandler {
                 .toList();
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ApiErrorResponse.of("VALIDATION_ERROR", "Validation failed", details));
+    }
+
+    @ExceptionHandler({HandlerMethodValidationException.class, ConstraintViolationException.class})
+    public ResponseEntity<ApiErrorResponse> handleMethodValidation(Exception e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiErrorResponse.of("VALIDATION_ERROR", "Validation failed"));
     }
 
     @ExceptionHandler(EntityNotFoundException.class)

--- a/src/main/java/com/plantcare/api/v1/ReportsController.java
+++ b/src/main/java/com/plantcare/api/v1/ReportsController.java
@@ -1,0 +1,62 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.api.generated.ReportsApi;
+import com.plantcare.api.generated.model.MonthlyReportResponse;
+import com.plantcare.api.generated.model.WeeklyHealthBucket;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.service.MonthlyReportApiService;
+import com.plantcare.core.service.MonthlyReportApiService.MonthlyReport;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * REST API сводных отчётов по уходу (issue #192, gap G23).
+ *
+ * <p>Документация и mapping живут в сгенерированном {@link ReportsApi}.
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class ReportsController implements ReportsApi {
+
+    private final MonthlyReportApiService monthlyReportApiService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    public MonthlyReportResponse getMonthlyReport(String month) {
+        User user = currentUserProvider.currentUser();
+        log.info("GET /api/v1/reports/monthly: userId={}, month={}", user.getId(), month);
+
+        MonthlyReport report = monthlyReportApiService.getMonthlyReport(
+                user.getId(), user.getTimezone(), month);
+
+        return toResponse(report);
+    }
+
+    private static MonthlyReportResponse toResponse(MonthlyReport report) {
+        Map<String, Integer> byType = new LinkedHashMap<>();
+        for (TaskType type : TaskType.values()) {
+            byType.put(type.name(), Math.toIntExact(report.byType().getOrDefault(type, 0L)));
+        }
+
+        List<WeeklyHealthBucket> healthTrend = report.healthTrend().stream()
+                .map(b -> new WeeklyHealthBucket(b.week(), Math.toIntExact(b.done()), b.onTimePct()))
+                .toList();
+
+        return new MonthlyReportResponse(
+                report.month(),
+                Math.toIntExact(report.done()),
+                Math.toIntExact(report.overdue()),
+                byType,
+                report.streak(),
+                healthTrend
+        );
+    }
+}

--- a/src/main/java/com/plantcare/core/repository/CareHistoryRepository.java
+++ b/src/main/java/com/plantcare/core/repository/CareHistoryRepository.java
@@ -209,6 +209,45 @@ public interface CareHistoryRepository extends JpaRepository<CareHistory, Long> 
             Limit limit
     );
 
+    // ===== Месячный отчёт REST API (issue #192, gap G23) =====
+
+    /**
+     * Кол-во активных (не-cancelled) действий ухода юзера за период
+     * {@code [from; toExclusive)}, выполненных с опозданием ({@code was_on_time = false}).
+     * Числитель «overdue» месячного отчёта. Границы — UTC LocalDateTime
+     * (начало/конец месяца в TZ юзера, сконвертированные в UTC).
+     */
+    @Query("SELECT COUNT(h) FROM CareHistory h " +
+            "WHERE h.plant.user.id = :userId AND h.cancelledBy IS NULL " +
+            "AND h.onTime = false " +
+            "AND h.doneAt >= :from AND h.doneAt < :toExclusive")
+    long countLateActiveByUserIdInRange(
+            @Param("userId") Long userId,
+            @Param("from") LocalDateTime from,
+            @Param("toExclusive") LocalDateTime toExclusive
+    );
+
+    /**
+     * Пары {@code (done_at, was_on_time)} всех активных (не-cancelled) действий
+     * юзера за период {@code [from; toExclusive)} — для понедельного тренда
+     * качества месячного отчёта (issue #192). Бакетинг по ISO-неделе и в TZ
+     * юзера выполняется в Java, поэтому из БД тянем сырые точки одним запросом.
+     */
+    @Query("SELECT h.doneAt AS doneAt, h.onTime AS onTime FROM CareHistory h " +
+            "WHERE h.plant.user.id = :userId AND h.cancelledBy IS NULL " +
+            "AND h.doneAt >= :from AND h.doneAt < :toExclusive")
+    List<DoneAtOnTime> findActiveDoneAtOnTimeByUserIdInRange(
+            @Param("userId") Long userId,
+            @Param("from") LocalDateTime from,
+            @Param("toExclusive") LocalDateTime toExclusive
+    );
+
+    /** Проекция «момент выполнения → on-time» для понедельного тренда (issue #192). */
+    interface DoneAtOnTime {
+        LocalDateTime getDoneAt();
+        boolean getOnTime();
+    }
+
     // ===== Done-фид для /today (issue #184, ADR-014) =====
 
     /**

--- a/src/main/java/com/plantcare/core/service/MonthlyReportApiService.java
+++ b/src/main/java/com/plantcare/core/service/MonthlyReportApiService.java
@@ -1,0 +1,182 @@
+package com.plantcare.core.service;
+
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.repository.CareHistoryRepository;
+import com.plantcare.core.repository.CareHistoryRepository.DoneAtOnTime;
+import com.plantcare.core.repository.CareHistoryRepository.TaskTypeCount;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.IsoFields;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Сервис месячного REST-отчёта по уходу (issue #192, gap G23, мобильный экран 14).
+ *
+ * <p>Скоуп — текущий пользователь. Границы отчётного месяца считаются в TZ
+ * пользователя ({@code users.timezone}) и конвертируются в UTC {@link LocalDateTime}
+ * для запросов по {@code care_history.done_at} (в БД done_at хранится как UTC
+ * wall-clock). Паттерн границ повторяет {@link MonthlyReportService}.
+ *
+ * <p>Отдельное имя от {@link MonthlyReportService} (тот шлёт Telegram push-отчёт за
+ * прошлый месяц) — здесь REST-агрегация за произвольный запрошенный месяц.
+ *
+ * <p>Метрики:
+ * <ul>
+ *   <li>{@code done} — активные (не-cancelled) действия в окне месяца;</li>
+ *   <li>{@code overdue} — из них выполненные с опозданием ({@code onTime = false});</li>
+ *   <li>{@code byType} — разбивка {@code done} по {@link TaskType}, все 4 ключа всегда
+ *       присутствуют (отсутствующие = 0);</li>
+ *   <li>{@code streak} — текущий стрик пользователя (переиспользуется
+ *       {@link CareHistoryService#computeUserStreak});</li>
+ *   <li>{@code healthTrend} — понедельные бакеты качества по ISO-неделям, в которые
+ *       попали действия месяца (бакетинг в TZ юзера, в Java).</li>
+ * </ul>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MonthlyReportApiService {
+
+    private static final DateTimeFormatter MONTH_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM");
+
+    private final CareHistoryRepository careHistoryRepository;
+    private final CareHistoryService careHistoryService;
+
+    /**
+     * Собрать месячный отчёт для пользователя.
+     *
+     * @param userId   внутренний id пользователя
+     * @param timezone строка таймзоны пользователя ({@code users.timezone})
+     * @param month    отчётный месяц в формате {@code YYYY-MM}
+     * @return сводка за месяц
+     * @throws IllegalArgumentException если {@code month} не парсится как {@code YYYY-MM}
+     *                                  (маппится в 400 через {@code ApiExceptionHandler})
+     */
+    public MonthlyReport getMonthlyReport(Long userId, String timezone, String month) {
+        YearMonth reportMonth = parseMonth(month);
+        ZoneId zone = safeZone(timezone);
+
+        LocalDateTime from = reportMonth.atDay(1).atStartOfDay(zone)
+                .toInstant().atZone(ZoneOffset.UTC).toLocalDateTime();
+        LocalDateTime toExclusive = reportMonth.plusMonths(1).atDay(1).atStartOfDay(zone)
+                .toInstant().atZone(ZoneOffset.UTC).toLocalDateTime();
+
+        log.debug("Monthly report: userId={}, month={}, from={}, toExclusive={}, zone={}",
+                userId, month, from, toExclusive, zone);
+
+        long done = careHistoryRepository.countActiveByUserIdInRange(userId, from, toExclusive);
+        long overdue = careHistoryRepository.countLateActiveByUserIdInRange(userId, from, toExclusive);
+        Map<TaskType, Long> byType = loadByType(userId, from, toExclusive);
+        int streak = careHistoryService.computeUserStreak(userId, timezone);
+        List<WeeklyHealthBucket> healthTrend = loadHealthTrend(userId, from, toExclusive, zone);
+
+        return new MonthlyReport(reportMonth.format(MONTH_FORMAT), done, overdue, byType, streak, healthTrend);
+    }
+
+    /** Разбивка done по типам ухода: все 4 enum-значения, отсутствующие = 0. */
+    private Map<TaskType, Long> loadByType(Long userId, LocalDateTime from, LocalDateTime toExclusive) {
+        Map<TaskType, Long> byType = new LinkedHashMap<>();
+        for (TaskType type : TaskType.values()) {
+            byType.put(type, 0L);
+        }
+        for (TaskTypeCount row : careHistoryRepository.countActiveByUserIdGroupedByTaskType(
+                userId, from, toExclusive)) {
+            byType.put(row.getTaskType(), row.getCount());
+        }
+        return byType;
+    }
+
+    /**
+     * Понедельный тренд: бакетим каждое done-действие по ISO-неделе локальной
+     * (в TZ юзера) даты его {@code doneAt}. Недели упорядочены хронологически.
+     */
+    private List<WeeklyHealthBucket> loadHealthTrend(Long userId, LocalDateTime from,
+                                                      LocalDateTime toExclusive, ZoneId zone) {
+        // key — пара (week-based-year, week-of-week-based-year) для корректной сортировки
+        // на стыке годов (например W52 2025 → W01 2026).
+        Map<Long, long[] /* [done, onTime] */> buckets = new TreeMap<>();
+        Map<Long, String> labels = new HashMap<>();
+
+        for (DoneAtOnTime row : careHistoryRepository.findActiveDoneAtOnTimeByUserIdInRange(
+                userId, from, toExclusive)) {
+            LocalDate local = row.getDoneAt().atOffset(ZoneOffset.UTC).atZoneSameInstant(zone).toLocalDate();
+            int week = local.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+            int weekYear = local.get(IsoFields.WEEK_BASED_YEAR);
+            long sortKey = (long) weekYear * 100 + week;
+
+            long[] acc = buckets.computeIfAbsent(sortKey, k -> new long[2]);
+            acc[0]++;
+            if (row.getOnTime()) {
+                acc[1]++;
+            }
+            labels.putIfAbsent(sortKey, String.format("%04d-W%02d", weekYear, week));
+        }
+
+        List<WeeklyHealthBucket> trend = new ArrayList<>(buckets.size());
+        for (Map.Entry<Long, long[]> e : buckets.entrySet()) {
+            long bucketDone = e.getValue()[0];
+            long onTime = e.getValue()[1];
+            double onTimePct = bucketDone == 0
+                    ? 0.0
+                    : Math.round(100.0 * onTime / bucketDone) / 100.0;
+            trend.add(new WeeklyHealthBucket(labels.get(e.getKey()), bucketDone, onTimePct));
+        }
+        return trend;
+    }
+
+    private YearMonth parseMonth(String month) {
+        if (month == null || month.isBlank()) {
+            throw new IllegalArgumentException("Query param 'month' is required (format YYYY-MM)");
+        }
+        try {
+            return YearMonth.parse(month, MONTH_FORMAT);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("Invalid 'month' format, expected YYYY-MM: " + month, e);
+        }
+    }
+
+    private static ZoneId safeZone(String tz) {
+        if (tz == null || tz.isBlank()) {
+            return ZoneOffset.UTC;
+        }
+        try {
+            return ZoneId.of(tz);
+        } catch (Exception e) {
+            return ZoneOffset.UTC;
+        }
+    }
+
+    /**
+     * Готовая сводка месячного отчёта. {@code byType} — все 4 {@link TaskType},
+     * {@code healthTrend} — хронологически упорядоченные недельные бакеты.
+     */
+    public record MonthlyReport(
+            String month,
+            long done,
+            long overdue,
+            Map<TaskType, Long> byType,
+            int streak,
+            List<WeeklyHealthBucket> healthTrend
+    ) {
+    }
+
+    /** Понедельный бакет качества: ISO-неделя, число done и доля on-time (0..1). */
+    public record WeeklyHealthBucket(String week, long done, double onTimePct) {
+    }
+}

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -78,6 +78,8 @@ tags:
     description: Задачи ухода, дедлайн которых до конца сегодняшнего дня в таймзоне пользователя.
   - name: Stats
     description: Статистика по уходу. Сейчас доступен только стрик растения.
+  - name: Reports
+    description: Сводные отчёты по уходу. Месячный отчёт для мобильного экрана (gap G23).
   - name: Species
     description: Публичный справочник видов растений. Без авторизации.
   - name: Care Types
@@ -128,6 +130,9 @@ paths:
 
   /api/v1/stats/streak:
     $ref: './resources/stats.yaml#/paths/Streak'
+
+  /api/v1/reports/monthly:
+    $ref: './resources/reports.yaml#/paths/Monthly'
 
   /api/v1/species:
     $ref: './resources/species.yaml#/paths/Collection'
@@ -229,6 +234,11 @@ components:
 
     StreakResponse:
       $ref: './resources/stats.yaml#/schemas/StreakResponse'
+
+    MonthlyReportResponse:
+      $ref: './resources/reports.yaml#/schemas/MonthlyReportResponse'
+    WeeklyHealthBucket:
+      $ref: './resources/reports.yaml#/schemas/WeeklyHealthBucket'
 
     SpeciesSummaryDto:
       $ref: './resources/species.yaml#/schemas/SpeciesSummaryDto'

--- a/src/main/resources/openapi/resources/reports.yaml
+++ b/src/main/resources/openapi/resources/reports.yaml
@@ -1,0 +1,102 @@
+# Месячный отчёт по уходу для мобильного экрана 14 (gap G23, issue #192).
+# Скоуп — текущий аутентифицированный пользователь; все границы месяца
+# считаются в TZ пользователя (users.timezone) и конвертируются в UTC.
+
+paths:
+  Monthly:
+    get:
+      tags: [Reports]
+      operationId: getMonthlyReport
+      summary: Месячный отчёт по уходу
+      description: |
+        Возвращает сводку по уходу за указанный месяц для текущего пользователя:
+        число выполненных действий, число просроченных (выполненных с опозданием),
+        разбивку по типам ухода, текущий стрик и понедельный тренд качества.
+
+        Месяц передаётся параметром `month` в формате `YYYY-MM`. Границы месяца
+        вычисляются в таймзоне пользователя (`users.timezone`).
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: month
+          in: query
+          required: true
+          description: Отчётный месяц в формате `YYYY-MM` (например, `2026-05`).
+          schema:
+            type: string
+            pattern: '^\d{4}-\d{2}$'
+            example: '2026-05'
+      responses:
+        '200':
+          description: Отчёт посчитан.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/MonthlyReportResponse'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+
+schemas:
+  MonthlyReportResponse:
+    type: object
+    description: Ответ `GET /api/v1/reports/monthly`.
+    required: [month, done, overdue, byType, streak, healthTrend]
+    properties:
+      month:
+        type: string
+        description: Эхо запрошенного месяца (`YYYY-MM`).
+        example: '2026-05'
+      done:
+        type: integer
+        format: int32
+        description: Число выполненных действий ухода за месяц.
+        example: 42
+      overdue:
+        type: integer
+        format: int32
+        description: Число действий, выполненных с опозданием (`onTime = false`).
+        example: 5
+      byType:
+        type: object
+        description: |
+          Разбивка `done` по типам ухода. Ключи — имена enum `TaskType`
+          (`WATERING`, `MISTING`, `FERTILIZING`, `SOIL_CHECK`); присутствуют
+          все четыре, отсутствующие — `0`.
+        additionalProperties:
+          type: integer
+          format: int32
+        example:
+          WATERING: 20
+          MISTING: 15
+          FERTILIZING: 5
+          SOIL_CHECK: 2
+      streak:
+        type: integer
+        format: int32
+        description: Текущий стрик пользователя (дней подряд) на момент запроса.
+        example: 12
+      healthTrend:
+        type: array
+        description: Понедельные бакеты качества для ISO-недель, пересекающих месяц.
+        items:
+          $ref: '#/schemas/WeeklyHealthBucket'
+
+  WeeklyHealthBucket:
+    type: object
+    description: Качество ухода за одну ISO-неделю.
+    required: [week, done, onTimePct]
+    properties:
+      week:
+        type: string
+        description: ISO-8601 неделя в формате `YYYY-Www` (например, `2026-W18`).
+        example: '2026-W18'
+      done:
+        type: integer
+        format: int32
+        description: Число выполненных действий за неделю.
+        example: 12
+      onTimePct:
+        type: number
+        format: double
+        description: Доля on-time действий (`onTime/done`), округлённая до 2 знаков; `0.0` если `done == 0`.
+        example: 0.92

--- a/src/test/java/com/plantcare/api/v1/ReportsControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/ReportsControllerTest.java
@@ -1,0 +1,173 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.api.auth.exception.AuthTokenException;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.service.MonthlyReportApiService;
+import com.plantcare.core.service.MonthlyReportApiService.MonthlyReport;
+import com.plantcare.core.service.MonthlyReportApiService.WeeklyHealthBucket;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Слайс-тест {@link ReportsController} (issue #192).
+ *
+ * <p>Проверяет JSON-форму ответа {@code GET /api/v1/reports/monthly}, скоуп по
+ * текущему пользователю (id и TZ берутся из {@link CurrentUserProvider}, не из
+ * запроса) и маппинг ошибок: 400 при невалидном месяце, 401 без аутентификации.
+ *
+ * <p>Сервис замокан — здесь тестируется только веб-слой и сериализация.
+ */
+@WebMvcTest(ReportsController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ReportsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MonthlyReportApiService monthlyReportApiService;
+
+    @MockBean
+    private CurrentUserProvider currentUserProvider;
+
+    @Test
+    void should_return_200_with_full_report_shape_when_month_valid() throws Exception {
+        // arrange
+        User user = mockUser(42L, "Europe/Moscow");
+        when(currentUserProvider.currentUser()).thenReturn(user);
+
+        Map<TaskType, Long> byType = new LinkedHashMap<>();
+        byType.put(TaskType.WATERING, 20L);
+        byType.put(TaskType.MISTING, 15L);
+        byType.put(TaskType.FERTILIZING, 5L);
+        byType.put(TaskType.SOIL_CHECK, 0L);
+
+        MonthlyReport report = new MonthlyReport(
+                "2026-04", 40L, 5L, byType, 12,
+                List.of(new WeeklyHealthBucket("2026-W15", 18L, 0.67),
+                        new WeeklyHealthBucket("2026-W16", 22L, 1.0)));
+        when(monthlyReportApiService.getMonthlyReport(anyLong(), anyString(), anyString()))
+                .thenReturn(report);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/reports/monthly").param("month", "2026-04"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.month").value("2026-04"))
+                .andExpect(jsonPath("$.done").value(40))
+                .andExpect(jsonPath("$.overdue").value(5))
+                .andExpect(jsonPath("$.streak").value(12))
+                .andExpect(jsonPath("$.byType.WATERING").value(20))
+                .andExpect(jsonPath("$.byType.MISTING").value(15))
+                .andExpect(jsonPath("$.byType.FERTILIZING").value(5))
+                .andExpect(jsonPath("$.byType.SOIL_CHECK").value(0))
+                .andExpect(jsonPath("$.healthTrend.length()").value(2))
+                .andExpect(jsonPath("$.healthTrend[0].week").value("2026-W15"))
+                .andExpect(jsonPath("$.healthTrend[0].done").value(18))
+                .andExpect(jsonPath("$.healthTrend[0].onTimePct").value(0.67))
+                .andExpect(jsonPath("$.healthTrend[1].week").value("2026-W16"))
+                .andExpect(jsonPath("$.healthTrend[1].onTimePct").value(1.0));
+    }
+
+    @Test
+    void should_pass_current_user_id_and_timezone_not_request_when_building_report() throws Exception {
+        // arrange — скоуп берётся из CurrentUserProvider, не из параметров запроса
+        User user = mockUser(99L, "Asia/Almaty");
+        when(currentUserProvider.currentUser()).thenReturn(user);
+        when(monthlyReportApiService.getMonthlyReport(anyLong(), anyString(), anyString()))
+                .thenReturn(emptyReport());
+
+        // act
+        mockMvc.perform(get("/api/v1/reports/monthly").param("month", "2026-04"))
+                .andExpect(status().isOk());
+
+        // assert — сервис вызван именно с id и TZ текущего пользователя
+        verify(monthlyReportApiService).getMonthlyReport(eq(99L), eq("Asia/Almaty"), eq("2026-04"));
+    }
+
+    @Test
+    void should_return_400_when_month_value_is_invalid() throws Exception {
+        // arrange — "2026-13" проходит regex ^\d{4}-\d{2}$, но сервис кидает IllegalArgumentException
+        User user = mockUser(42L, "UTC");
+        when(currentUserProvider.currentUser()).thenReturn(user);
+        when(monthlyReportApiService.getMonthlyReport(anyLong(), anyString(), eq("2026-13")))
+                .thenThrow(new IllegalArgumentException("Invalid 'month' format, expected YYYY-MM: 2026-13"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/reports/monthly").param("month", "2026-13"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("BAD_REQUEST"));
+    }
+
+    @Test
+    void should_reject_pattern_violating_month_before_reaching_service() throws Exception {
+        // arrange — "garbage" не проходит @Pattern(^\d{4}-\d{2}$) на @RequestParam.
+        // Нарушение @Pattern на query-параметре поднимает HandlerMethodValidationException,
+        // которую ApiExceptionHandler маппит в 400 VALIDATION_ERROR. Невалидный параметр
+        // отбивается ДО бизнес-логики (сервис не вызывается).
+        User user = mockUser(42L, "UTC");
+        when(currentUserProvider.currentUser()).thenReturn(user);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/reports/monthly").param("month", "garbage"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+
+        verify(monthlyReportApiService, never()).getMonthlyReport(anyLong(), anyString(), anyString());
+    }
+
+    @Test
+    void should_return_401_when_no_authenticated_user() throws Exception {
+        // arrange — нет JWT в SecurityContext
+        when(currentUserProvider.currentUser())
+                .thenThrow(AuthTokenException.invalid("No authenticated user in security context"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/reports/monthly").param("month", "2026-04"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("TOKEN_INVALID"));
+    }
+
+    // ===================== helpers =====================
+
+    private User mockUser(Long id, String timezone) {
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(id);
+        when(user.getTimezone()).thenReturn(timezone);
+        return user;
+    }
+
+    private MonthlyReport emptyReport() {
+        Map<TaskType, Long> byType = new LinkedHashMap<>();
+        for (TaskType type : TaskType.values()) {
+            byType.put(type, 0L);
+        }
+        return new MonthlyReport("2026-04", 0L, 0L, byType, 0, List.of());
+    }
+}

--- a/src/test/java/com/plantcare/core/service/MonthlyReportApiServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/MonthlyReportApiServiceTest.java
@@ -1,0 +1,404 @@
+package com.plantcare.core.service;
+
+import com.plantcare.core.domain.CareHistory;
+import com.plantcare.core.domain.Location;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.repository.CareHistoryRepository;
+import com.plantcare.core.repository.LocationRepository;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.UserRepository;
+import com.plantcare.core.service.MonthlyReportApiService.MonthlyReport;
+import com.plantcare.core.service.MonthlyReportApiService.WeeklyHealthBucket;
+import com.plantcare.bot.support.IntegrationTestBase;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+/**
+ * Интеграционные тесты REST-сервиса месячного отчёта (issue #192, gap G23) на
+ * реальном Postgres через Testcontainers — агрегаты {@code COUNT}/{@code GROUP BY}
+ * и проекция {@code (done_at, was_on_time)} прогоняются на Postgres-диалекте, а не
+ * на моках репозитория (CLAUDE.md: «Не мокать репозитории, если есть Testcontainers»).
+ *
+ * <p>Границы месяца считаются в TZ юзера и конвертируются в UTC — отдельный тест
+ * проверяет, что действие у границы месяца попадает в нужный месяц именно по TZ
+ * юзера, а не по UTC-календарю.
+ *
+ * <p>Покрывает:
+ *   - happy path: done/overdue/byType/healthTrend на реальных данных;
+ *   - не-UTC граница месяца (Asia/Almaty) — действие у полуночи месяца;
+ *   - ISO-неделя на стыке годов + округление onTimePct до 2 знаков;
+ *   - пустой месяц → нули и пустой тренд;
+ *   - стабильность byType (все 4 ключа даже при одном типе);
+ *   - изоляция по пользователю (чужие данные не текут);
+ *   - невалидный/пустой month → IllegalArgumentException;
+ *   - cancelled-записи не считаются.
+ */
+@DisplayName("MonthlyReportApiService — REST месячный отчёт (issue #192)")
+class MonthlyReportApiServiceTest extends IntegrationTestBase {
+
+    @Autowired private MonthlyReportApiService service;
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private LocationRepository locationRepository;
+    @Autowired private PlantRepository plantRepository;
+    @Autowired private CareHistoryRepository careHistoryRepository;
+    @Autowired private EntityManager entityManager;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    /**
+     * Жёсткая очистка ДО и ПОСЛЕ каждого теста через {@code TRUNCATE ... CASCADE}.
+     *
+     * <p>Контейнер Postgres переиспользуется ({@code withReuse}) между запусками
+     * {@code mvn}, поэтому в нём могут оставаться строки прошлых прогонов в любых
+     * дочерних таблицах (care_schedules, reminders и т.п.). Обычный
+     * {@code deleteAll()} по 4 таблицам падал бы на FK от неучтённых детей —
+     * {@code TRUNCATE users CASCADE} атомарно сносит весь граф зависимостей и
+     * делает тест независимым от остаточных данных (известная контаминация).
+     *
+     * <p>Транзакция нужна явно через {@link TransactionTemplate}: {@code @Transactional}
+     * на lifecycle-методе JUnit Spring не оборачивает.
+     */
+    @BeforeEach
+    @AfterEach
+    void cleanDatabase() {
+        new TransactionTemplate(transactionManager).executeWithoutResult(status ->
+                entityManager.createNativeQuery(
+                        "TRUNCATE TABLE users RESTART IDENTITY CASCADE").executeUpdate());
+    }
+
+    @Test
+    @DisplayName("should_aggregate_done_overdue_byType_and_trend_when_user_active_in_month")
+    void should_aggregate_done_overdue_byType_and_trend_when_user_active_in_month() {
+        // arrange: апрель 2026, UTC. 5 активных + 1 cancelled. 2 из активных — late.
+        // Действия распределены по двум ISO-неделям апреля.
+        User user = savedUser(7001L, "UTC");
+        Plant plant = savedPlant(user, "Монстера");
+
+        // ISO-неделя 2026-W15 (06–12 апр): WATERING on-time, MISTING late
+        savedCare(plant, TaskType.WATERING, utc("2026-04-06T10:00:00"), true, null);
+        savedCare(plant, TaskType.MISTING, utc("2026-04-08T10:00:00"), false, null);
+        // ISO-неделя 2026-W16 (13–19 апр): WATERING on-time, FERTILIZING late, SOIL_CHECK on-time
+        savedCare(plant, TaskType.WATERING, utc("2026-04-13T10:00:00"), true, null);
+        savedCare(plant, TaskType.FERTILIZING, utc("2026-04-15T10:00:00"), false, null);
+        savedCare(plant, TaskType.SOIL_CHECK, utc("2026-04-17T10:00:00"), true, null);
+        // cancelled запись в апреле — не должна попасть ни в один агрегат
+        CareHistory compensator = savedCare(plant, TaskType.WATERING, utc("2026-04-18T10:00:00"), true, null);
+        savedCare(plant, TaskType.WATERING, utc("2026-04-10T10:00:00"), true, compensator);
+
+        // act
+        MonthlyReport report = service.getMonthlyReport(user.getId(), "UTC", "2026-04");
+
+        // assert
+        assertSoftly(softly -> {
+            softly.assertThat(report.month()).isEqualTo("2026-04");
+            softly.assertThat(report.done()).isEqualTo(6L); // 5 базовых + compensator, cancelled не в счёт
+            softly.assertThat(report.overdue()).isEqualTo(2L); // MISTING + FERTILIZING late
+            softly.assertThat(report.byType())
+                    .containsEntry(TaskType.WATERING, 3L)
+                    .containsEntry(TaskType.MISTING, 1L)
+                    .containsEntry(TaskType.FERTILIZING, 1L)
+                    .containsEntry(TaskType.SOIL_CHECK, 1L);
+            // тренд: две недели, хронологически
+            softly.assertThat(report.healthTrend())
+                    .extracting(WeeklyHealthBucket::week)
+                    .containsExactly("2026-W15", "2026-W16");
+        });
+    }
+
+    @Test
+    @DisplayName("should_count_action_in_local_month_when_done_near_boundary_in_almaty")
+    void should_count_action_in_local_month_when_done_near_boundary_in_almaty() {
+        // arrange: юзер в Asia/Almaty (UTC+5). Действие 1 апреля 02:00 ЛОКАЛЬНО Алматы
+        // = 31 марта 21:00 UTC. По UTC-календарю это МАРТ, по локальному — АПРЕЛЬ.
+        // Оно ОБЯЗАНО учитываться в апрельском отчёте (границы — в TZ юзера).
+        // Зеркально: действие 1 мая 02:00 локально = 30 апр 21:00 UTC (UTC-апрель!),
+        // но локально это МАЙ → НЕ должно попасть в апрель.
+        User user = savedUser(7002L, "Asia/Almaty");
+        Plant plant = savedPlant(user, "Алматинская");
+
+        savedCare(plant, TaskType.WATERING, utc("2026-03-31T21:00:00"), true, null);  // апрель локально
+        savedCare(plant, TaskType.WATERING, utc("2026-04-15T07:00:00"), true, null);  // явно апрель
+        savedCare(plant, TaskType.WATERING, utc("2026-04-30T21:00:00"), true, null);  // май локально (1 мая 02:00)
+
+        // act
+        MonthlyReport report = service.getMonthlyReport(user.getId(), "Asia/Almaty", "2026-04");
+
+        // assert: граничные считаются по TZ юзера → ровно 2 (31 марта 21:00 UTC + 15 апр),
+        // а 30 апр 21:00 UTC (= 1 мая локально) выпадает. При наивном UTC-расчёте было бы
+        // тоже 2, но другой состав — поэтому проверяем зеркало в отдельном assert ниже.
+        assertThat(report.done()).isEqualTo(2L);
+
+        // act 2: тот же набор за МАЙ — должно быть ровно 1 (то, что выпало из апреля)
+        MonthlyReport may = service.getMonthlyReport(user.getId(), "Asia/Almaty", "2026-05");
+
+        // assert: майское действие (1 мая 02:00 локально) учтено в мае
+        assertThat(may.done()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("should_bucket_trend_by_user_timezone_not_utc_on_week_boundary")
+    void should_bucket_trend_by_user_timezone_not_utc_on_week_boundary() {
+        // arrange: Asia/Almaty. Действие 2026-04-06 01:00 ЛОКАЛЬНО (понедельник, ISO-W15)
+        // = 2026-04-05 20:00 UTC (воскресенье, ISO-W14). Бакетинг идёт в TZ юзера →
+        // должно лечь в W15, а не W14. Второе действие явно в W15 для контроля.
+        User user = savedUser(7003L, "Asia/Almaty");
+        Plant plant = savedPlant(user, "Граничная неделя");
+
+        savedCare(plant, TaskType.WATERING, utc("2026-04-05T20:00:00"), true, null); // пн W15 локально
+        savedCare(plant, TaskType.WATERING, utc("2026-04-07T07:00:00"), true, null); // вт W15 локально
+
+        // act
+        MonthlyReport report = service.getMonthlyReport(user.getId(), "Asia/Almaty", "2026-04");
+
+        // assert: оба в одной неделе W15 (если бы бакетили по UTC, первое уехало бы в W14)
+        assertThat(report.healthTrend())
+                .extracting(WeeklyHealthBucket::week)
+                .containsExactly("2026-W15");
+        assertThat(report.healthTrend().get(0).done()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("should_round_onTimePct_to_two_decimals_per_week")
+    void should_round_onTimePct_to_two_decimals_per_week() {
+        // arrange: одна ISO-неделя, 3 действия, 2 on-time → 2/3 = 0.6667 → округление 0.67
+        User user = savedUser(7004L, "UTC");
+        Plant plant = savedPlant(user, "Дробь");
+
+        savedCare(plant, TaskType.WATERING, utc("2026-04-13T10:00:00"), true, null);
+        savedCare(plant, TaskType.WATERING, utc("2026-04-14T10:00:00"), true, null);
+        savedCare(plant, TaskType.WATERING, utc("2026-04-15T10:00:00"), false, null);
+
+        // act
+        MonthlyReport report = service.getMonthlyReport(user.getId(), "UTC", "2026-04");
+
+        // assert
+        assertThat(report.healthTrend()).hasSize(1);
+        WeeklyHealthBucket bucket = report.healthTrend().get(0);
+        assertThat(bucket.week()).isEqualTo("2026-W16");
+        assertThat(bucket.done()).isEqualTo(3L);
+        assertThat(bucket.onTimePct()).isEqualTo(0.67);
+    }
+
+    @Test
+    @DisplayName("should_order_trend_chronologically_across_year_boundary")
+    void should_order_trend_chronologically_across_year_boundary() {
+        // arrange: январь 2026. ISO-W01 2026 начинается 2025-12-29 (пн). Действие
+        // 2025-12-29 (которое в запросе за январь не появится — оно вне окна месяца),
+        // поэтому возьмём действия внутри января, попадающие на W01 (2025-W01? нет —
+        // 2026-W01) и W02 2026 — и проверим хронологический порядок ярлыков с week-year.
+        // Главная цель: метки идут возрастающе и week-based-year корректно 2026.
+        User user = savedUser(7005L, "UTC");
+        Plant plant = savedPlant(user, "Январь");
+
+        // 2026-01-02 — пятница ISO-W01-2026
+        savedCare(plant, TaskType.WATERING, utc("2026-01-02T10:00:00"), true, null);
+        // 2026-01-08 — четверг ISO-W02-2026
+        savedCare(plant, TaskType.WATERING, utc("2026-01-08T10:00:00"), true, null);
+
+        // act
+        MonthlyReport report = service.getMonthlyReport(user.getId(), "UTC", "2026-01");
+
+        // assert: метки в хронологическом порядке, week-based-year = 2026
+        assertThat(report.healthTrend())
+                .extracting(WeeklyHealthBucket::week)
+                .containsExactly("2026-W01", "2026-W02");
+    }
+
+    @Test
+    @DisplayName("should_return_zeros_and_empty_trend_when_no_history_in_month")
+    void should_return_zeros_and_empty_trend_when_no_history_in_month() {
+        // arrange: растение есть, но за апрель ноль действий
+        User user = savedUser(7006L, "UTC");
+        savedPlant(user, "Молчун");
+
+        // act
+        MonthlyReport report = service.getMonthlyReport(user.getId(), "UTC", "2026-04");
+
+        // assert
+        assertSoftly(softly -> {
+            softly.assertThat(report.done()).isZero();
+            softly.assertThat(report.overdue()).isZero();
+            softly.assertThat(report.byType())
+                    .containsEntry(TaskType.WATERING, 0L)
+                    .containsEntry(TaskType.MISTING, 0L)
+                    .containsEntry(TaskType.FERTILIZING, 0L)
+                    .containsEntry(TaskType.SOIL_CHECK, 0L);
+            softly.assertThat(report.streak()).isZero(); // нет истории → стрик 0
+            softly.assertThat(report.healthTrend()).isEmpty();
+        });
+    }
+
+    @Test
+    @DisplayName("should_return_all_four_byType_keys_when_only_watering_present")
+    void should_return_all_four_byType_keys_when_only_watering_present() {
+        // arrange: за месяц только WATERING
+        User user = savedUser(7007L, "UTC");
+        Plant plant = savedPlant(user, "Только полив");
+        savedCare(plant, TaskType.WATERING, utc("2026-04-10T10:00:00"), true, null);
+        savedCare(plant, TaskType.WATERING, utc("2026-04-20T10:00:00"), true, null);
+
+        // act
+        MonthlyReport report = service.getMonthlyReport(user.getId(), "UTC", "2026-04");
+
+        // assert: все 4 ключа, остальные = 0
+        assertThat(report.byType())
+                .containsOnlyKeys(TaskType.WATERING, TaskType.MISTING,
+                        TaskType.FERTILIZING, TaskType.SOIL_CHECK)
+                .containsEntry(TaskType.WATERING, 2L)
+                .containsEntry(TaskType.MISTING, 0L)
+                .containsEntry(TaskType.FERTILIZING, 0L)
+                .containsEntry(TaskType.SOIL_CHECK, 0L);
+    }
+
+    @Test
+    @DisplayName("should_not_count_other_users_data_in_report")
+    void should_not_count_other_users_data_in_report() {
+        // arrange: два юзера, у каждого активность в апреле. Отчёт строится для первого.
+        User me = savedUser(7008L, "UTC");
+        Plant myPlant = savedPlant(me, "Моё");
+        savedCare(myPlant, TaskType.WATERING, utc("2026-04-10T10:00:00"), true, null);
+
+        User other = savedUser(7009L, "UTC");
+        Plant otherPlant = savedPlant(other, "Чужое");
+        savedCare(otherPlant, TaskType.WATERING, utc("2026-04-11T10:00:00"), true, null);
+        savedCare(otherPlant, TaskType.MISTING, utc("2026-04-12T10:00:00"), false, null);
+
+        // act
+        MonthlyReport report = service.getMonthlyReport(me.getId(), "UTC", "2026-04");
+
+        // assert: только моё одно действие, чужие два не утекли
+        assertSoftly(softly -> {
+            softly.assertThat(report.done()).isEqualTo(1L);
+            softly.assertThat(report.overdue()).isZero();
+            softly.assertThat(report.byType()).containsEntry(TaskType.WATERING, 1L);
+            softly.assertThat(report.healthTrend()).hasSize(1);
+            softly.assertThat(report.healthTrend().get(0).done()).isEqualTo(1L);
+        });
+    }
+
+    @Test
+    @DisplayName("should_compute_current_streak_when_consecutive_active_days_until_today")
+    void should_compute_current_streak_when_consecutive_active_days_until_today() {
+        // arrange: стрик считается от LocalDate.now(tz). Привязываем действия к
+        // «сегодня», «вчера», «позавчера» в UTC, чтобы тест не зависел от стенового
+        // времени машины. Запрашиваем отчёт за текущий месяц.
+        User user = savedUser(7010L, "UTC");
+        Plant plant = savedPlant(user, "Стрик");
+
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        saveCareOn(plant, today, 10);
+        saveCareOn(plant, today.minusDays(1), 10);
+        saveCareOn(plant, today.minusDays(2), 10);
+        // разрыв: 4 дня назад (не подряд) — не должен продлевать стрик
+        saveCareOn(plant, today.minusDays(4), 10);
+
+        String month = today.toString().substring(0, 7); // YYYY-MM текущего месяца
+
+        // act
+        MonthlyReport report = service.getMonthlyReport(user.getId(), "UTC", month);
+
+        // assert: 3 подряд (today, -1, -2), разрыв на -3 → стрик 3
+        assertThat(report.streak()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("should_throw_when_month_is_blank")
+    void should_throw_when_month_is_blank() {
+        // arrange
+        User user = savedUser(7011L, "UTC");
+
+        // act + assert
+        assertThatThrownBy(() -> service.getMonthlyReport(user.getId(), "UTC", "  "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("month");
+    }
+
+    @Test
+    @DisplayName("should_throw_when_month_has_invalid_value")
+    void should_throw_when_month_has_invalid_value() {
+        // arrange
+        User user = savedUser(7012L, "UTC");
+
+        // act + assert: 13-й месяц не парсится в YearMonth
+        assertThatThrownBy(() -> service.getMonthlyReport(user.getId(), "UTC", "2026-13"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("2026-13");
+    }
+
+    @Test
+    @DisplayName("should_throw_when_month_is_garbage")
+    void should_throw_when_month_is_garbage() {
+        // arrange
+        User user = savedUser(7013L, "UTC");
+
+        // act + assert
+        assertThatThrownBy(() -> service.getMonthlyReport(user.getId(), "UTC", "garbage"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ===================== helpers =====================
+
+    private User savedUser(Long chatId, String timezone) {
+        return userRepository.save(User.builder()
+                .telegramChatId(chatId)
+                .timezone(timezone)
+                .blocked(false)
+                .build());
+    }
+
+    private Location savedDefaultLocation(User user) {
+        return locationRepository.findByUserIdAndDefaultLocationTrue(user.getId())
+                .orElseGet(() -> locationRepository.save(Location.builder()
+                        .user(user)
+                        .name(Location.DEFAULT_NAME)
+                        .emoji(Location.DEFAULT_EMOJI)
+                        .defaultLocation(true)
+                        .build()));
+    }
+
+    private Plant savedPlant(User user, String name) {
+        return plantRepository.save(Plant.builder()
+                .user(user)
+                .location(savedDefaultLocation(user))
+                .name(name)
+                .acquiredAt(LocalDate.of(2024, 1, 1))
+                .build());
+    }
+
+    /** done_at хранится в БД как UTC LocalDateTime — передаём его напрямую. */
+    private CareHistory savedCare(Plant plant, TaskType type, LocalDateTime doneAtUtc,
+                                  boolean onTime, CareHistory cancelledBy) {
+        return careHistoryRepository.save(CareHistory.builder()
+                .plant(plant)
+                .taskType(type)
+                .doneAt(doneAtUtc.truncatedTo(ChronoUnit.MICROS))
+                .onTime(onTime)
+                .cancelledBy(cancelledBy)
+                .build());
+    }
+
+    private void saveCareOn(Plant plant, LocalDate dayUtc, int hour) {
+        savedCare(plant, TaskType.WATERING, dayUtc.atTime(hour, 0), true, null);
+    }
+
+    private static LocalDateTime utc(String isoLocal) {
+        return LocalDateTime.parse(isoLocal).truncatedTo(ChronoUnit.MICROS);
+    }
+}


### PR DESCRIPTION
Closes #192

## Что сделано
- Новый REST-эндпоинт `GET /api/v1/reports/monthly?month=YYYY-MM` (bearer-auth, scope: текущий пользователь, TZ-aware) — экран 14 «Месячный отчёт», mobile-гэп **G23**.
- Ответ:
  ```jsonc
  {
    "month": "2026-05",
    "done": 42,        // активные care_history (cancelledBy IS NULL), doneAt в месяце (TZ юзера)
    "overdue": 5,      // просрочки за месяц: активные записи с onTime=false
    "byType": { "WATERING": 20, "MISTING": 15, "FERTILIZING": 5, "SOIL_CHECK": 2 },
    "streak": 12,      // текущий per-user streak (переиспользован CareHistoryService)
    "healthTrend": [ { "week": "2026-W18", "done": 12, "onTimePct": 0.92 } ]
  }
  ```
- `MonthlyReportApiService` (`@Transactional(readOnly = true)`): границы месяца считаются в TZ пользователя → UTC (тот же паттерн, что в `MonthlyReportService`); ISO-week бакетинг `healthTrend` — по локальной дате пользователя, сортировка устойчива к границе года (W52/W53→W01).
- `ReportsController implements` сгенерированный `ReportsApi` (spec-first OpenAPI: `reports.yaml` + регистрация в `openapi.yaml` → присутствует в `/v3/api-docs`).
- `CareHistoryRepository`: добавлены `countLateActiveByUserIdInRange`, `findActiveDoneAtOnTimeByUserIdInRange` (+ проекция `DoneAtOnTime`).
- `ApiExceptionHandler`: невалидный `month` (нарушение `@Pattern` на query-параметре) теперь даёт **400 VALIDATION_ERROR**, а не 500 (маппинг `HandlerMethodValidationException` / `jakarta.validation.ConstraintViolationException`).
- Docs: README (таблица REST API) + `http/api.http` (runnable пример).

## Acceptance criteria
- [x] `GET /reports/monthly?month=YYYY-MM` отдаёт агрегаты за месяц в TZ пользователя.
- [x] Присутствует в `/v3/api-docs` (spec-first: `reports.yaml` зарегистрирован в `openapi.yaml`).

## Решения по неоднозначным полям (согласованы с автором)
- `overdue` = просрочки **за месяц** (`onTime=false`), а не snapshot «просрочено сейчас».
- `streak` = **текущий** per-user streak (на момент запроса).
- `healthTrend` = **недельные бакеты качества** `{week, done, onTimePct}` (считаются из `care_history`, без новой модели здоровья).

## Миграции
Нет — read-only агрегация по существующей `care_history`. Новые запросы попадают в существующий индекс `care_history(done_at)`, новый индекс не требуется.

## Backward-compat риски
**safe.** Только добавление: новый эндпоинт + новые read-only запросы. Изменение `ApiExceptionHandler` затрагивает все `/api/**`, но строго улучшает поведение (невалидный параметр → 400 вместо 500); ловится только `jakarta.validation.ConstraintViolationException` (не Hibernate/SQL), регрессий по 107 controller-тестам нет.

## Тесты
- `MonthlyReportApiServiceTest` (Testcontainers Postgres, 12 тестов): happy-path, **граница месяца в не-UTC TZ (Asia/Almaty)**, ISO-week бакетинг в TZ юзера, граница года, округление `onTimePct` (2/3→0.67), пустые данные, стабильность 4 ключей `byType`, **scope-изоляция** (чужие данные не попадают), streak.
- `ReportsControllerTest` (`@WebMvcTest`, 5 тестов): JSON-контракт, current-user scoping, **400** на невалидный `month`, 401 без аутентификации.

## Чек
- [x] `./mvnw verify` (системный `mvn verify`) зелёное — `Tests run: 1338, Failures: 0, Errors: 0`
- [x] reviewer прошёл — 0 BLOCKING, 0 SHOULD-FIX (2 NIT, один исправлен, второй принят как defensible)
