### PR TITLE
feat: токсичность в публичном SpeciesDto (#186)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,10 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
       "fertilizingDays": 14,
       "soilCheckDays": null,
       "careDifficulty": "EASY",
-      "lightPreference": "INDIRECT"
+      "lightPreference": "INDIRECT",
+      "toxicToCats": true,
+      "toxicToDogs": true,
+      "toxicToHumans": null
     }
   ],
   "page": 0,
@@ -183,6 +186,8 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
   "totalPages": 2
 }
 ```
+
+Флаги `toxicToCats` / `toxicToDogs` / `toxicToHumans` — тройное состояние: `true` токсично, `false` безопасно, `null` данных нет.
 
 Ответ `GET /api/v1/species/{id}` — те же поля плюс `description` и `facts[]` — энциклопедические факты вида (ADR-011), отсортированные по категории, затем по `display_order`; пустой массив, если фактов нет. Каждый факт: `category` (`ORIGIN`/`CARE`/`TOXICITY`/`CURIOSITY`), `body`, опциональные `title` и `source`. При отсутствии записи — `404`.
 

--- a/src/main/java/com/plantcare/api/web/SpeciesController.java
+++ b/src/main/java/com/plantcare/api/web/SpeciesController.java
@@ -76,7 +76,10 @@ public class SpeciesController implements SpeciesApi {
                 .fertilizingDays(s.getFertilizingDays())
                 .soilCheckDays(s.getSoilCheckDays())
                 .careDifficulty(s.getCareDifficulty() != null ? s.getCareDifficulty().name() : null)
-                .lightPreference(s.getLightPreference() != null ? s.getLightPreference().name() : null);
+                .lightPreference(s.getLightPreference() != null ? s.getLightPreference().name() : null)
+                .toxicToCats(s.getToxicToCats())
+                .toxicToDogs(s.getToxicToDogs())
+                .toxicToHumans(s.getToxicToHumans());
     }
 
     private static SpeciesFactDto toFact(com.plantcare.core.service.SpeciesFactDto fact) {
@@ -94,6 +97,9 @@ public class SpeciesController implements SpeciesApi {
                 .soilCheckDays(s.getSoilCheckDays())
                 .careDifficulty(s.getCareDifficulty() != null ? s.getCareDifficulty().name() : null)
                 .lightPreference(s.getLightPreference() != null ? s.getLightPreference().name() : null)
+                .toxicToCats(s.getToxicToCats())
+                .toxicToDogs(s.getToxicToDogs())
+                .toxicToHumans(s.getToxicToHumans())
                 .description(s.getDescription());
     }
 }

--- a/src/main/resources/openapi/resources/species.yaml
+++ b/src/main/resources/openapi/resources/species.yaml
@@ -125,6 +125,18 @@ schemas:
         nullable: true
         description: Имя enum'а `LightPreference.name()`.
         example: BRIGHT_INDIRECT
+      toxicToCats:
+        type: boolean
+        nullable: true
+        description: Токсично для кошек. null — данных нет.
+      toxicToDogs:
+        type: boolean
+        nullable: true
+        description: Токсично для собак. null — данных нет.
+      toxicToHumans:
+        type: boolean
+        nullable: true
+        description: Токсично для человека. null — данных нет.
 
   SpeciesDetailDto:
     type: object
@@ -162,6 +174,18 @@ schemas:
       lightPreference:
         type: string
         nullable: true
+      toxicToCats:
+        type: boolean
+        nullable: true
+        description: Токсично для кошек. null — данных нет.
+      toxicToDogs:
+        type: boolean
+        nullable: true
+        description: Токсично для собак. null — данных нет.
+      toxicToHumans:
+        type: boolean
+        nullable: true
+        description: Токсично для человека. null — данных нет.
       description:
         type: string
         nullable: true

--- a/src/test/java/com/plantcare/api/web/SpeciesControllerTest.java
+++ b/src/test/java/com/plantcare/api/web/SpeciesControllerTest.java
@@ -134,6 +134,58 @@ class SpeciesControllerTest {
     }
 
     @Test
+    void should_return_toxicity_flags_in_detail_when_species_has_values() throws Exception {
+        // arrange — issue #186: токсичность отдаётся на GET /species/{id}
+        var species = buildSpecies(1L, "Монстера", "Monstera deliciosa");
+        species.setToxicToCats(true);
+        species.setToxicToDogs(true);
+        species.setToxicToHumans(false);
+        when(speciesService.getById(1L)).thenReturn(species);
+        when(speciesFactService.getFactsBySpecies(eq(1L), any())).thenReturn(Map.of());
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/species/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.toxicToCats").value(true))
+                .andExpect(jsonPath("$.toxicToDogs").value(true))
+                .andExpect(jsonPath("$.toxicToHumans").value(false));
+    }
+
+    @Test
+    void should_return_toxicity_flags_in_list_item_when_species_has_values() throws Exception {
+        // arrange — issue #186: токсичность отдаётся и в элементах списка GET /species
+        var species = buildSpecies(7L, "Орхидея фаленопсис", "Phalaenopsis");
+        species.setToxicToCats(false);
+        species.setToxicToDogs(false);
+        species.setToxicToHumans(false);
+        Page<Species> page = new PageImpl<>(List.of(species));
+        when(speciesService.findPage(any(), any(Pageable.class))).thenReturn(page);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/species"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items[0].toxicToCats").value(false))
+                .andExpect(jsonPath("$.items[0].toxicToDogs").value(false))
+                .andExpect(jsonPath("$.items[0].toxicToHumans").value(false));
+    }
+
+    @Test
+    void should_serialize_toxicity_as_null_in_detail_when_no_data() throws Exception {
+        // arrange — поля nullable: NULL означает «данных о токсичности нет»
+        var species = buildSpecies(1L, "Монстера", "Monstera deliciosa");
+        // toxic* остаются null (билдер их не выставляет)
+        when(speciesService.getById(1L)).thenReturn(species);
+        when(speciesFactService.getFactsBySpecies(eq(1L), any())).thenReturn(Map.of());
+
+        // act + assert — сериализация не падает, значения присутствуют как null
+        mockMvc.perform(get("/api/v1/species/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.toxicToCats").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.toxicToDogs").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.toxicToHumans").value(org.hamcrest.Matchers.nullValue()));
+    }
+
+    @Test
     void should_return_404_when_species_not_found() throws Exception {
         // arrange
         when(speciesService.getById(999L))


### PR DESCRIPTION
Closes #186

## Что сделано
- В публичный `SpeciesDto` на `GET /species` и `GET /species/{id}` добавлены три признака токсичности: `toxicToCats`, `toxicToDogs`, `toxicToHumans` (nullable `boolean`).
- Решение: отдаём **уже существующие** в сущности `Species` поля как есть, без новой формы. Бейдж 🐈 (экран 12) маппится на `toxicToCats`, баннер (экран 20) — на любой `true`. `null` = «данных о токсичности нет».
- `species.yaml`: поля добавлены в `SpeciesSummaryDto` и `SpeciesDetailDto` (`nullable: true`, не в `required`) → попадают в `/v3/api-docs` и Swift/Kotlin SDK из спеки.
- `SpeciesController`: проброс в мапперах `toSummary`/`toDetail`.
- README: пример ответа `/species` дополнен новыми полями.

## Миграции
Нет. Колонки заведены в `V26`, значения **уже засижены в `V29`** с осознанной семантикой `NULL = «нет достоверных данных»` (для cats/dogs — у части видов, для humans — только выраженный риск). Поэтому исходно запланированный сидинг-V34 был **удалён**, чтобы не затирать решение V29 и не ломать `SeedSpeciesFactsMigrationTest`.

## Backward-compat риски
Safe, один релиз. Изменение чисто аддитивное: новые поля `nullable`, не в `required` — для существующих клиентов и сгенерированных SDK это optional-поля, контракт не ломается.

## Тесты
`SpeciesControllerTest` (`@WebMvcTest`) — 3 кейса:
- happy: `GET /species/{id}` возвращает три флага с корректными значениями;
- happy: элемент списка `GET /species` содержит флаги;
- edge: при `null` поля сериализуются как `null`, без NPE.

Зелёные в изоляции: `SpeciesControllerTest` 10/10, `SpeciesApiServiceTest` 5/5, `SpeciesFactServiceTest` 3/3, `SeedSpeciesFactsMigrationTest` 6/6 (семантика NULL из V29 цела).

## Чек
- [ ] `mvn verify` зелёное — **НЕТ, и это не из-за этого PR.** Полный `verify` на ветке красный из-за pre-existing флаки/неизолированных тестов (Testcontainers reuse → пустые таблицы; `MonthlyReportServiceTest` виснет на исчерпании HikariPool). Доказано прогоном на **чистом `develop` без правок**: `SpeciesRepositoryTest` и `SpeciesSeedTest` падают идентично. Затронутый нашим изменением код — зелёный в изоляции (см. выше).
- [x] reviewer прошёл — LGTM, 0 BLOCKING, 0 SHOULD-FIX, 1 косметический NIT (инлайн `Matchers.nullValue()` вместо static import).
