### PR TITLE
feat: пассивная диагностика растения GET /plants/{id}/diagnosis (#193)

### DIFF
--- a/src/main/java/com/plantcare/api/v1/PlantController.java
+++ b/src/main/java/com/plantcare/api/v1/PlantController.java
@@ -1,8 +1,10 @@
 package com.plantcare.api.v1;
 
 import com.plantcare.api.generated.PlantsApi;
+import com.plantcare.api.generated.model.DiagnosisIssueDto;
 import com.plantcare.api.generated.model.PageResponsePlantDto;
 import com.plantcare.api.generated.model.PlantCreateRequest;
+import com.plantcare.api.generated.model.PlantDiagnosisDto;
 import com.plantcare.api.generated.model.PlantDto;
 import com.plantcare.api.generated.model.PlantHealthDto;
 import com.plantcare.api.generated.model.PlantUpdateRequest;
@@ -10,6 +12,7 @@ import com.plantcare.api.CurrentUserProvider;
 import com.plantcare.core.domain.Plant;
 import com.plantcare.core.domain.User;
 import com.plantcare.core.service.HealthScoreService;
+import com.plantcare.core.service.PlantDiagnosisReportService;
 import com.plantcare.core.service.PlantService;
 import com.plantcare.core.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -81,6 +84,21 @@ public class PlantController implements PlantsApi {
                     .zone(PlantHealthDto.ZoneEnum.fromValue(health.zone().name()));
         }
         return dto;
+    }
+
+    @Override
+    public PlantDiagnosisDto getPlantDiagnosis(Long id) {
+        Long userId = currentUserProvider.currentUserId();
+        PlantDiagnosisReportService.DiagnosisReport report = plantService.getPlantDiagnosis(userId, id);
+
+        List<DiagnosisIssueDto> issues = report.issues().stream()
+                .map(issue -> new DiagnosisIssueDto(
+                        issue.code(),
+                        DiagnosisIssueDto.SeverityEnum.fromValue(issue.severity().name()),
+                        issue.title()))
+                .toList();
+
+        return new PlantDiagnosisDto(issues, report.recommendations());
     }
 
     private static PlantDto toDto(Plant plant) {

--- a/src/main/java/com/plantcare/core/service/PlantDiagnosisReportService.java
+++ b/src/main/java/com/plantcare/core/service/PlantDiagnosisReportService.java
@@ -1,0 +1,185 @@
+package com.plantcare.core.service;
+
+import com.plantcare.core.domain.CareSchedule;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.enums.HealthZone;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.repository.CareHistoryRepository;
+import com.plantcare.core.repository.CareScheduleRepository;
+import com.plantcare.core.util.TimeUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * Issue #193 (mobile screen 15 «Диагноз»): пассивная диагностика растения
+ * поверх уже имеющихся данных — без ИИ и без интерактивного опросника.
+ * Новой схемы БД не требует (по аналогии с health #138).
+ *
+ * <p><b>Не путать</b> с {@code com.plantcare.bot.diagnosis.PlantDiagnosisService}
+ * и {@code com.plantcare.core.diagnosis.DiagnosisRuleEngine} — это движок
+ * интерактивного опросника, здесь же пассивный отчёт.
+ *
+ * <p>Используются ровно два сигнала:
+ * <ol>
+ *   <li>Просроченные активные расписания ухода ({@code active = true},
+ *       {@code nextDueAt <= now}). «На сколько дней просрочено» считается в
+ *       <b>таймзоне пользователя</b> как разница календарных дней (зеркало
+ *       {@code HealthScoreService.windowStartUtc} / {@link TimeUtils#safeZone}).
+ *       {@code nextDueAt} хранится как UTC wall-clock {@code LocalDateTime}.</li>
+ *   <li>Health-зона из {@link HealthScoreService#computeForPlant(Plant)}
+ *       ({@link HealthZone#RED} = сигнал «уход нерегулярный»).</li>
+ * </ol>
+ *
+ * <p>Порог «мало данных» — тот же {@link CareHistoryService#MIN_ACTIONS_FOR_STATS}
+ * ({@code < 3} активных записей → диагноз не строим).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PlantDiagnosisReportService {
+
+    private static final String INSUFFICIENT_DATA_HINT =
+            "Пока мало данных для диагноза — продолжай отмечать уход";
+
+    private final Clock clock;
+    private final CareScheduleRepository careScheduleRepository;
+    private final CareHistoryRepository careHistoryRepository;
+    private final HealthScoreService healthScoreService;
+
+    /**
+     * Серьёзность проблемы. Порядок констант = порядок убывания приоритета,
+     * чтобы сортировать по {@link Enum#ordinal()}.
+     */
+    public enum Severity {
+        HIGH, MEDIUM, LOW
+    }
+
+    /**
+     * Отдельная выявленная проблема. {@code code} — семантический строковый код
+     * (forward-совместимость с новыми кодами), {@code recommendations} — подсказки,
+     * которые попадут в общий список рекомендаций отчёта.
+     */
+    public record Issue(String code, Severity severity, String title, List<String> recommendations) {
+    }
+
+    /**
+     * Результат пассивной диагностики: список проблем и плоский список рекомендаций.
+     */
+    public record DiagnosisReport(List<Issue> issues, List<String> recommendations) {
+    }
+
+    /**
+     * Строит диагноз для растения. Зовётся из read-only транзакции с уже
+     * загруженным {@code plant} (нужен lazy {@code user} для таймзоны).
+     */
+    @Transactional(readOnly = true)
+    public DiagnosisReport diagnose(Plant plant) {
+        Long plantId = plant.getId();
+
+        long activeHistory = careHistoryRepository.countActiveByPlantId(plantId);
+        if (activeHistory < CareHistoryService.MIN_ACTIONS_FOR_STATS) {
+            log.debug("Diagnosis for plant={}: insufficient data (active={})", plantId, activeHistory);
+            return new DiagnosisReport(List.of(), List.of(INSUFFICIENT_DATA_HINT));
+        }
+
+        String timezone = plant.getUser() != null ? plant.getUser().getTimezone() : null;
+        LocalDate today = today(timezone);
+
+        List<Issue> issues = new ArrayList<>();
+
+        for (CareSchedule schedule : careScheduleRepository.findAllByPlantId(plantId)) {
+            if (!schedule.isActive() || schedule.getNextDueAt() == null) {
+                continue;
+            }
+            long daysOverdue = daysOverdue(schedule, timezone, today);
+            if (daysOverdue <= 0) {
+                continue;
+            }
+            issues.add(issueForOverdue(schedule, daysOverdue));
+        }
+
+        HealthScoreService.HealthScore health = healthScoreService.computeForPlant(plant);
+        if (!health.insufficientData() && health.zone() == HealthZone.RED) {
+            issues.add(new Issue(
+                    "NEGLECTED",
+                    Severity.MEDIUM,
+                    "Уход нерегулярный",
+                    List.of("Вернись к регулярному графику ухода")));
+        }
+
+        issues.sort(Comparator
+                .comparingInt((Issue i) -> i.severity().ordinal())
+                .thenComparingInt(PlantDiagnosisReportService::taskOrderOf));
+
+        LinkedHashSet<String> recommendations = new LinkedHashSet<>();
+        for (Issue issue : issues) {
+            recommendations.addAll(issue.recommendations());
+        }
+
+        log.debug("Diagnosis for plant={}: issues={} recommendations={}",
+                plantId, issues.size(), recommendations.size());
+        return new DiagnosisReport(List.copyOf(issues), List.copyOf(recommendations));
+    }
+
+    /**
+     * Маппинг просроченного расписания → проблема. Для WATERING различаем
+     * «пересушен» (просрочка > одного интервала) и «нужен полив» (≤ интервала).
+     */
+    private Issue issueForOverdue(CareSchedule schedule, long daysOverdue) {
+        TaskType taskType = schedule.getTaskType();
+        return switch (taskType) {
+            case WATERING -> daysOverdue > schedule.getIntervalDays()
+                    ? new Issue("UNDERWATERED", Severity.HIGH, "Пересушен",
+                            List.of("Полей растение сегодня", "Проверь, не пересох ли грунт"))
+                    : new Issue("UNDERWATERED", Severity.MEDIUM, "Нужен полив",
+                            List.of("Полей растение сегодня"));
+            case FERTILIZING -> new Issue("UNDERFED", Severity.LOW, "Не хватает подкормки",
+                    List.of("Подкорми растение по графику"));
+            case MISTING -> new Issue("LOW_HUMIDITY", Severity.LOW, "Низкая влажность",
+                    List.of("Опрыскай растение"));
+            case SOIL_CHECK -> new Issue("SOIL_CHECK_DUE", Severity.LOW, "Пора проверить грунт",
+                    List.of("Проверь состояние грунта"));
+        };
+    }
+
+    /**
+     * На сколько календарных дней просрочено расписание в TZ юзера. {@code nextDueAt}
+     * хранится как UTC wall-clock: переводим в Instant как UTC, затем в дату TZ юзера
+     * и считаем разницу с «сегодня» в той же TZ. {@code <= 0} — не просрочено.
+     */
+    private long daysOverdue(CareSchedule schedule, String timezone, LocalDate today) {
+        ZoneId zone = TimeUtils.safeZone(timezone);
+        LocalDate dueDate = schedule.getNextDueAt()
+                .toInstant(ZoneOffset.UTC)
+                .atZone(zone)
+                .toLocalDate();
+        return today.toEpochDay() - dueDate.toEpochDay();
+    }
+
+    /** Сегодняшняя дата в TZ юзера (через инжектируемый {@link Clock}). */
+    private LocalDate today(String timezone) {
+        return clock.instant().atZone(TimeUtils.safeZone(timezone)).toLocalDate();
+    }
+
+    /** Стабильный tie-break внутри одной severity — по порядку типов ухода. */
+    private static int taskOrderOf(Issue issue) {
+        return switch (issue.code()) {
+            case "UNDERWATERED" -> TaskType.WATERING.ordinal();
+            case "LOW_HUMIDITY" -> TaskType.MISTING.ordinal();
+            case "UNDERFED" -> TaskType.FERTILIZING.ordinal();
+            case "SOIL_CHECK_DUE" -> TaskType.SOIL_CHECK.ordinal();
+            default -> TaskType.values().length; // NEGLECTED и прочие — в конце
+        };
+    }
+}

--- a/src/main/java/com/plantcare/core/service/PlantService.java
+++ b/src/main/java/com/plantcare/core/service/PlantService.java
@@ -39,6 +39,7 @@ public class PlantService {
     private final LocationService locationService;
     private final com.plantcare.core.seasonal.service.SeasonalIntervalService seasonalIntervalService;
     private final HealthScoreService healthScoreService;
+    private final PlantDiagnosisReportService plantDiagnosisReportService;
 
     // =================================================================
     // REST API CRUD (issue #85)
@@ -70,6 +71,18 @@ public class PlantService {
     public HealthScoreService.HealthScore getPlantHealth(Long userId, Long plantId) {
         Plant plant = getPlantOrThrow(userId, plantId);
         return healthScoreService.computeForPlant(plant);
+    }
+
+    /**
+     * Пассивная диагностика растения для REST API (mobile screen 15, issue #193).
+     * Ownership/архив-проверки те же, что в {@link #getPlantOrThrow}. Расчёт идёт
+     * в этой же read-only транзакции — lazy {@code plant.user} (TZ) и расписания
+     * инициализируются без LazyInitializationException.
+     */
+    @Transactional(readOnly = true)
+    public PlantDiagnosisReportService.DiagnosisReport getPlantDiagnosis(Long userId, Long plantId) {
+        Plant plant = getPlantOrThrow(userId, plantId);
+        return plantDiagnosisReportService.diagnose(plant);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -106,6 +106,8 @@ paths:
     $ref: './resources/plant-history.yaml#/paths/ItemHistory'
   /api/v1/plants/{id}/health:
     $ref: './resources/plants.yaml#/paths/ItemHealth'
+  /api/v1/plants/{id}/diagnosis:
+    $ref: './resources/plants.yaml#/paths/ItemDiagnosis'
 
   /api/v1/locations:
     $ref: './resources/locations.yaml#/paths/Collection'
@@ -199,6 +201,10 @@ components:
       $ref: './resources/plants.yaml#/schemas/PlantUpdateRequest'
     PageResponsePlantDto:
       $ref: './resources/plants.yaml#/schemas/PageResponsePlantDto'
+    PlantDiagnosisDto:
+      $ref: './resources/plants.yaml#/schemas/PlantDiagnosisDto'
+    DiagnosisIssueDto:
+      $ref: './resources/plants.yaml#/schemas/DiagnosisIssueDto'
 
     PlantHistoryResponse:
       $ref: './resources/plant-history.yaml#/schemas/PlantHistoryResponse'

--- a/src/main/resources/openapi/resources/plants.yaml
+++ b/src/main/resources/openapi/resources/plants.yaml
@@ -202,7 +202,88 @@ paths:
         '404':
           $ref: '../_common/responses.yaml#/NotFound'
 
+  ItemDiagnosis:
+    get:
+      tags: [Plants]
+      operationId: getPlantDiagnosis
+      summary: Пассивная диагностика растения
+      description: |
+        Возвращает список выявленных проблем (`issues`) и рекомендаций
+        (`recommendations`) для растения (mobile screen 15 «Диагноз»,
+        issue #193). Диагноз пассивный — выводится только из уже имеющихся
+        данных (просроченные расписания ухода, health-зона), без ИИ и без
+        интерактивного опросника. Новой схемы БД не требует.
+
+        Если активных записей ухода меньше порога (`< 3`), диагноз не
+        строится: `issues` пустой, в `recommendations` — единственная
+        подсказка продолжать отмечать уход.
+
+        У здорового растения (данных достаточно, нет просрочек, зона не `RED`)
+        и `issues`, и `recommendations` пустые.
+
+        Доступ только к своему неархивированному растению (как `GET /plants/{id}`).
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '../_common/parameters.yaml#/PlantIdPath'
+      responses:
+        '200':
+          description: Диагноз растения.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/PlantDiagnosisDto'
+        '403':
+          $ref: '../_common/responses.yaml#/Forbidden'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
 schemas:
+  PlantDiagnosisDto:
+    type: object
+    description: |
+      Результат пассивной диагностики растения (mobile screen 15, issue #193).
+      Форма ответа всегда `{ issues, recommendations }` — даже когда данных мало
+      или растение здорово (тогда массивы пустые / содержат только подсказку).
+    required: [issues, recommendations]
+    properties:
+      issues:
+        type: array
+        description: Выявленные проблемы, отсортированы по severity (HIGH → LOW).
+        items:
+          $ref: '#/schemas/DiagnosisIssueDto'
+      recommendations:
+        type: array
+        description: |
+          Рекомендации, собранные по проблемам (в том же порядке) с дедупликацией.
+        items:
+          type: string
+        example:
+          - Полей растение сегодня
+          - Проверь, не пересох ли грунт
+
+  DiagnosisIssueDto:
+    type: object
+    description: Отдельная выявленная проблема растения.
+    required: [code, severity, title]
+    properties:
+      code:
+        type: string
+        description: |
+          Семантический код проблемы (`UNDERWATERED`, `UNDERFED`,
+          `LOW_HUMIDITY`, `SOIL_CHECK_DUE`, `NEGLECTED`, ...). Строка —
+          а не enum — для forward-совместимости с новыми кодами.
+        example: UNDERWATERED
+      severity:
+        type: string
+        enum: [HIGH, MEDIUM, LOW]
+        description: Серьёзность проблемы.
+        example: HIGH
+      title:
+        type: string
+        description: Человекочитаемый заголовок проблемы (локализован).
+        example: Пересушен
+
   PlantHealthDto:
     type: object
     description: |

--- a/src/test/java/com/plantcare/api/v1/HealthControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/HealthControllerTest.java
@@ -56,4 +56,12 @@ class HealthControllerTest extends IntegrationTestBase {
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.info.title").value("Plants Care API"));
     }
+
+    @Test
+    void should_document_plant_diagnosis_path_in_api_docs() throws Exception {
+        // issue #193: новый эндпоинт диагностики должен присутствовать в OpenAPI-контракте.
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.paths['/api/v1/plants/{id}/diagnosis'].get").exists());
+    }
 }

--- a/src/test/java/com/plantcare/api/v1/PlantControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/PlantControllerTest.java
@@ -12,6 +12,7 @@ import jakarta.persistence.EntityNotFoundException;
 import org.springframework.security.access.AccessDeniedException;
 import com.plantcare.core.service.HealthScoreService;
 import com.plantcare.core.service.LocationService;
+import com.plantcare.core.service.PlantDiagnosisReportService;
 import com.plantcare.core.service.PlantService;
 import com.plantcare.core.service.UserService;
 import org.junit.jupiter.api.Test;
@@ -341,6 +342,55 @@ class PlantControllerTest {
 
         // act + assert
         mockMvc.perform(get("/api/v1/plants/999/health"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // ---------------------------------------------------- diagnosis (#193)
+
+    @Test
+    void should_return_diagnosis_json_shape_when_plant_has_issues() throws Exception {
+        // arrange — отчёт с двумя проблемами (HIGH первой) и deduped-рекомендациями
+        var issues = List.of(
+                new PlantDiagnosisReportService.Issue(
+                        "UNDERWATERED",
+                        PlantDiagnosisReportService.Severity.HIGH,
+                        "Пересушен",
+                        List.of("Полей растение сегодня", "Проверь, не пересох ли грунт")),
+                new PlantDiagnosisReportService.Issue(
+                        "UNDERFED",
+                        PlantDiagnosisReportService.Severity.LOW,
+                        "Не хватает подкормки",
+                        List.of("Подкорми растение по графику")));
+        var report = new PlantDiagnosisReportService.DiagnosisReport(
+                issues,
+                List.of("Полей растение сегодня", "Проверь, не пересох ли грунт",
+                        "Подкорми растение по графику"));
+
+        when(plantService.getPlantDiagnosis(1L, 1L)).thenReturn(report);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants/1/diagnosis"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.issues.length()").value(2))
+                .andExpect(jsonPath("$.issues[0].code").value("UNDERWATERED"))
+                .andExpect(jsonPath("$.issues[0].severity").value("HIGH"))
+                .andExpect(jsonPath("$.issues[0].title").value("Пересушен"))
+                .andExpect(jsonPath("$.issues[1].code").value("UNDERFED"))
+                .andExpect(jsonPath("$.issues[1].severity").value("LOW"))
+                .andExpect(jsonPath("$.recommendations.length()").value(3))
+                .andExpect(jsonPath("$.recommendations[0]").value("Полей растение сегодня"))
+                .andExpect(jsonPath("$.recommendations[2]").value("Подкорми растение по графику"));
+    }
+
+    @Test
+    void should_return_404_for_diagnosis_of_missing_plant() throws Exception {
+        // arrange — чужое/архивное растение → not-found пробрасывается из сервиса
+        when(plantService.getPlantDiagnosis(1L, 999L))
+                .thenThrow(new EntityNotFoundException("Plant not found: 999"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants/999/diagnosis"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
     }

--- a/src/test/java/com/plantcare/core/service/PlantDiagnosisReportServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/PlantDiagnosisReportServiceTest.java
@@ -1,0 +1,357 @@
+package com.plantcare.core.service;
+
+import com.plantcare.core.domain.CareHistory;
+import com.plantcare.core.domain.CareSchedule;
+import com.plantcare.core.domain.Location;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.repository.CareHistoryRepository;
+import com.plantcare.core.repository.CareScheduleRepository;
+import com.plantcare.core.repository.LocationRepository;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.UserRepository;
+import com.plantcare.core.service.PlantDiagnosisReportService.DiagnosisReport;
+import com.plantcare.core.service.PlantDiagnosisReportService.Issue;
+import com.plantcare.core.service.PlantDiagnosisReportService.Severity;
+import com.plantcare.bot.support.IntegrationTestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+/**
+ * Интеграционные тесты пассивной диагностики (issue #193) на реальном Postgres
+ * через Testcontainers — диагноз строится поверх настоящих {@code care_schedules}
+ * и {@code care_history}-записей, а не на моках репозиториев (правило проекта:
+ * моки только для внешних API).
+ *
+ * <p>{@link Clock}-бин подменён фиксированным моментом ({@link #FIXED_NOW}), чтобы
+ * «сегодня» и «на сколько дней просрочено» были детерминированными. Просрочка
+ * считается в TZ юзера как разница календарных дней, поэтому {@code nextDueAt}
+ * выставляется относительно зафиксированного «сейчас».
+ *
+ * <p>Покрывает правила #193:
+ * <ul>
+ *   <li>happy — полив просрочен ≤ интервала → UNDERWATERED/MEDIUM «Нужен полив»;</li>
+ *   <li>полив просрочен &gt; интервала → UNDERWATERED/HIGH «Пересушен», рекомендации deduped;</li>
+ *   <li>несколько типов задач → сортировка severity desc (HIGH первым), recommendations deduped/ordered;</li>
+ *   <li>health RED-зона без просрочек → NEGLECTED/MEDIUM;</li>
+ *   <li>edge — мало данных (&lt;3 действий) → пустые issues + «мало данных»-подсказка;</li>
+ *   <li>edge — здоровое растение → пустые issues + пустые recommendations;</li>
+ *   <li>edge — не-UTC TZ (Asia/Almaty) на границе суток: просрочка считается в TZ юзера;</li>
+ *   <li>edge — acclimation активна → диагноз строится как обычно (acclimation игнорируется).</li>
+ * </ul>
+ */
+@DisplayName("PlantDiagnosisReportService — пассивная диагностика (issue #193)")
+@Import(PlantDiagnosisReportServiceTest.FixedClockConfig.class)
+class PlantDiagnosisReportServiceTest extends IntegrationTestBase {
+
+    /**
+     * Фиксированный «сейчас». 00:30 UTC специально: для восточных TZ (Almaty UTC+5)
+     * локальная дата уже «сегодня», а UTC-полночь и локальная-полночь расходятся на
+     * день — это и эксплуатирует TZ-кейс.
+     */
+    static final Instant FIXED_NOW = Instant.parse("2026-05-25T00:30:00Z");
+
+    @TestConfiguration
+    static class FixedClockConfig {
+        @Bean
+        @Primary
+        Clock fixedClock() {
+            return Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+        }
+    }
+
+    @Autowired private PlantDiagnosisReportService service;
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private LocationRepository locationRepository;
+    @Autowired private PlantRepository plantRepository;
+    @Autowired private CareHistoryRepository careHistoryRepository;
+    @Autowired private CareScheduleRepository careScheduleRepository;
+
+    @AfterEach
+    void cleanup() {
+        careHistoryRepository.deleteAll();
+        careScheduleRepository.deleteAll();
+        plantRepository.deleteAll();
+        locationRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("should_report_underwatered_medium_when_watering_overdue_within_one_interval")
+    void should_report_underwatered_medium_when_watering_overdue_within_one_interval() {
+        // arrange: интервал 7 дней, просрочка 3 дня (<= интервала) → «Нужен полив» (MEDIUM).
+        User user = savedUser(9001L, "UTC");
+        Plant plant = savedPlant(user, "Фикус", null, null);
+        givenEnoughHistory(plant);
+        saveSchedule(plant, TaskType.WATERING, 7, daysAgo(3), true);
+
+        // act
+        DiagnosisReport report = service.diagnose(plant);
+
+        // assert
+        assertThat(report.issues()).containsExactly(
+                new Issue("UNDERWATERED", Severity.MEDIUM, "Нужен полив",
+                        report.issues().get(0).recommendations()));
+        assertThat(report.issues().get(0).recommendations()).containsExactly("Полей растение сегодня");
+        assertThat(report.recommendations()).containsExactly("Полей растение сегодня");
+    }
+
+    @Test
+    @DisplayName("should_report_underwatered_high_and_dedup_recommendations_when_overdue_more_than_one_interval")
+    void should_report_underwatered_high_and_dedup_recommendations_when_overdue_more_than_one_interval() {
+        // arrange: интервал 5 дней, просрочка 12 дней (> интервала) → «Пересушен» (HIGH).
+        User user = savedUser(9002L, "UTC");
+        Plant plant = savedPlant(user, "Пересушенный кактус", null, null);
+        givenEnoughHistory(plant);
+        saveSchedule(plant, TaskType.WATERING, 5, daysAgo(12), true);
+
+        // act
+        DiagnosisReport report = service.diagnose(plant);
+
+        // assert
+        assertThat(report.issues()).hasSize(1);
+        Issue issue = report.issues().get(0);
+        assertSoftly(softly -> {
+            softly.assertThat(issue.code()).isEqualTo("UNDERWATERED");
+            softly.assertThat(issue.severity()).isEqualTo(Severity.HIGH);
+            softly.assertThat(issue.title()).isEqualTo("Пересушен");
+        });
+        assertThat(report.recommendations())
+                .containsExactly("Полей растение сегодня", "Проверь, не пересох ли грунт");
+    }
+
+    @Test
+    @DisplayName("should_sort_issues_high_first_and_dedup_recommendations_when_multiple_overdue_tasks")
+    void should_sort_issues_high_first_and_dedup_recommendations_when_multiple_overdue_tasks() {
+        // arrange: полив просрочен > интервала (HIGH), подкормка и опрыскивание просрочены (LOW).
+        User user = savedUser(9003L, "UTC");
+        Plant plant = savedPlant(user, "Запущенная монстера", null, null);
+        givenEnoughHistory(plant);
+        saveSchedule(plant, TaskType.WATERING, 5, daysAgo(12), true);
+        saveSchedule(plant, TaskType.FERTILIZING, 14, daysAgo(2), true);
+        saveSchedule(plant, TaskType.MISTING, 3, daysAgo(2), true);
+
+        // act
+        DiagnosisReport report = service.diagnose(plant);
+
+        // assert: HIGH (полив) первым, затем LOW по порядку типов (MISTING перед FERTILIZING).
+        assertThat(report.issues())
+                .extracting(Issue::code)
+                .containsExactly("UNDERWATERED", "LOW_HUMIDITY", "UNDERFED");
+        assertThat(report.issues())
+                .extracting(Issue::severity)
+                .containsExactly(Severity.HIGH, Severity.LOW, Severity.LOW);
+        assertThat(report.recommendations()).containsExactly(
+                "Полей растение сегодня",
+                "Проверь, не пересох ли грунт",
+                "Опрыскай растение",
+                "Подкорми растение по графику");
+    }
+
+    @Test
+    @DisplayName("should_report_neglected_medium_when_health_zone_is_red_and_no_overdue_schedule")
+    void should_report_neglected_medium_when_health_zone_is_red_and_no_overdue_schedule() {
+        // arrange: 4 действия, лишь 1 on-time → 25% → score 20 → RED-зона. Расписаний нет.
+        User user = savedUser(9004L, "UTC");
+        Plant plant = savedPlant(user, "Нерегулярный уход", null, null);
+        saveCare(plant, TaskType.WATERING, daysAgo(1), true);
+        saveCare(plant, TaskType.WATERING, daysAgo(2), false);
+        saveCare(plant, TaskType.WATERING, daysAgo(3), false);
+        saveCare(plant, TaskType.WATERING, daysAgo(4), false);
+
+        // act
+        DiagnosisReport report = service.diagnose(plant);
+
+        // assert
+        assertThat(report.issues()).containsExactly(
+                new Issue("NEGLECTED", Severity.MEDIUM, "Уход нерегулярный",
+                        report.issues().get(0).recommendations()));
+        assertThat(report.recommendations()).containsExactly("Вернись к регулярному графику ухода");
+    }
+
+    @Test
+    @DisplayName("should_return_insufficient_data_hint_when_fewer_than_three_actions")
+    void should_return_insufficient_data_hint_when_fewer_than_three_actions() {
+        // arrange: всего 2 активных действия (порог MIN_ACTIONS_FOR_STATS = 3),
+        // при этом расписание просрочено — но диагноз не строим из-за нехватки данных.
+        User user = savedUser(9005L, "UTC");
+        Plant plant = savedPlant(user, "Новичок", null, null);
+        saveCare(plant, TaskType.WATERING, daysAgo(1), true);
+        saveCare(plant, TaskType.WATERING, daysAgo(2), true);
+        saveSchedule(plant, TaskType.WATERING, 5, daysAgo(20), true);
+
+        // act
+        DiagnosisReport report = service.diagnose(plant);
+
+        // assert
+        assertThat(report.issues()).isEmpty();
+        assertThat(report.recommendations())
+                .containsExactly("Пока мало данных для диагноза — продолжай отмечать уход");
+    }
+
+    @Test
+    @DisplayName("should_return_empty_report_when_plant_is_healthy")
+    void should_return_empty_report_when_plant_is_healthy() {
+        // arrange: 5 действий, все on-time → 100% → GREEN, расписание НЕ просрочено
+        // (nextDueAt в будущем) → ни одной проблемы.
+        User user = savedUser(9006L, "UTC");
+        Plant plant = savedPlant(user, "Образцовый фикус", "photo-id", "поливаю по графику");
+        for (int i = 1; i <= 5; i++) {
+            saveCare(plant, TaskType.WATERING, daysAgo(i), true);
+        }
+        saveSchedule(plant, TaskType.WATERING, 7, inDays(5), true);
+
+        // act
+        DiagnosisReport report = service.diagnose(plant);
+
+        // assert
+        assertThat(report.issues()).isEmpty();
+        assertThat(report.recommendations()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_compute_days_overdue_in_user_timezone_not_utc")
+    void should_compute_days_overdue_in_user_timezone_not_utc() {
+        // arrange: юзер в Asia/Almaty (UTC+5). FIXED_NOW = 2026-05-25 00:30 UTC =
+        // 2026-05-25 05:30 Алматы → сегодня (локально) = 25 мая.
+        //
+        // nextDueAt хранится как UTC wall-clock. Возьмём nextDueAt = 2026-05-24 22:00.
+        //   - как Instant(UTC) → 2026-05-24 22:00Z = 2026-05-25 03:00 Алматы → dueDate = 25 мая;
+        //   - значит daysOverdue = today(25) - due(25) = 0 → НЕ просрочено.
+        // При наивном UTC-расчёте dueDate было бы 24 мая → daysOverdue = 1 → ложная просрочка.
+        // Пустой список issues доказывает, что граница суток считается в TZ юзера.
+        User user = savedUser(9007L, "Asia/Almaty");
+        Plant plant = savedPlant(user, "Алматинское граничное", null, null);
+        givenEnoughHistory(plant);
+        saveSchedule(plant, TaskType.WATERING, 7,
+                LocalDateTime.parse("2026-05-24T22:00:00"), true);
+
+        // act
+        DiagnosisReport report = service.diagnose(plant);
+
+        // assert: due-дата в Алматы = сегодня → нет просрочки → нет проблем.
+        assertThat(report.issues()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_diagnose_normally_when_acclimation_active")
+    void should_diagnose_normally_when_acclimation_active() {
+        // arrange: растение в acclimation-режиме (acclimationUntil в будущем). Acclimation
+        // не должна подавлять диагноз — просроченный полив всё равно даёт проблему.
+        User user = savedUser(9008L, "UTC");
+        // acclimationUntil выставляем в одном save: повторный save() детачнутого plant
+        // сделал бы merge и подменил user lazy-прокси → LazyInit вне транзакции теста.
+        Plant plant = plantRepository.save(Plant.builder()
+                .user(user)
+                .location(savedDefaultLocation(user))
+                .name("На адаптации")
+                .acquiredAt(LocalDate.of(2024, 1, 1))
+                .acclimationUntil(FIXED_NOW.plus(10, ChronoUnit.DAYS)
+                        .atZone(ZoneOffset.UTC).toLocalDateTime())
+                .build());
+        givenEnoughHistory(plant);
+        saveSchedule(plant, TaskType.WATERING, 7, daysAgo(3), true);
+
+        // act
+        DiagnosisReport report = service.diagnose(plant);
+
+        // assert: acclimation проигнорирована — полив всё равно просрочен.
+        assertThat(report.issues())
+                .extracting(Issue::code)
+                .containsExactly("UNDERWATERED");
+        assertThat(report.issues().get(0).severity()).isEqualTo(Severity.MEDIUM);
+    }
+
+    // ===================== helpers =====================
+
+    private User savedUser(Long chatId, String timezone) {
+        return userRepository.save(User.builder()
+                .telegramChatId(chatId)
+                .timezone(timezone)
+                .blocked(false)
+                .build());
+    }
+
+    private Location savedDefaultLocation(User user) {
+        return locationRepository.findByUserIdAndDefaultLocationTrue(user.getId())
+                .orElseGet(() -> locationRepository.save(Location.builder()
+                        .user(user)
+                        .name(Location.DEFAULT_NAME)
+                        .emoji(Location.DEFAULT_EMOJI)
+                        .defaultLocation(true)
+                        .build()));
+    }
+
+    private Plant savedPlant(User user, String name, String photoFileId, String notes) {
+        return plantRepository.save(Plant.builder()
+                .user(user)
+                .location(savedDefaultLocation(user))
+                .name(name)
+                .photoFileId(photoFileId)
+                .notes(notes)
+                .acquiredAt(LocalDate.of(2024, 1, 1))
+                .build());
+    }
+
+    /**
+     * Достаточно активной истории, чтобы пройти порог MIN_ACTIONS_FOR_STATS (3) и при
+     * этом не свалиться в RED-зону: 3 on-time действия → 100% → GREEN. Так health-сигнал
+     * не зашумляет тесты, проверяющие сигнал «просроченное расписание».
+     */
+    private void givenEnoughHistory(Plant plant) {
+        saveCare(plant, TaskType.WATERING, daysAgo(1), true);
+        saveCare(plant, TaskType.WATERING, daysAgo(2), true);
+        saveCare(plant, TaskType.WATERING, daysAgo(3), true);
+    }
+
+    /** doneAt хранится как UTC wall-clock LocalDateTime. */
+    private CareHistory saveCare(Plant plant, TaskType type, LocalDateTime doneAtUtc, boolean onTime) {
+        return careHistoryRepository.save(CareHistory.builder()
+                .plant(plant)
+                .taskType(type)
+                .doneAt(doneAtUtc.truncatedTo(ChronoUnit.MICROS))
+                .onTime(onTime)
+                .build());
+    }
+
+    private CareSchedule saveSchedule(Plant plant, TaskType type, int intervalDays,
+                                      LocalDateTime nextDueAtUtc, boolean active) {
+        return careScheduleRepository.save(CareSchedule.builder()
+                .plant(plant)
+                .taskType(type)
+                .intervalDays(intervalDays)
+                .nextDueAt(nextDueAtUtc)
+                .active(active)
+                .build());
+    }
+
+    /** UTC wall-clock «N суток назад» относительно фиксированного {@link #FIXED_NOW}. */
+    private LocalDateTime daysAgo(int days) {
+        return FIXED_NOW.minus(days, ChronoUnit.DAYS)
+                .atZone(ZoneOffset.UTC).toLocalDateTime();
+    }
+
+    /** UTC wall-clock «через N суток» относительно фиксированного {@link #FIXED_NOW}. */
+    private LocalDateTime inDays(int days) {
+        return FIXED_NOW.plus(days, ChronoUnit.DAYS)
+                .atZone(ZoneOffset.UTC).toLocalDateTime();
+    }
+}


### PR DESCRIPTION
Closes #193

## Что сделано
- Новый эндпоинт `GET /api/v1/plants/{id}/diagnosis` (scope = текущий JWT-юзер) для экрана 15 «Диагноз» (mobile G24): отдаёт `{ issues: [{code, severity, title}], recommendations: [...] }`.
- Пассивная диагностика **без AI и без интерактивного опросника** — поверх уже имеющихся данных. Сигналы: просроченные активные `care_schedules` (дни просрочки считаются в TZ юзера) + health RED-зона.
- Семантические коды: `UNDERWATERED` (HIGH если просрочка > интервала, иначе MEDIUM), `UNDERFED` / `LOW_HUMIDITY` / `SOIL_CHECK_DUE` (LOW), `NEGLECTED` (MEDIUM по RED-зоне). Severity: HIGH/MEDIUM/LOW.
- Edge: `<3` действий → пустые issues + подсказка «мало данных»; здоровое растение → пустой отчёт. Архив/несуществующее → 404, чужое → 403 (как у остальных `/plants/{id}/*`).
- Сортировка issues по severity (HIGH первым), рекомендации дедуплицируются с сохранением порядка.
- Эндпоинт и схемы (`PlantDiagnosisDto`, `DiagnosisIssueDto`) описаны в OpenAPI → видны в `/v3/api-docs` и Swagger UI.

## Миграции
нет (фича целиком поверх существующих данных, как health #138).

## Backward-compat риски
safe — только новый GET-эндпоинт + новые OpenAPI-схемы, существующие контракты не меняются, схема БД не трогается.

## Тесты
`mvn verify` зелёный (полный Testcontainers-прогон). Покрыто:
- `PlantDiagnosisReportServiceTest` — happy (полив просрочен ≤ и > интервала), несколько типов задач с сортировкой/дедупом, NEGLECTED по RED-зоне, edge «мало данных», здоровое растение, **не-UTC TZ (Asia/Almaty) на границе суток**, acclimation игнорируется.
- `PlantControllerTest` — 200 (форма JSON) и 404.
- `HealthControllerTest` — наличие пути `/api/v1/plants/{id}/diagnosis` в `/v3/api-docs`.

## Чек
- [x] `mvn verify` зелёное
- [x] reviewer прошёл (LGTM, 0 blocking / 0 should-fix; 2 опциональных нита оставлены как есть)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
