### PR TITLE
feat: чтение/редактирование расписаний ухода GET/PUT /plants/{id}/schedules (#185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 - **V28** — добавляет `plants.parent_id BIGINT NULL` — self-FK на `plants(id)` для родословной растений (ADR-012, issue #139). Растение-черенок ссылается на материнское; NULL = корень родословной. FK `ON DELETE SET NULL` (удаление родителя обрывает связь, потомок остаётся). btree-индекс `idx_plants_parent_id` под выборку потомков по родителю. Карточка показывает «🌱 Потомки: N» у родителя и кликабельную ссылку «⬅️ Родитель: …» у потомка
 - **V29** — сидинг энциклопедических фактов в `species_facts` (`ORIGIN`/`CARE`/`TOXICITY`/`CURIOSITY`) и простановка флагов токсичности `species.toxic_to_*` для топ-видов по популярности (issue #132). Это сидинг, обещанный в V22 (#129), и данные под флаги из V26 (#130). Чистый сид без DDL. Привязка к виду по `latin_name`, не по id. Идемпотентен: факты — `INSERT ... WHERE NOT EXISTS` по `(species_id, category, body)`, токсичность — `UPDATE`. Виды без достоверных данных ASPCA остаются с `NULL` («нет данных»)
 - **V30** — таблица `transplant_supply_suggestions` (issue #141): трекер идемпотентности подсказок расходников перед пересадкой. По строке на `(user_id, plant_id, source_event_id)`, где `source_event_id` — id записи TRANSPLANT в `plant_events`, от которой посчитана предстоящая пересадка. UNIQUE `(user_id, plant_id, source_event_id)` гарантирует один пуш на одно предстоящее событие (новая пересадка → новый `source_event_id` → можно подсказать снова). `status` (`SUGGESTED`/`ADDED`/`DISMISSED`, CHECK), `predicted_transplant_at`. FK на `users`/`plants`/`plant_events` `ON DELETE CASCADE`. Индексы `(user_id, status)` и по обоим FK
+- **V34** — добавляет `care_schedules.amount_ml INT NULL` (issue #185): объём полива в миллилитрах для расписаний типа `WATERING`. NULL = объём не задан; для остальных типов колонка не используется
 
 ## REST API
 
@@ -116,6 +117,25 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 | `POST` | `/api/v1/plants` | Создать растение (без расписания полива) |
 | `PUT` | `/api/v1/plants/{id}` | Обновить растение. PATCH-семантика: обновляются только переданные поля (`name`, `notes`, `locationId`) |
 | `DELETE` | `/api/v1/plants/{id}` | Soft-delete: выставляет `archivedAt`, из выборок не возвращается |
+
+При создании растения через REST засеваются все четыре расписания ухода (`WATERING`/`MISTING`/`FERTILIZING`/`SOIL_CHECK`) из дефолтов вида; включён по умолчанию только `WATERING`.
+
+### Schedules (issue #185)
+
+Расписания ухода конкретного растения. У каждого растения ровно четыре расписания по числу типов ухода. Все эндпоинты user-scoped (JWT).
+
+| Метод | Путь | Описание |
+|---|---|---|
+| `GET` | `/api/v1/plants/{id}/schedules` | Все четыре расписания в фиксированном порядке. Если расписание ещё не настроено — отдаётся дефолтный интервал вида с `enabled=false` |
+| `PUT` | `/api/v1/plants/{id}/schedules/{type}` | Создать/обновить расписание типа `{type}`; пересчитывает `nextDueAt` |
+
+`type` ∈ `WATERING` / `MISTING` / `FERTILIZING` / `SOIL_CHECK`. Тело `PUT`: `{ "every", "unit", "amountMl?", "enabled" }`. Элемент ответа:
+
+```json
+{ "type": "WATERING", "every": 7, "unit": "DAY", "amountMl": 250, "enabled": true, "nextDueAt": "2026-06-05T08:00:00Z" }
+```
+
+`unit` сейчас всегда `DAY`. `amountMl` осмыслен только для `WATERING` (для остальных типов игнорируется). `nextDueAt` (UTC) заполнен только при `enabled=true`, иначе `null`.
 
 ### Locations
 

--- a/http/api.http
+++ b/http/api.http
@@ -97,6 +97,24 @@ Authorization: Bearer {{token}}
 GET {{baseUrl}}/api/v1/plants/1/history?offset=0&limit=20
 Authorization: Bearer {{token}}
 
+### --- Schedules (расписания ухода растения) ---
+
+### Все четыре расписания растения
+GET {{baseUrl}}/api/v1/plants/1/schedules
+Authorization: Bearer {{token}}
+
+### Изменить расписание (type: WATERING | MISTING | FERTILIZING | SOIL_CHECK; amountMl только для WATERING)
+PUT {{baseUrl}}/api/v1/plants/1/schedules/WATERING
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+  "every": 7,
+  "unit": "DAY",
+  "amountMl": 250,
+  "enabled": true
+}
+
 ### --- Locations ---
 
 ### Список локаций

--- a/src/main/java/com/plantcare/api/v1/PlantController.java
+++ b/src/main/java/com/plantcare/api/v1/PlantController.java
@@ -56,7 +56,7 @@ public class PlantController implements PlantsApi {
     @Override
     public PlantDto createPlant(PlantCreateRequest request) {
         User user = userService.getByIdOrThrow(currentUserProvider.currentUserId());
-        Plant plant = plantService.createPlant(
+        Plant plant = plantService.createPlantWithDefaultSchedules(
                 user, request.getName(), request.getNotes(), request.getLocationId(), request.getSpeciesId());
         return toDto(plant);
     }

--- a/src/main/java/com/plantcare/api/v1/ScheduleController.java
+++ b/src/main/java/com/plantcare/api/v1/ScheduleController.java
@@ -1,0 +1,66 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.api.generated.SchedulesApi;
+import com.plantcare.api.generated.model.CareScheduleDto;
+import com.plantcare.api.generated.model.CareScheduleUpdateRequest;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.service.PlantService;
+import com.plantcare.core.service.PlantService.ScheduleView;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.ZoneOffset;
+import java.util.List;
+
+/**
+ * REST API для чтения и редактирования расписаний ухода растения (issue #185).
+ *
+ * <p>Документация и mapping живут в сгенерированном {@link SchedulesApi} (см. openapi.yaml).
+ */
+@RestController
+@RequiredArgsConstructor
+public class ScheduleController implements SchedulesApi {
+
+    private final PlantService plantService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    public List<CareScheduleDto> listPlantSchedules(Long id) {
+        Long userId = currentUserProvider.currentUserId();
+        return plantService.getSchedules(userId, id).stream()
+                .map(ScheduleController::toDto)
+                .toList();
+    }
+
+    @Override
+    public CareScheduleDto updatePlantSchedule(
+            Long id, String type, CareScheduleUpdateRequest request) {
+        Long userId = currentUserProvider.currentUserId();
+
+        TaskType taskType;
+        try {
+            taskType = TaskType.valueOf(type);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Неизвестный тип задачи: " + type);
+        }
+
+        ScheduleView view = plantService.updateSchedule(
+                userId, id, taskType,
+                request.getEvery(), request.getAmountMl(), request.getEnabled());
+        return toDto(view);
+    }
+
+    private static CareScheduleDto toDto(ScheduleView v) {
+        CareScheduleDto dto = new CareScheduleDto(
+                CareScheduleDto.TypeEnum.fromValue(v.type().name()),
+                v.every(),
+                CareScheduleDto.UnitEnum.DAY,
+                v.enabled())
+                .amountMl(v.amountMl());
+        if (v.nextDueAt() != null) {
+            dto.nextDueAt(v.nextDueAt().atOffset(ZoneOffset.UTC));
+        }
+        return dto;
+    }
+}

--- a/src/main/java/com/plantcare/core/domain/CareSchedule.java
+++ b/src/main/java/com/plantcare/core/domain/CareSchedule.java
@@ -47,6 +47,13 @@ public class CareSchedule extends BaseEntity {
     @Column(name = "interval_days", nullable = false)
     private Integer intervalDays;
 
+    /**
+     * Объём полива в миллилитрах (issue #185). Осмысленно только для
+     * {@code task_type = WATERING}; для остальных типов задач — {@code null}.
+     */
+    @Column(name = "amount_ml")
+    private Integer amountMl;
+
     @Column(name = "next_due_at", nullable = false)
     private LocalDateTime nextDueAt;
 

--- a/src/main/java/com/plantcare/core/service/PlantService.java
+++ b/src/main/java/com/plantcare/core/service/PlantService.java
@@ -132,6 +132,146 @@ public class PlantService {
         return saved;
     }
 
+    // =================================================================
+    // REST API: чтение/редактирование расписаний ухода (issue #185, G19/G14)
+    // =================================================================
+
+    /**
+     * Проекция расписания ухода для REST API. Возвращается всегда по всем четырём
+     * типам задач, даже если строки в БД ещё нет — тогда отдаём дефолтный интервал
+     * и {@code enabled=false}. {@code nextDueAt} наружу отдаём только для активных
+     * расписаний (для выключенных в колонке лежит placeholder, но он не имеет смысла).
+     */
+    public record ScheduleView(
+            TaskType type,
+            int every,
+            Integer amountMl,
+            boolean enabled,
+            LocalDateTime nextDueAt
+    ) {}
+
+    /**
+     * Фиксированный порядок выдачи расписаний в REST-ответе.
+     */
+    private static final List<TaskType> SCHEDULE_ORDER = List.of(
+            TaskType.WATERING, TaskType.MISTING, TaskType.FERTILIZING, TaskType.SOIL_CHECK);
+
+    /**
+     * Все четыре расписания ухода растения для REST API (issue #185).
+     * Ownership/архив проверяются в {@link #getPlantOrThrow} (чужое/архив → 404).
+     */
+    @Transactional(readOnly = true)
+    public List<ScheduleView> getSchedules(Long userId, Long plantId) {
+        Plant plant = getPlantOrThrow(userId, plantId);
+
+        java.util.Map<TaskType, CareSchedule> existing = careScheduleRepository
+                .findAllByPlantId(plant.getId()).stream()
+                .collect(java.util.stream.Collectors.toMap(CareSchedule::getTaskType, s -> s));
+
+        return SCHEDULE_ORDER.stream()
+                .map(type -> {
+                    CareSchedule row = existing.get(type);
+                    if (row != null) {
+                        boolean enabled = row.isActive();
+                        return new ScheduleView(
+                                type,
+                                row.getIntervalDays(),
+                                row.getAmountMl(),
+                                enabled,
+                                enabled ? row.getNextDueAt() : null);
+                    }
+                    return new ScheduleView(type, defaultIntervalFor(plant, type), null, false, null);
+                })
+                .toList();
+    }
+
+    /**
+     * Создать/обновить одно расписание ухода из REST API (issue #185).
+     * {@code amountMl} осмыслен только для WATERING — для прочих типов сбрасывается в null.
+     * {@code nextDueAt} наружу отдаём только если расписание активно.
+     */
+    @Transactional
+    public ScheduleView updateSchedule(
+            Long userId, Long plantId, TaskType type, int every, Integer amountMl, boolean enabled) {
+        if (!isValidInterval(every)) {
+            throw new IllegalArgumentException("Интервал должен быть от 1 до 365 дней");
+        }
+        Integer effectiveAmount = (type == TaskType.WATERING) ? amountMl : null;
+        if (effectiveAmount != null && effectiveAmount <= 0) {
+            throw new IllegalArgumentException("Объём должен быть положительным");
+        }
+
+        Plant plant = getPlantOrThrow(userId, plantId);
+
+        int effectiveInterval = seasonalIntervalService.effectiveIntervalDays(
+                plant, plant.getUser(), every);
+        LocalDateTime now = LocalDateTime.now();
+
+        CareSchedule schedule = careScheduleRepository
+                .findByPlantIdAndTaskType(plant.getId(), type)
+                .orElse(null);
+
+        if (schedule != null) {
+            schedule.setIntervalDays(every);
+            schedule.setAmountMl(effectiveAmount);
+            schedule.setActive(enabled);
+            if (enabled) {
+                schedule.rescheduleFrom(now, effectiveInterval);
+            }
+            // disabled: nextDueAt оставляем как есть — колонка NOT NULL, а наружу не отдаём.
+        } else {
+            schedule = CareSchedule.builder()
+                    .plant(plant)
+                    .taskType(type)
+                    .intervalDays(every)
+                    .amountMl(effectiveAmount)
+                    // placeholder даже для disabled — колонка NOT NULL.
+                    .nextDueAt(now.plusDays(effectiveInterval))
+                    .active(enabled)
+                    .build();
+        }
+        CareSchedule saved = careScheduleRepository.save(schedule);
+
+        log.info("Updated {} schedule for plant {} (every={}, amountMl={}, enabled={}, user {})",
+                type, plantId, every, effectiveAmount, enabled, userId);
+
+        return new ScheduleView(type, every, effectiveAmount, enabled,
+                enabled ? saved.getNextDueAt() : null);
+    }
+
+    /**
+     * Создать растение из REST API и сразу засеять все четыре расписания ухода
+     * (issue #185, G14). Включено только WATERING; остальные типы создаются
+     * неактивными, чтобы пользователь мог включить их одним PUT. Telegram-flow
+     * ({@link #createPlantWithWateringSchedule}) этим методом не затрагивается.
+     */
+    @Transactional
+    public Plant createPlantWithDefaultSchedules(
+            User user, String name, String notes, Long locationId, Long speciesId) {
+        Plant plant = createPlant(user, name, notes, locationId, speciesId);
+
+        LocalDateTime now = LocalDateTime.now();
+        for (TaskType type : SCHEDULE_ORDER) {
+            int interval = defaultIntervalFor(plant, type);
+            boolean active = (type == TaskType.WATERING);
+            LocalDateTime nextDueAt = active
+                    ? now.plusDays(seasonalIntervalService.effectiveIntervalDays(plant, user, interval))
+                    : now.plusDays(interval); // placeholder для неактивных — колонка NOT NULL.
+
+            CareSchedule schedule = CareSchedule.builder()
+                    .plant(plant)
+                    .taskType(type)
+                    .intervalDays(interval)
+                    .nextDueAt(nextDueAt)
+                    .active(active)
+                    .build();
+            careScheduleRepository.save(schedule);
+        }
+
+        log.info("Seeded default schedules for plant {} (user {})", plant.getId(), user.getId());
+        return plant;
+    }
+
     @Transactional
     public Plant updatePlant(Long userId, Long plantId, String name, String notes, Long locationId) {
         Plant plant = getPlantOrThrow(userId, plantId);

--- a/src/main/resources/db/migration/V34__add_amount_ml_to_care_schedules.sql
+++ b/src/main/resources/db/migration/V34__add_amount_ml_to_care_schedules.sql
@@ -1,0 +1,35 @@
+-- V34__add_amount_ml_to_care_schedules.sql
+-- Issue #185: объём полива (миллилитры) на расписание ухода.
+--
+-- Добавляем опциональный объём в care_schedules.amount_ml. Поле осмысленно
+-- только для task_type = 'WATERING' (сколько воды лить). Для MISTING /
+-- FERTILIZING / SOIL_CHECK и для всех существующих строк значение NULL —
+-- «объём не задан». Это корректная семантика, бэкфил не нужен.
+--
+-- CHECK (amount_ml > 0) — в стиле уже имеющегося в этой таблице
+-- chk_interval_positive: отрицательный/нулевой объём бессмысленен.
+-- NULL допускается (IS NULL OR > 0), т.к. объём опционален.
+--
+-- Backward-compat note:
+--   * Колонка NULLABLE без NOT NULL → старые INSERT в care_schedules,
+--     не упоминающие amount_ml, остаются валидными. Один шаг, без бэкфила
+--     и без отдельной NOT NULL-миграции.
+--   * CHECK не затрагивает существующие строки (для них amount_ml = NULL).
+--   * Индекс не добавляем: запросов с WHERE/ORDER BY по amount_ml нет,
+--     поле читается вместе со строкой расписания.
+--   * Безопасно для rolling deploy. Только DDL, без сидинга.
+
+BEGIN;
+
+ALTER TABLE care_schedules
+    ADD COLUMN amount_ml INTEGER;
+
+ALTER TABLE care_schedules
+    ADD CONSTRAINT chk_care_schedules_amount_ml_positive
+        CHECK (amount_ml IS NULL OR amount_ml > 0);
+
+COMMENT ON COLUMN care_schedules.amount_ml IS
+    'Объём полива в миллилитрах. Осмысленно только для task_type = WATERING. '
+        'NULL — объём не задан (другие типы задач или старые записи до issue #185).';
+
+COMMIT;

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -84,6 +84,10 @@ tags:
     description: Публичный справочник видов растений. Без авторизации.
   - name: Care Types
     description: Публичный справочник типов ухода (полив, опрыскивание, и т.п.). Без авторизации.
+  - name: Schedules
+    description: |
+      Расписания ухода конкретного растения (полив, опрыскивание, удобрение,
+      проверка почвы). Чтение всех четырёх и редактирование одного по типу.
   - name: Shopping
     description: Персональный список покупок пользователя — расходники для ухода за растениями.
 
@@ -112,6 +116,10 @@ paths:
     $ref: './resources/plants.yaml#/paths/ItemHealth'
   /api/v1/plants/{id}/diagnosis:
     $ref: './resources/plants.yaml#/paths/ItemDiagnosis'
+  /api/v1/plants/{id}/schedules:
+    $ref: './resources/schedules.yaml#/paths/Collection'
+  /api/v1/plants/{id}/schedules/{type}:
+    $ref: './resources/schedules.yaml#/paths/Item'
 
   /api/v1/locations:
     $ref: './resources/locations.yaml#/paths/Collection'
@@ -262,6 +270,11 @@ components:
 
     CareTypeDto:
       $ref: './resources/care-types.yaml#/schemas/CareTypeDto'
+
+    CareScheduleDto:
+      $ref: './resources/schedules.yaml#/schemas/CareScheduleDto'
+    CareScheduleUpdateRequest:
+      $ref: './resources/schedules.yaml#/schemas/CareScheduleUpdateRequest'
 
     ShoppingItemDto:
       $ref: './resources/shopping.yaml#/schemas/ShoppingItemDto'

--- a/src/main/resources/openapi/resources/schedules.yaml
+++ b/src/main/resources/openapi/resources/schedules.yaml
@@ -1,0 +1,134 @@
+# Чтение и редактирование расписаний ухода конкретного растения (issue #185).
+#
+# У каждого растения ровно четыре расписания (WATERING / MISTING / FERTILIZING /
+# SOIL_CHECK). Коллекция всегда возвращает все четыре — даже если строки в БД ещё
+# нет (тогда отдаётся дефолтный интервал и enabled=false).
+
+paths:
+  Collection:
+    get:
+      tags: [Schedules]
+      operationId: listPlantSchedules
+      summary: Расписания ухода растения
+      description: |
+        Возвращает все четыре расписания ухода растения (WATERING, MISTING,
+        FERTILIZING, SOIL_CHECK) в фиксированном порядке. Если расписание ещё
+        не настроено — отдаётся дефолтный интервал вида с `enabled=false`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '../_common/parameters.yaml#/PlantIdPath'
+      responses:
+        '200':
+          description: Список из четырёх расписаний ухода.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/schemas/CareScheduleDto'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+  Item:
+    put:
+      tags: [Schedules]
+      operationId: updatePlantSchedule
+      summary: Изменить расписание ухода
+      description: |
+        Создаёт или обновляет расписание ухода заданного типа. Поле `amountMl`
+        осмысленно только для типа `WATERING`; для остальных типов игнорируется.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '../_common/parameters.yaml#/PlantIdPath'
+        - name: type
+          in: path
+          required: true
+          description: Тип задачи ухода.
+          schema:
+            type: string
+            enum: [WATERING, MISTING, FERTILIZING, SOIL_CHECK]
+            example: WATERING
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/CareScheduleUpdateRequest'
+            example:
+              every: 7
+              unit: DAY
+              amountMl: 250
+              enabled: true
+      responses:
+        '200':
+          description: Расписание сохранено.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/CareScheduleDto'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+schemas:
+  CareScheduleDto:
+    type: object
+    description: Расписание ухода растения одного типа.
+    required: [type, every, unit, enabled]
+    properties:
+      type:
+        type: string
+        enum: [WATERING, MISTING, FERTILIZING, SOIL_CHECK]
+        example: WATERING
+      every:
+        type: integer
+        format: int32
+        description: Интервал в днях.
+        example: 7
+      unit:
+        type: string
+        enum: [DAY]
+        description: Единица интервала. Сейчас всегда DAY.
+        example: DAY
+      amountMl:
+        type: integer
+        format: int32
+        nullable: true
+        description: Объём полива в миллилитрах. Только для type=WATERING.
+        example: 250
+      enabled:
+        type: boolean
+        example: true
+      nextDueAt:
+        type: string
+        format: date-time
+        nullable: true
+        description: Ближайшее срабатывание (UTC). Заполнено только если enabled=true.
+
+  CareScheduleUpdateRequest:
+    type: object
+    required: [every, unit, enabled]
+    properties:
+      every:
+        type: integer
+        format: int32
+        minimum: 1
+        maximum: 365
+        example: 7
+      unit:
+        type: string
+        enum: [DAY]
+        example: DAY
+      amountMl:
+        type: integer
+        format: int32
+        nullable: true
+        minimum: 1
+        description: Объём полива в миллилитрах. Только для type=WATERING.
+        example: 250
+      enabled:
+        type: boolean
+        example: true

--- a/src/test/java/com/plantcare/api/v1/HealthControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/HealthControllerTest.java
@@ -64,4 +64,13 @@ class HealthControllerTest extends IntegrationTestBase {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.paths['/api/v1/plants/{id}/diagnosis'].get").exists());
     }
+
+    @Test
+    void should_document_plant_schedules_paths_in_api_docs() throws Exception {
+        // issue #185 AC: per-plant расписания задокументированы в /v3/api-docs
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.paths['/api/v1/plants/{id}/schedules'].get").exists())
+                .andExpect(jsonPath("$.paths['/api/v1/plants/{id}/schedules/{type}'].put").exists());
+    }
 }

--- a/src/test/java/com/plantcare/api/v1/PlantControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/PlantControllerTest.java
@@ -175,7 +175,7 @@ class PlantControllerTest {
         Plant plant = mockPlant(10L, 1L, "Ficus");
 
         when(userService.getByIdOrThrow(1L)).thenReturn(user);
-        when(plantService.createPlant(eq(user), eq("Ficus"), isNull(), isNull(), isNull()))
+        when(plantService.createPlantWithDefaultSchedules(eq(user), eq("Ficus"), isNull(), isNull(), isNull()))
                 .thenReturn(plant);
 
         String body = """
@@ -202,7 +202,7 @@ class PlantControllerTest {
         when(plant.getSpecies()).thenReturn(species);
 
         when(userService.getByIdOrThrow(1L)).thenReturn(user);
-        when(plantService.createPlant(eq(user), eq("Монстера"), isNull(), isNull(), eq(7L)))
+        when(plantService.createPlantWithDefaultSchedules(eq(user), eq("Монстера"), isNull(), isNull(), eq(7L)))
                 .thenReturn(plant);
 
         String body = """

--- a/src/test/java/com/plantcare/api/v1/ScheduleControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/ScheduleControllerTest.java
@@ -1,0 +1,195 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.service.PlantService;
+import com.plantcare.core.service.PlantService.ScheduleView;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @WebMvcTest для {@link ScheduleController} (issue #185).
+ *
+ * <p>Зеркалит стиль {@code LocationControllerTest}: web-слайс + замоканный
+ * {@link PlantService} и {@link CurrentUserProvider}. Покрывает GET-массив из 4,
+ * PUT-обновление, неизвестный {type}, плохой unit, every вне диапазона и 404 от сервиса.
+ */
+@WebMvcTest(ScheduleController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ScheduleControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PlantService plantService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    @BeforeEach
+    void stubCurrentUser() {
+        when(currentUserProvider.currentUserId()).thenReturn(1L);
+    }
+
+    // ----------------------------------------------------------------- GET
+
+    @Test
+    void should_return_array_of_four_schedules_when_listing() throws Exception {
+        // arrange
+        List<ScheduleView> views = List.of(
+                new ScheduleView(TaskType.WATERING, 7, 250, true,
+                        LocalDateTime.of(2026, 6, 5, 9, 0)),
+                new ScheduleView(TaskType.MISTING, 3, null, false, null),
+                new ScheduleView(TaskType.FERTILIZING, 14, null, false, null),
+                new ScheduleView(TaskType.SOIL_CHECK, 3, null, false, null));
+
+        when(plantService.getSchedules(1L, 42L)).thenReturn(views);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants/42/schedules"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(4))
+                .andExpect(jsonPath("$[0].type").value("WATERING"))
+                .andExpect(jsonPath("$[0].every").value(7))
+                .andExpect(jsonPath("$[0].unit").value("DAY"))
+                .andExpect(jsonPath("$[0].amountMl").value(250))
+                .andExpect(jsonPath("$[0].enabled").value(true))
+                .andExpect(jsonPath("$[0].nextDueAt").exists())
+                .andExpect(jsonPath("$[1].type").value("MISTING"))
+                .andExpect(jsonPath("$[1].enabled").value(false))
+                // nextDueAt отсутствует/null для выключенного расписания
+                .andExpect(jsonPath("$[1].nextDueAt").doesNotExist())
+                .andExpect(jsonPath("$[2].type").value("FERTILIZING"))
+                .andExpect(jsonPath("$[3].type").value("SOIL_CHECK"));
+    }
+
+    @Test
+    void should_return_404_when_get_schedules_throws_not_found() throws Exception {
+        // arrange
+        when(plantService.getSchedules(1L, 99L))
+                .thenThrow(new EntityNotFoundException("Plant not found: 99"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants/99/schedules"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // ----------------------------------------------------------------- PUT
+
+    @Test
+    void should_return_updated_dto_when_put_valid() throws Exception {
+        // arrange
+        ScheduleView updated = new ScheduleView(
+                TaskType.WATERING, 5, 300, true, LocalDateTime.of(2026, 6, 10, 8, 0));
+
+        when(plantService.updateSchedule(1L, 42L, TaskType.WATERING, 5, 300, true))
+                .thenReturn(updated);
+
+        String body = """
+                {"every": 5, "unit": "DAY", "amountMl": 300, "enabled": true}
+                """;
+
+        // act + assert
+        mockMvc.perform(put("/api/v1/plants/42/schedules/WATERING")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.type").value("WATERING"))
+                .andExpect(jsonPath("$.every").value(5))
+                .andExpect(jsonPath("$.unit").value("DAY"))
+                .andExpect(jsonPath("$.amountMl").value(300))
+                .andExpect(jsonPath("$.enabled").value(true))
+                .andExpect(jsonPath("$.nextDueAt").exists());
+    }
+
+    @Test
+    void should_return_400_when_put_unknown_type() throws Exception {
+        // arrange — TaskType.valueOf("FOO") → IllegalArgumentException → 400
+        String body = """
+                {"every": 7, "unit": "DAY", "enabled": true}
+                """;
+
+        // act + assert
+        mockMvc.perform(put("/api/v1/plants/42/schedules/FOO")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    // Примечание: плохой unit ("WEEK") даёт HttpMessageNotReadableException, который в
+    // ApiExceptionHandler не маппится на 400 (падает в generic RuntimeException → 500),
+    // поэтому 400 на уровне MVC здесь НЕ выразим — отдельного теста на bad unit нет.
+
+    @Test
+    void should_return_400_when_put_every_out_of_range() throws Exception {
+        // arrange — @Max(365) на every нарушено bean-валидацией
+        String body = """
+                {"every": 400, "unit": "DAY", "enabled": true}
+                """;
+
+        // act + assert
+        mockMvc.perform(put("/api/v1/plants/42/schedules/WATERING")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void should_return_400_when_put_every_zero() throws Exception {
+        // arrange — @Min(1) на every нарушено
+        String body = """
+                {"every": 0, "unit": "DAY", "enabled": true}
+                """;
+
+        // act + assert
+        mockMvc.perform(put("/api/v1/plants/42/schedules/WATERING")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void should_return_404_when_put_on_plant_throwing_not_found() throws Exception {
+        // arrange — сервис кидает EntityNotFoundException (чужое/отсутствующее растение)
+        when(plantService.updateSchedule(eq(1L), eq(99L), eq(TaskType.WATERING),
+                eq(7), isNull(), eq(true)))
+                .thenThrow(new EntityNotFoundException("Plant not found: 99"));
+
+        String body = """
+                {"every": 7, "unit": "DAY", "enabled": true}
+                """;
+
+        // act + assert
+        mockMvc.perform(put("/api/v1/plants/99/schedules/WATERING")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+}

--- a/src/test/java/com/plantcare/core/service/PlantScheduleServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/PlantScheduleServiceTest.java
@@ -1,0 +1,385 @@
+package com.plantcare.core.service;
+
+import com.plantcare.bot.support.IntegrationTestBase;
+import com.plantcare.core.domain.CareSchedule;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.Species;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.repository.CareHistoryRepository;
+import com.plantcare.core.repository.CareScheduleRepository;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.SpeciesRepository;
+import com.plantcare.core.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Интеграционные тесты per-plant расписаний ухода для REST API (issue #185, G14/G19).
+ *
+ * <p>Покрывает {@link PlantService#getSchedules}, {@link PlantService#updateSchedule}
+ * и {@link PlantService#createPlantWithDefaultSchedules} на реальном Postgres
+ * (Testcontainers), без моков репозиториев. Внешних API здесь нет.
+ *
+ * <p>Замечание про время: {@code PlantService} использует {@code LocalDateTime.now()}
+ * (Clock-бина нет), поэтому {@code nextDueAt} проверяется с допуском (день/диапазон),
+ * а не пин к конкретному инстанту.
+ *
+ * <p>telegramChatId уникальны (8500+) во избежание коллизий с другими тест-классами
+ * при включённом reuse контейнера.
+ */
+@DisplayName("Интеграционные тесты PlantService — расписания ухода (issue #185)")
+class PlantScheduleServiceTest extends IntegrationTestBase {
+
+    @Autowired private PlantService plantService;
+    @Autowired private PlantRepository plantRepository;
+    @Autowired private CareScheduleRepository scheduleRepository;
+    @Autowired private CareHistoryRepository careHistoryRepository;
+    @Autowired private SpeciesRepository speciesRepository;
+    @Autowired private UserRepository userRepository;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = userRepository.save(User.builder()
+                .telegramChatId(8500L)
+                .username("schedule_test_user")
+                .build());
+    }
+
+    @AfterEach
+    void cleanup() {
+        careHistoryRepository.deleteAll();
+        scheduleRepository.deleteAll();
+        plantRepository.deleteAll();
+        // удаляем только наши кастомные виды, seed-данные не трогаем
+        speciesRepository.findByName("ТестВид185")
+                .ifPresent(s -> speciesRepository.delete(s));
+        userRepository.deleteAll();
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private User newUser(long chatId, String name) {
+        return userRepository.save(User.builder()
+                .telegramChatId(chatId)
+                .username(name)
+                .build());
+    }
+
+    /** Вид с заведомо нестандартными интервалами — чтобы доказать, что дефолты текут из species. */
+    private Species customSpecies() {
+        return speciesRepository.save(Species.builder()
+                .name("ТестВид185")
+                .wateringDays(9)
+                .mistingDays(5)
+                .fertilizingDays(21)
+                .soilCheckDays(4)
+                .build());
+    }
+
+    // ============================= getSchedules =============================
+
+    @Test
+    @DisplayName("getSchedules: ровно 4 расписания в порядке WATERING, MISTING, FERTILIZING, SOIL_CHECK")
+    void should_return_four_schedules_in_fixed_order_when_no_rows() {
+        Plant plant = plantService.createPlant(testUser, "Без расписаний", null, null, null);
+
+        List<PlantService.ScheduleView> views = plantService.getSchedules(testUser.getId(), plant.getId());
+
+        assertThat(views).extracting(PlantService.ScheduleView::type)
+                .containsExactly(TaskType.WATERING, TaskType.MISTING,
+                        TaskType.FERTILIZING, TaskType.SOIL_CHECK);
+    }
+
+    @Test
+    @DisplayName("getSchedules: растение без строк → все disabled, интервалы из species-дефолтов")
+    void should_use_species_defaults_when_no_rows() {
+        Species species = customSpecies();
+        Plant plant = plantService.createPlant(testUser, "Из вида", null, null, species.getId());
+
+        List<PlantService.ScheduleView> views = plantService.getSchedules(testUser.getId(), plant.getId());
+
+        assertThat(views).allMatch(v -> !v.enabled());
+        assertThat(views).allMatch(v -> v.nextDueAt() == null);
+        assertThat(views).allMatch(v -> v.amountMl() == null);
+        assertThat(views).extracting(PlantService.ScheduleView::every)
+                .containsExactly(9, 5, 21, 4); // wateringDays, mistingDays, fertilizingDays, soilCheckDays
+    }
+
+    @Test
+    @DisplayName("getSchedules: species == null → hardcode-дефолты W7/M3/F14/S3")
+    void should_use_hardcoded_defaults_when_species_null() {
+        Plant plant = plantService.createPlant(testUser, "Без вида", null, null, null);
+
+        List<PlantService.ScheduleView> views = plantService.getSchedules(testUser.getId(), plant.getId());
+
+        assertThat(views).extracting(PlantService.ScheduleView::every)
+                .containsExactly(7, 3, 14, 3);
+    }
+
+    @Test
+    @DisplayName("getSchedules: активная строка → отражает interval/amountMl/active и nextDueAt не null")
+    void should_reflect_active_row_with_next_due_at() {
+        Plant plant = plantService.createPlant(testUser, "С поливом", null, null, null);
+        plantService.updateSchedule(testUser.getId(), plant.getId(),
+                TaskType.WATERING, 4, 250, true);
+
+        PlantService.ScheduleView watering = plantService
+                .getSchedules(testUser.getId(), plant.getId()).getFirst();
+
+        assertThat(watering.enabled()).isTrue();
+        assertThat(watering.every()).isEqualTo(4);
+        assertThat(watering.amountMl()).isEqualTo(250);
+        assertThat(watering.nextDueAt()).isNotNull();
+        assertThat(watering.nextDueAt()).isAfter(LocalDateTime.now().minusMinutes(1));
+    }
+
+    @Test
+    @DisplayName("getSchedules: неактивная строка → enabled=false и nextDueAt=null")
+    void should_hide_next_due_at_for_inactive_row() {
+        Plant plant = plantService.createPlant(testUser, "Выключенное", null, null, null);
+        // включаем, затем выключаем — строка существует, но active=false
+        plantService.updateSchedule(testUser.getId(), plant.getId(), TaskType.MISTING, 3, null, true);
+        plantService.updateSchedule(testUser.getId(), plant.getId(), TaskType.MISTING, 3, null, false);
+
+        PlantService.ScheduleView misting = plantService
+                .getSchedules(testUser.getId(), plant.getId()).get(1);
+
+        assertThat(misting.type()).isEqualTo(TaskType.MISTING);
+        assertThat(misting.enabled()).isFalse();
+        assertThat(misting.nextDueAt()).isNull();
+    }
+
+    // ============================ updateSchedule ============================
+
+    @Test
+    @DisplayName("updateSchedule: включение WATERING создаёт активную строку с amountMl и nextDueAt ≈ now+interval")
+    void should_create_active_watering_row_when_enabled() {
+        Plant plant = plantService.createPlant(testUser, "Полив", null, null, null);
+
+        PlantService.ScheduleView view = plantService.updateSchedule(
+                testUser.getId(), plant.getId(), TaskType.WATERING, 5, 300, true);
+
+        assertThat(view.enabled()).isTrue();
+        assertThat(view.amountMl()).isEqualTo(300);
+        assertThat(view.nextDueAt())
+                .isAfter(LocalDateTime.now().plusDays(4))
+                .isBefore(LocalDateTime.now().plusDays(6));
+
+        CareSchedule row = scheduleRepository
+                .findByPlantIdAndTaskType(plant.getId(), TaskType.WATERING).orElseThrow();
+        assertThat(row.isActive()).isTrue();
+        assertThat(row.getIntervalDays()).isEqualTo(5);
+        assertThat(row.getAmountMl()).isEqualTo(300);
+    }
+
+    @Test
+    @DisplayName("updateSchedule: повторный вызов меняет interval/amount и пересчитывает nextDueAt")
+    void should_update_existing_row_and_recompute_next_due_at() {
+        Plant plant = plantService.createPlant(testUser, "Полив", null, null, null);
+        plantService.updateSchedule(testUser.getId(), plant.getId(), TaskType.WATERING, 5, 300, true);
+
+        PlantService.ScheduleView updated = plantService.updateSchedule(
+                testUser.getId(), plant.getId(), TaskType.WATERING, 10, 500, true);
+
+        assertThat(updated.every()).isEqualTo(10);
+        assertThat(updated.amountMl()).isEqualTo(500);
+        assertThat(updated.nextDueAt())
+                .isAfter(LocalDateTime.now().plusDays(9))
+                .isBefore(LocalDateTime.now().plusDays(11));
+
+        // одна строка, не дубль
+        assertThat(scheduleRepository.findAllByPlantId(plant.getId()).stream()
+                .filter(s -> s.getTaskType() == TaskType.WATERING).toList()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("updateSchedule: enabled=false → строка inactive, getSchedules показывает nextDueAt=null")
+    void should_disable_row_and_null_next_due_at_in_view() {
+        Plant plant = plantService.createPlant(testUser, "Удобрение", null, null, null);
+        plantService.updateSchedule(testUser.getId(), plant.getId(), TaskType.FERTILIZING, 14, null, true);
+
+        PlantService.ScheduleView disabled = plantService.updateSchedule(
+                testUser.getId(), plant.getId(), TaskType.FERTILIZING, 14, null, false);
+
+        assertThat(disabled.enabled()).isFalse();
+        assertThat(disabled.nextDueAt()).isNull();
+
+        CareSchedule row = scheduleRepository
+                .findByPlantIdAndTaskType(plant.getId(), TaskType.FERTILIZING).orElseThrow();
+        assertThat(row.isActive()).isFalse();
+
+        // и в проекции наружу тоже null
+        PlantService.ScheduleView fromList = plantService
+                .getSchedules(testUser.getId(), plant.getId()).get(2);
+        assertThat(fromList.nextDueAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("updateSchedule: amountMl игнорируется (null) для MISTING/FERTILIZING/SOIL_CHECK")
+    void should_ignore_amount_ml_for_non_watering_types() {
+        Plant plant = plantService.createPlant(testUser, "Не полив", null, null, null);
+
+        for (TaskType type : List.of(TaskType.MISTING, TaskType.FERTILIZING, TaskType.SOIL_CHECK)) {
+            PlantService.ScheduleView view = plantService.updateSchedule(
+                    testUser.getId(), plant.getId(), type, 3, 999, true);
+
+            assertThat(view.amountMl())
+                    .as("amountMl должен игнорироваться для типа %s", type)
+                    .isNull();
+            assertThat(scheduleRepository.findByPlantIdAndTaskType(plant.getId(), type)
+                    .orElseThrow().getAmountMl()).isNull();
+        }
+    }
+
+    @Test
+    @DisplayName("updateSchedule: amountMl <= 0 для WATERING → IllegalArgumentException")
+    void should_reject_non_positive_amount_ml_for_watering() {
+        Plant plant = plantService.createPlant(testUser, "Полив", null, null, null);
+
+        assertThatThrownBy(() -> plantService.updateSchedule(
+                testUser.getId(), plant.getId(), TaskType.WATERING, 5, 0, true))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> plantService.updateSchedule(
+                testUser.getId(), plant.getId(), TaskType.WATERING, 5, -50, true))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("updateSchedule: every вне [1,365] (0 и 366) → IllegalArgumentException")
+    void should_reject_interval_out_of_range() {
+        Plant plant = plantService.createPlant(testUser, "Полив", null, null, null);
+
+        assertThatThrownBy(() -> plantService.updateSchedule(
+                testUser.getId(), plant.getId(), TaskType.WATERING, 0, null, true))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> plantService.updateSchedule(
+                testUser.getId(), plant.getId(), TaskType.WATERING, 366, null, true))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ============================ cross-user scope ============================
+
+    @Test
+    @DisplayName("getSchedules: чужое растение → AccessDeniedException")
+    void should_deny_get_schedules_for_foreign_plant() {
+        User owner = newUser(8501L, "owner");
+        Plant plant = plantService.createPlant(owner, "Чужое", null, null, null);
+
+        User intruder = newUser(8502L, "intruder");
+
+        assertThatThrownBy(() -> plantService.getSchedules(intruder.getId(), plant.getId()))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("updateSchedule: чужое растение → AccessDeniedException, строка не создаётся")
+    void should_deny_update_schedule_for_foreign_plant() {
+        User owner = newUser(8503L, "owner2");
+        Plant plant = plantService.createPlant(owner, "Чужое2", null, null, null);
+
+        User intruder = newUser(8504L, "intruder2");
+
+        assertThatThrownBy(() -> plantService.updateSchedule(
+                intruder.getId(), plant.getId(), TaskType.WATERING, 5, 100, true))
+                .isInstanceOf(AccessDeniedException.class);
+
+        assertThat(scheduleRepository.findAllByPlantId(plant.getId())).isEmpty();
+    }
+
+    // ================================ G14 ====================================
+
+    @Test
+    @DisplayName("createPlantWithDefaultSchedules: speciesId → 4 строки, активен только WATERING с nextDueAt")
+    void should_seed_four_schedules_only_watering_active_with_species() {
+        Species species = customSpecies();
+
+        Plant plant = plantService.createPlantWithDefaultSchedules(
+                testUser, "G14 с видом", null, null, species.getId());
+
+        List<CareSchedule> rows = scheduleRepository.findAllByPlantId(plant.getId());
+        assertThat(rows).hasSize(4);
+
+        CareSchedule watering = byType(rows, TaskType.WATERING);
+        assertThat(watering.isActive()).isTrue();
+        assertThat(watering.getIntervalDays()).isEqualTo(9);   // species watering default
+        assertThat(watering.getNextDueAt()).isAfter(LocalDateTime.now().minusMinutes(1));
+
+        assertThat(byType(rows, TaskType.MISTING).isActive()).isFalse();
+        assertThat(byType(rows, TaskType.FERTILIZING).isActive()).isFalse();
+        assertThat(byType(rows, TaskType.SOIL_CHECK).isActive()).isFalse();
+
+        // интервалы у неактивных тоже из species-дефолтов
+        assertThat(byType(rows, TaskType.MISTING).getIntervalDays()).isEqualTo(5);
+        assertThat(byType(rows, TaskType.FERTILIZING).getIntervalDays()).isEqualTo(21);
+        assertThat(byType(rows, TaskType.SOIL_CHECK).getIntervalDays()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("createPlantWithDefaultSchedules: speciesId=null → hardcode-дефолты, активен только WATERING")
+    void should_seed_four_schedules_with_hardcoded_defaults_when_species_null() {
+        Plant plant = plantService.createPlantWithDefaultSchedules(
+                testUser, "G14 без вида", null, null, null);
+
+        List<CareSchedule> rows = scheduleRepository.findAllByPlantId(plant.getId());
+        assertThat(rows).hasSize(4);
+
+        assertThat(byType(rows, TaskType.WATERING).isActive()).isTrue();
+        assertThat(byType(rows, TaskType.WATERING).getIntervalDays()).isEqualTo(7);
+        assertThat(byType(rows, TaskType.MISTING).isActive()).isFalse();
+        assertThat(byType(rows, TaskType.MISTING).getIntervalDays()).isEqualTo(3);
+        assertThat(byType(rows, TaskType.FERTILIZING).getIntervalDays()).isEqualTo(14);
+        assertThat(byType(rows, TaskType.SOIL_CHECK).getIntervalDays()).isEqualTo(3);
+
+        long active = rows.stream().filter(CareSchedule::isActive).count();
+        assertThat(active).isEqualTo(1);
+    }
+
+    // ============================ non-UTC timezone ============================
+
+    @Test
+    @DisplayName("updateSchedule: nextDueAt корректен (now+interval) для пользователя в Asia/Almaty")
+    void should_compute_next_due_at_correctly_for_non_utc_timezone() {
+        User almatyUser = userRepository.save(User.builder()
+                .telegramChatId(8505L)
+                .username("almaty_user")
+                .timezone("Asia/Almaty")
+                .build());
+
+        Plant plant = plantService.createPlant(almatyUser, "Алматинское", null, null, null);
+
+        LocalDateTime before = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+
+        PlantService.ScheduleView view = plantService.updateSchedule(
+                almatyUser.getId(), plant.getId(), TaskType.WATERING, 7, 200, true);
+
+        LocalDateTime after = LocalDateTime.now();
+
+        // nextDueAt хранится в UTC wall-clock = now + 7 дней (сезонность у юзера выключена),
+        // и не зависит от его таймзоны.
+        assertThat(view.nextDueAt())
+                .isAfterOrEqualTo(before.plusDays(7))
+                .isBeforeOrEqualTo(after.plusDays(7).plusSeconds(1));
+    }
+
+    // ---------------------------------------------------------------- util
+
+    private static CareSchedule byType(List<CareSchedule> rows, TaskType type) {
+        return rows.stream().filter(r -> r.getTaskType() == type).findFirst().orElseThrow();
+    }
+}


### PR DESCRIPTION
Closes #185

## Что сделано
- **`GET /api/v1/plants/{id}/schedules`** → всегда массив из 4 расписаний (`WATERING/MISTING/FERTILIZING/SOIL_CHECK`): `{ type, every, unit, amountMl?, enabled, nextDueAt? }`. Для типа без строки — `enabled=false`, `every`=дефолт вида (или хардкод W7/M3/F14/S3), `amountMl=null`, `nextDueAt=null`.
- **`PUT /api/v1/plants/{id}/schedules/{type}`** `{ every, unit, amountMl?, enabled }` → обновляет одно расписание (создаёт строку при необходимости), **пересчитывает `nextDueAt`** через `seasonalIntervalService` (как `toggleSchedule`). `every∈[1,365]`, `amountMl` осмыслен только для `WATERING` (для прочих принудительно `null`, `≤0` → 400), `unit` всегда `DAY`.
- **G14 (closes)**: создание растения через REST теперь засеивает все 4 расписания из дефолтов вида, **enabled только `WATERING`** (остальные `active=false`). Telegram-бот (`createPlantWithWateringSchedule`) и core `createPlant` **не тронуты** — никакого роста объёма напоминаний для существующих сценариев.
- **Scope по пользователю**: `getSchedules`/`updateSchedule` резолвят растение через `getPlantOrThrow(userId, …)` → чужое/отсутствующее → **404** (как в остальном Plants API).
- Spec-first: `resources/schedules.yaml` + регистрация в `openapi.yaml` → в `/v3/api-docs` и генерируемых SDK. `unit`/`type` — enum в спеке.

## Миграции
**V34** `add_amount_ml_to_care_schedules`: `ALTER TABLE care_schedules ADD COLUMN amount_ml INTEGER` (nullable) + `CHECK (amount_ml IS NULL OR amount_ml > 0)` (в стиле существующего `chk_interval_positive`).

## Backward-compat риски
safe — единственный шаг, nullable-колонка без бэкфила; CHECK не трогает существующие строки (у них `amount_ml = NULL`). Rolling-deploy безопасно. Развязка `next_due_at` (NOT NULL) сохранена: отключённые строки хранят значение, в DTO отдаётся `null`.

## Тесты
Полный `mvn verify` тут **нестабильно красный из-за pre-existing инфра-флейка** (Testcontainers reuse) и `MonthlyReportServiceTest`, который вешает билд намертво — поэтому корректность доказана прогоном затронутых классов в изоляции на Java 21 (контейнеры предварительно очищены): **131 tests, 0 failures**:
- `PlantScheduleServiceTest` (16): getSchedules (4 типа, дефолты вида/хардкод, активные/неактивные), updateSchedule (enable/disable, пересчёт nextDueAt, amountMl-правила, every вне диапазона), **cross-user scope**, **G14-сидинг** (с/без speciesId), **не-UTC таймзона**.
- `ScheduleControllerTest` (7): GET-массив, PUT 200, неизвестный `{type}`→400, every вне диапазона→400, 404 от сервиса.
- `HealthControllerTest` (+1): пути расписаний присутствуют в `/v3/api-docs`.
- Регрессии не задеты: `PlantControllerTest` 17, `PlantServiceTest` 48, `PlantDiagnosisReportServiceTest` 8 (#193), `SpeciesControllerTest` 10 (#186), `SchemaMigrationTest` 14, `ConstraintsTest` 6 — все зелёные (ветка пере-базирована на актуальный develop с #193/#186).

## Чек
- [x] затронутые классы зелёные в изоляции (131 tests, 0 fail); full verify не гоняю по задокументированному инфра-флейку (`MonthlyReportServiceTest` виснет)
- [x] reviewer пройден

### Reviewer: 🔴 был, устранён; 2× 🟡 приняты
- 🔴 **Stale base** (ветка была от develop до мёрджа #193/#186) — **устранено rebase'ом на актуальный develop**; финальный diff содержит только #185-файлы, #193/#186 целы (их тесты зелёные). (Замечание «merge удалит фичи» — артефакт two-dot `git diff`; реальный 3-way merge ничего бы не удалил, но привести базу в порядок всё равно правильно.)
- 🟡 **`unit` вне enum (напр. `WEEK`) → 500, не 400** — это **pre-existing глобальное** поведение: любой невалидный enum/JSON в теле на любом эндпоинте сейчас даёт 500 (в `ApiExceptionHandler` нет маппинга `HttpMessageNotReadableException`). Правильный фикс — глобальный `HttpMessageNotReadableException`→400, заслуживает отдельного небольшого PR; для соответствующего спеке клиента (unit=DAY) не воспроизводится. **Отложено.**
- 🟡 **Re-wrap `IllegalArgumentException` в `ScheduleController`** (теряется cause) — косметика, поведение корректно и покрыто тестом (`unknown {type}`→400). **Принято.**
