### PR TITLE
feat: прогресс выполнения по дням GET /api/v1/calendar/progress (#179)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 | `/api/v1/plants/{id}/history` | `GET` | 200 | История ухода за растением с offset-пагинацией. Query params: `limit` [1–100], default 20; `offset`, default 0. Проверяет ownership растения |
 | `/api/v1/today` | `GET` | 200 | Задачи ухода на сегодня в таймзоне пользователя |
 | `/api/v1/calendar` | `GET` | 200 | Расписание за произвольный период. Query params: `from`, `to` (ISO date). Диапазон не более 60 дней. Дни без задач в ответ не включаются |
+| `/api/v1/calendar/progress` | `GET` | 200 | Прогресс выполнения по дням за период: карта `{ "YYYY-MM-DD": { "planned", "done" } }`, где `planned` — запланированные occurrence'ы расписаний, `done` — выполненные (не отменённые) записи ухода за этот локальный день в таймзоне пользователя. Query params: `from`, `to` (ISO date), диапазон не более 60 дней. Дни без планов и без выполнений не включаются |
 | `/api/v1/stats/streak` | `GET` | 200 | Текущий стрик растения (последовательные выполнения без пропусков). Query param: `plantId` |
 | `/api/v1/reports/monthly` | `GET` | 200 | Сводный отчёт по уходу за месяц текущего пользователя: `done`, `overdue` (выполнено с опозданием), `byType` (по всем типам ухода), `streak`, `healthTrend` (понедельные ISO-бакеты качества). Query param `month` обязателен, формат `YYYY-MM`. Границы месяца считаются в таймзоне пользователя. Невалидный `month` → 400 |
 

--- a/http/api.http
+++ b/http/api.http
@@ -53,6 +53,10 @@ Authorization: Bearer {{token}}
 GET {{baseUrl}}/api/v1/calendar
 Authorization: Bearer {{token}}
 
+### Прогресс по дням (planned/done), диапазон ≤ 60 дней
+GET {{baseUrl}}/api/v1/calendar/progress?from=2026-05-01&to=2026-05-31
+Authorization: Bearer {{token}}
+
 ### Стрик растения
 GET {{baseUrl}}/api/v1/stats/streak?plantId=1
 Authorization: Bearer {{token}}

--- a/src/main/java/com/plantcare/api/v1/CalendarController.java
+++ b/src/main/java/com/plantcare/api/v1/CalendarController.java
@@ -1,6 +1,7 @@
 package com.plantcare.api.v1;
 
 import com.plantcare.api.generated.CalendarApi;
+import com.plantcare.api.generated.model.DayProgress;
 import com.plantcare.api.generated.model.TaskDto;
 import com.plantcare.core.domain.CareSchedule;
 import com.plantcare.core.domain.User;
@@ -58,6 +59,24 @@ public class CalendarController implements CalendarApi {
                         .add(TodayController.toTaskDto(schedule));
             }
         }
+
+        return result;
+    }
+
+    @Override
+    public Map<String, DayProgress> getCalendarProgress(LocalDate from, LocalDate to) {
+        if (ChronoUnit.DAYS.between(from, to) > MAX_RANGE_DAYS) {
+            throw new IllegalArgumentException(
+                    "Date range exceeds maximum of " + MAX_RANGE_DAYS + " days");
+        }
+
+        User user = currentUserProvider.currentUser();
+        log.info("GET /api/v1/calendar/progress: userId={}, from={}, to={}", user.getId(), from, to);
+
+        Map<String, DayProgress> result = new TreeMap<>();
+        calendarApiService.getProgress(user.getId(), from, to, user.getTimezone())
+                .forEach((day, progress) ->
+                        result.put(day.toString(), new DayProgress(progress.planned(), progress.done())));
 
         return result;
     }

--- a/src/main/java/com/plantcare/core/repository/CareHistoryRepository.java
+++ b/src/main/java/com/plantcare/core/repository/CareHistoryRepository.java
@@ -209,6 +209,25 @@ public interface CareHistoryRepository extends JpaRepository<CareHistory, Long> 
             Limit limit
     );
 
+    // ===== Прогресс выполнения по дням (issue #179, gap G11) =====
+
+    /**
+     * {@code done_at} всех активных (не-cancelled) записей юзера за окно
+     * {@code [from; toExclusive)} — для агрегации прогресса по локальным дням
+     * в {@code GET /api/v1/calendar/progress}. Бакетирование по TZ юзера
+     * выполняется в сервисе, поэтому возвращаем сырые UTC-метки.
+     *
+     * <p>Границы — «начало/конец локального дня в TZ юзера, сконвертированные в UTC».
+     */
+    @Query("SELECT h.doneAt FROM CareHistory h " +
+            "WHERE h.plant.user.id = :userId AND h.cancelledBy IS NULL " +
+            "AND h.doneAt >= :from AND h.doneAt < :toExclusive")
+    List<LocalDateTime> findActiveDoneAtsByUserIdInRange(
+            @Param("userId") Long userId,
+            @Param("from") LocalDateTime from,
+            @Param("toExclusive") LocalDateTime toExclusive
+    );
+
     // ===== Месячный отчёт REST API (issue #192, gap G23) =====
 
     /**

--- a/src/main/java/com/plantcare/core/service/CalendarApiService.java
+++ b/src/main/java/com/plantcare/core/service/CalendarApiService.java
@@ -1,6 +1,7 @@
 package com.plantcare.core.service;
 
 import com.plantcare.core.domain.CareSchedule;
+import com.plantcare.core.repository.CareHistoryRepository;
 import com.plantcare.core.repository.CareScheduleRepository;
 import com.plantcare.core.util.TimeUtils;
 import lombok.RequiredArgsConstructor;
@@ -9,11 +10,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Сервис для REST API календаря ухода (issue #86).
@@ -28,6 +32,56 @@ import java.util.List;
 public class CalendarApiService {
 
     private final CareScheduleRepository careScheduleRepository;
+    private final CareHistoryRepository careHistoryRepository;
+
+    /**
+     * Прогресс выполнения по дням за диапазон {@code [from, to]} (включительно)
+     * в таймзоне пользователя (issue #179, gap G11).
+     *
+     * <p>{@code planned} — число запланированных occurrence'ов (та же проекция
+     * активных расписаний, что и в {@link #projectEvents}). {@code done} — число
+     * активных (не-cancelled) записей {@code care_history}, попавших в этот
+     * локальный день. Дни без планов и без выполнений в результат не попадают.
+     *
+     * @param userId   id пользователя
+     * @param from     начало диапазона (включительно)
+     * @param to       конец диапазона (включительно)
+     * @param timezone строка таймзоны пользователя
+     * @return отсортированная по дате карта «локальный день → прогресс»
+     */
+    public Map<LocalDate, DayProgress> getProgress(Long userId, LocalDate from,
+                                                   LocalDate to, String timezone) {
+        ZoneId tz = TimeUtils.safeZone(timezone);
+        LocalDate winEnd = to.plusDays(1);
+
+        // counts[0] = planned, counts[1] = done
+        Map<LocalDate, int[]> counts = new TreeMap<>();
+
+        for (CareSchedule schedule : careScheduleRepository.findActiveSchedulesByUserId(userId)) {
+            for (LocalDate day : projectEvents(schedule, from, winEnd, timezone)) {
+                counts.computeIfAbsent(day, k -> new int[2])[0]++;
+            }
+        }
+
+        LocalDateTime fromUtc = from.atStartOfDay(tz).toInstant().atZone(ZoneOffset.UTC).toLocalDateTime();
+        LocalDateTime toExclusiveUtc = winEnd.atStartOfDay(tz).toInstant().atZone(ZoneOffset.UTC).toLocalDateTime();
+
+        for (LocalDateTime doneAtUtc : careHistoryRepository.findActiveDoneAtsByUserIdInRange(userId, fromUtc, toExclusiveUtc)) {
+            LocalDate localDay = doneAtUtc.atOffset(ZoneOffset.UTC).atZoneSameInstant(tz).toLocalDate();
+            counts.computeIfAbsent(localDay, k -> new int[2])[1]++;
+        }
+
+        Map<LocalDate, DayProgress> result = new TreeMap<>();
+        counts.forEach((day, c) -> result.put(day, new DayProgress(c[0], c[1])));
+        log.debug("getProgress: userId={}, from={}, to={}, days={}", userId, from, to, result.size());
+        return result;
+    }
+
+    /**
+     * Прогресс за один день: запланировано/выполнено. Числа в TZ пользователя.
+     */
+    public record DayProgress(int planned, int done) {
+    }
 
     /**
      * Все активные расписания пользователя.

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -133,6 +133,8 @@ paths:
 
   /api/v1/calendar:
     $ref: './resources/calendar.yaml#/paths/Collection'
+  /api/v1/calendar/progress:
+    $ref: './resources/calendar.yaml#/paths/Progress'
 
   /api/v1/today:
     $ref: './resources/today.yaml#/paths/Collection'
@@ -247,6 +249,10 @@ components:
       $ref: './resources/calendar.yaml#/schemas/TaskDto'
     CalendarResponse:
       $ref: './resources/calendar.yaml#/schemas/CalendarResponse'
+    DayProgress:
+      $ref: './resources/calendar.yaml#/schemas/DayProgress'
+    CalendarProgressResponse:
+      $ref: './resources/calendar.yaml#/schemas/CalendarProgressResponse'
 
     TodayResponse:
       $ref: './resources/today.yaml#/schemas/TodayResponse'

--- a/src/main/resources/openapi/resources/calendar.yaml
+++ b/src/main/resources/openapi/resources/calendar.yaml
@@ -44,6 +44,50 @@ paths:
         '400':
           $ref: '../_common/responses.yaml#/BadRequest'
 
+  Progress:
+    get:
+      tags: [Calendar]
+      operationId: getCalendarProgress
+      summary: Прогресс выполнения задач ухода по дням
+      description: |
+        Возвращает по каждому дню диапазона `[from, to]` (включительно) пару
+        чисел: сколько задач **запланировано** (проекция активных расписаний)
+        и сколько **выполнено** (`care_history` с `cancelled_by IS NULL`).
+
+        Оба числа считаются в **таймзоне пользователя** (`users.timezone`).
+        Дни без планов и без выполнений в ответе **не появляются**. Ключи —
+        строки-даты `YYYY-MM-DD`, упорядоченные по возрастанию.
+
+        Максимальная длина диапазона — 60 дней; больше → 400.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: from
+          in: query
+          required: true
+          description: Начало диапазона (включительно).
+          schema:
+            type: string
+            format: date
+            example: 2026-05-24
+        - name: to
+          in: query
+          required: true
+          description: Конец диапазона (включительно). Разница `to - from` ≤ 60 дней.
+          schema:
+            type: string
+            format: date
+            example: 2026-06-22
+      responses:
+        '200':
+          description: Карта «дата → прогресс».
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/CalendarProgressResponse'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+
 schemas:
   TaskDto:
     type: object
@@ -104,3 +148,26 @@ schemas:
       type: array
       items:
         $ref: '#/components/schemas/TaskDto'
+
+  DayProgress:
+    type: object
+    description: Прогресс за один день — запланировано/выполнено в TZ пользователя.
+    required: [planned, done]
+    properties:
+      planned:
+        type: integer
+        format: int32
+        description: Количество запланированных occurrence'ов в этот локальный день.
+      done:
+        type: integer
+        format: int32
+        description: Количество выполненных (не отменённых) записей в этот локальный день.
+
+  CalendarProgressResponse:
+    type: object
+    description: |
+      Карта `date → {planned, done}` для эндпоинта `/api/v1/calendar/progress`.
+      Ключи — строки `YYYY-MM-DD`, отсортированы по возрастанию. Значения —
+      объекты `DayProgress`.
+    additionalProperties:
+      $ref: '#/schemas/DayProgress'

--- a/src/test/java/com/plantcare/api/v1/CalendarControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/CalendarControllerTest.java
@@ -23,6 +23,8 @@ import org.springframework.test.web.servlet.MvcResult;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -220,6 +222,99 @@ class CalendarControllerTest {
                         .param("from", "2026-01-01")
                         .param("to", "2026-03-02"))  // 60 дней
                 .andExpect(status().isOk());
+    }
+
+    // ===================== GET /api/v1/calendar/progress (#179) =====================
+
+    @Test
+    void should_return_200_with_progress_per_day_when_valid_range() throws Exception {
+        // arrange — два дня с прогрессом
+        User user = mockUserWithTimezone(7L, 7L, "UTC");
+        when(currentUserProvider.currentUser()).thenReturn(user);
+        when(calendarApiService.getProgress(anyLong(), any(LocalDate.class), any(LocalDate.class), anyString()))
+                .thenReturn(new TreeMap<>(Map.of(
+                        LocalDate.parse("2026-01-03"), new CalendarApiService.DayProgress(1, 1),
+                        LocalDate.parse("2026-01-05"), new CalendarApiService.DayProgress(2, 0))));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/calendar/progress")
+                        .param("from", "2026-01-01")
+                        .param("to", "2026-01-07"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$['2026-01-03'].planned").value(1))
+                .andExpect(jsonPath("$['2026-01-03'].done").value(1))
+                .andExpect(jsonPath("$['2026-01-05'].planned").value(2))
+                .andExpect(jsonPath("$['2026-01-05'].done").value(0));
+    }
+
+    @Test
+    void should_return_empty_map_when_no_progress_in_range() throws Exception {
+        // arrange — нет активности в диапазоне
+        User user = mockUserWithTimezone(8L, 8L, "UTC");
+        when(currentUserProvider.currentUser()).thenReturn(user);
+        when(calendarApiService.getProgress(anyLong(), any(LocalDate.class), any(LocalDate.class), anyString()))
+                .thenReturn(new TreeMap<>());
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/calendar/progress")
+                        .param("from", "2026-01-01")
+                        .param("to", "2026-01-07"))
+                .andExpect(status().isOk())
+                .andExpect(result -> assertThat(result.getResponse().getContentAsString())
+                        .isEqualTo("{}"));
+    }
+
+    @Test
+    void should_return_400_when_progress_range_exceeds_60_days() throws Exception {
+        // arrange
+        User user = mockUserWithTimezone(9L, 9L, "UTC");
+        when(currentUserProvider.currentUser()).thenReturn(user);
+
+        // act + assert — тот же контракт ошибки, что у /calendar
+        mockMvc.perform(get("/api/v1/calendar/progress")
+                        .param("from", "2026-01-01")
+                        .param("to", "2026-03-03"))  // 61 день
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("BAD_REQUEST"))
+                .andExpect(result -> assertThat(result.getResponse().getContentAsString())
+                        .contains("60 days"));
+    }
+
+    @Test
+    void should_return_401_for_progress_when_no_authenticated_user() throws Exception {
+        // arrange
+        when(currentUserProvider.currentUser())
+                .thenThrow(AuthTokenException.invalid("No authenticated user in security context"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/calendar/progress")
+                        .param("from", "2026-01-01")
+                        .param("to", "2026-01-07"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("TOKEN_INVALID"));
+    }
+
+    @Test
+    void should_return_progress_dates_in_ascending_order() throws Exception {
+        // arrange — карта намеренно с обратным порядком вставки
+        User user = mockUserWithTimezone(10L, 10L, "UTC");
+        when(currentUserProvider.currentUser()).thenReturn(user);
+        when(calendarApiService.getProgress(anyLong(), any(LocalDate.class), any(LocalDate.class), anyString()))
+                .thenReturn(new TreeMap<>(Map.of(
+                        LocalDate.parse("2026-01-05"), new CalendarApiService.DayProgress(1, 0),
+                        LocalDate.parse("2026-01-02"), new CalendarApiService.DayProgress(0, 1))));
+
+        // act
+        MvcResult result = mockMvc.perform(get("/api/v1/calendar/progress")
+                        .param("from", "2026-01-01")
+                        .param("to", "2026-01-07"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // assert — TreeMap гарантирует возрастающий порядок ключей
+        String body = result.getResponse().getContentAsString();
+        assertThat(body.indexOf("2026-01-02")).isLessThan(body.indexOf("2026-01-05"));
     }
 
     // ===================== helpers =====================

--- a/src/test/java/com/plantcare/core/service/CalendarApiServiceProgressTest.java
+++ b/src/test/java/com/plantcare/core/service/CalendarApiServiceProgressTest.java
@@ -1,0 +1,219 @@
+package com.plantcare.core.service;
+
+import com.plantcare.bot.support.IntegrationTestBase;
+import com.plantcare.core.domain.CareHistory;
+import com.plantcare.core.domain.CareSchedule;
+import com.plantcare.core.domain.Location;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.repository.CareHistoryRepository;
+import com.plantcare.core.repository.CareScheduleRepository;
+import com.plantcare.core.repository.LocationRepository;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.UserRepository;
+import com.plantcare.core.service.CalendarApiService.DayProgress;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Интеграционные тесты {@link CalendarApiService#getProgress} на реальном Postgres
+ * через Testcontainers (issue #179, gap G11).
+ *
+ * <p>{@code planned} проецируется из активных расписаний (интервал/nextDueAt),
+ * {@code done} агрегируется из {@code care_history} с бакетированием по локальному
+ * дню в TZ юзера. Проверяем happy, пустые дни и ключевой TZ-кейс на границе суток.
+ */
+@DisplayName("CalendarApiService#getProgress — прогресс по дням (#179)")
+class CalendarApiServiceProgressTest extends IntegrationTestBase {
+
+    @Autowired private CalendarApiService service;
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private LocationRepository locationRepository;
+    @Autowired private PlantRepository plantRepository;
+    @Autowired private CareScheduleRepository careScheduleRepository;
+    @Autowired private CareHistoryRepository careHistoryRepository;
+
+    @AfterEach
+    void cleanup() {
+        careHistoryRepository.deleteAll();
+        careScheduleRepository.deleteAll();
+        plantRepository.deleteAll();
+        locationRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("happy: за диапазон считаются planned (из расписаний) и done (из истории)")
+    void should_count_planned_and_done_per_day() {
+        // arrange — UTC-юзер; полив каждые 7 дней, nextDueAt = 2026-05-04
+        User user = savedUser(5000L, "UTC");
+        Plant plant = savedPlant(user, "Монстера");
+        savedSchedule(plant, TaskType.WATERING, 7, LocalDateTime.of(2026, 5, 4, 9, 0));
+
+        // Выполнено: 04 мая (день с планом) и 06 мая (день без плана).
+        saveCare(plant, TaskType.WATERING, utc(2026, 5, 4, 10, 0));
+        saveCare(plant, TaskType.MISTING, utc(2026, 5, 6, 10, 0));
+
+        // act — окно 2026-05-01..2026-05-10
+        Map<LocalDate, DayProgress> progress = service.getProgress(
+                user.getId(), LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 10), "UTC");
+
+        // assert — 04: planned=1 (occurrence) + done=1; 06: planned=0 + done=1.
+        assertThat(progress).containsKeys(LocalDate.of(2026, 5, 4), LocalDate.of(2026, 5, 6));
+        assertThat(progress.get(LocalDate.of(2026, 5, 4)))
+                .isEqualTo(new DayProgress(1, 1));
+        assertThat(progress.get(LocalDate.of(2026, 5, 6)))
+                .isEqualTo(new DayProgress(0, 1));
+    }
+
+    @Test
+    @DisplayName("edge: день без планов и без выполнений отсутствует в карте")
+    void should_omit_days_without_any_activity() {
+        // arrange — единственное выполнение 5 мая, нет расписаний
+        User user = savedUser(5001L, "UTC");
+        Plant plant = savedPlant(user, "Монстера");
+        saveCare(plant, TaskType.WATERING, utc(2026, 5, 5, 12, 0));
+
+        // act
+        Map<LocalDate, DayProgress> progress = service.getProgress(
+                user.getId(), LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 10), "UTC");
+
+        // assert — только 5 мая, остальные дни отсутствуют (не {0,0})
+        assertThat(progress).containsOnlyKeys(LocalDate.of(2026, 5, 5));
+        assertThat(progress.get(LocalDate.of(2026, 5, 5)))
+                .isEqualTo(new DayProgress(0, 1));
+    }
+
+    @Test
+    @DisplayName("edge: cancelled-запись не учитывается в done")
+    void should_exclude_cancelled_entry_from_done() {
+        // arrange
+        User user = savedUser(5002L, "UTC");
+        Plant plant = savedPlant(user, "Монстера");
+
+        CareHistory compensation = saveCare(plant, TaskType.WATERING, utc(2026, 5, 5, 18, 0));
+        CareHistory original = CareHistory.builder()
+                .plant(plant)
+                .taskType(TaskType.WATERING)
+                .doneAt(LocalDateTime.of(2026, 5, 5, 8, 0))
+                .onTime(true)
+                .cancelledBy(compensation)
+                .build();
+        careHistoryRepository.save(original);
+
+        // act
+        Map<LocalDate, DayProgress> progress = service.getProgress(
+                user.getId(), LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 10), "UTC");
+
+        // assert — done=1 (только активная компенсация), не 2
+        assertThat(progress.get(LocalDate.of(2026, 5, 5)))
+                .isEqualTo(new DayProgress(0, 1));
+    }
+
+    @Test
+    @DisplayName("TZ: done бакетируется в локальный день Almaty, а не UTC-день")
+    void should_bucket_done_into_local_day_for_almaty() {
+        // arrange — Almaty (UTC+5). doneAt 2026-05-05 20:00 UTC = 2026-05-06 01:00 Almaty.
+        // По UTC попал бы в 5 мая, по локальному календарю — 6 мая.
+        User user = savedUser(5003L, "Asia/Almaty");
+        Plant plant = savedPlant(user, "Монстера");
+        saveCare(plant, TaskType.WATERING, utc(2026, 5, 5, 20, 0));
+
+        // act
+        Map<LocalDate, DayProgress> progress = service.getProgress(
+                user.getId(), LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 10), "Asia/Almaty");
+
+        // assert — запись в локальном 6 мая, не в 5 мая
+        assertThat(progress).containsOnlyKeys(LocalDate.of(2026, 5, 6));
+        assertThat(progress.get(LocalDate.of(2026, 5, 6)))
+                .isEqualTo(new DayProgress(0, 1));
+    }
+
+    @Test
+    @DisplayName("TZ: окно done на границе диапазона учитывает локальные сутки (от/до)")
+    void should_respect_local_window_boundaries_for_almaty() {
+        // arrange — Almaty (UTC+5). Запрос за один локальный день 2026-05-05.
+        // Локальный 2026-05-05 = [2026-05-04 19:00 UTC; 2026-05-05 19:00 UTC).
+        User user = savedUser(5004L, "Asia/Almaty");
+        Plant plant = savedPlant(user, "Монстера");
+
+        // 2026-05-04 19:00 UTC = 2026-05-05 00:00 Almaty → входит.
+        saveCare(plant, TaskType.WATERING, utc(2026, 5, 4, 19, 0));
+        // 2026-05-04 18:00 UTC = 2026-05-04 23:00 Almaty → НЕ входит (предыдущий локальный день).
+        saveCare(plant, TaskType.MISTING, utc(2026, 5, 4, 18, 0));
+
+        // act — диапазон только 5 мая (один день)
+        Map<LocalDate, DayProgress> progress = service.getProgress(
+                user.getId(), LocalDate.of(2026, 5, 5), LocalDate.of(2026, 5, 5), "Asia/Almaty");
+
+        // assert
+        assertThat(progress).containsOnlyKeys(LocalDate.of(2026, 5, 5));
+        assertThat(progress.get(LocalDate.of(2026, 5, 5)))
+                .isEqualTo(new DayProgress(0, 1));
+    }
+
+    // ===================== helpers =====================
+
+    private User savedUser(Long chatId, String timezone) {
+        return userRepository.save(User.builder()
+                .telegramChatId(chatId)
+                .timezone(timezone)
+                .blocked(false)
+                .build());
+    }
+
+    private Location savedDefaultLocation(User user) {
+        return locationRepository.findByUserIdAndDefaultLocationTrue(user.getId())
+                .orElseGet(() -> locationRepository.save(Location.builder()
+                        .user(user)
+                        .name(Location.DEFAULT_NAME)
+                        .emoji(Location.DEFAULT_EMOJI)
+                        .defaultLocation(true)
+                        .build()));
+    }
+
+    private Plant savedPlant(User user, String name) {
+        return plantRepository.save(Plant.builder()
+                .user(user)
+                .location(savedDefaultLocation(user))
+                .name(name)
+                .build());
+    }
+
+    private CareSchedule savedSchedule(Plant plant, TaskType type, int intervalDays,
+                                       LocalDateTime nextDueAt) {
+        return careScheduleRepository.save(CareSchedule.builder()
+                .plant(plant)
+                .taskType(type)
+                .intervalDays(intervalDays)
+                .nextDueAt(nextDueAt)
+                .active(true)
+                .updatedAt(LocalDateTime.of(2026, 5, 1, 0, 0))
+                .build());
+    }
+
+    private CareHistory saveCare(Plant plant, TaskType type, LocalDateTime doneAtUtc) {
+        return careHistoryRepository.save(CareHistory.builder()
+                .plant(plant)
+                .taskType(type)
+                .doneAt(doneAtUtc.truncatedTo(ChronoUnit.MICROS))
+                .onTime(true)
+                .build());
+    }
+
+    private static LocalDateTime utc(int y, int mo, int d, int h, int mi) {
+        return LocalDateTime.of(y, mo, d, h, mi).atZone(ZoneId.of("UTC")).toLocalDateTime();
+    }
+}


### PR DESCRIPTION
Closes #179

## Что сделано
Часть **B** issue #179 (mobile gap **G11**) — прогресс выполнения по дням для недельного календаря экрана «График».

- Новый аддитивный эндпоинт `GET /api/v1/calendar/progress?from&to` → карта `{"YYYY-MM-DD": {"planned": int, "done": int}}`:
  - `planned` — запланированные occurrence'ы активных расписаний (та же проекция `projectEvents`, что у `/calendar`);
  - `done` — выполненные (не отменённые, `cancelled_by IS NULL`) записи `care_history`, бакетированные по **локальному дню в TZ пользователя**;
  - дни без планов и без выполнений в карту не попадают; лимит диапазона 60 дней (как у `/calendar`).
- `CalendarApiService.getProgress(...)` + `CareHistoryRepository.findActiveDoneAtsByUserIdInRange(...)` (тянет сырые UTC `done_at`, бакетинг по TZ в Java).
- OpenAPI: путь `Progress` + схемы `DayProgress` / `CalendarProgressResponse` (`/v3/api-docs` отдаёт автоматически).
- README + `http/api.http` — описание и готовый запрос.

> **Scope:** часть **A** (`/today` done-фид, G13b) уже зашипана отдельно в **#184** (`doneAt` в `TaskDto` + `summary`). Здесь только часть B; этот PR закрывает остаток #179.

## Миграции
Нет — `done` берётся из существующей `care_history`.

## Backward-compat риски
Safe. Изменения OpenAPI строго аддитивны: существующий контракт `/calendar` (`Map<date, TaskDto[]>`) и `TaskDto` не меняются → drift-gate (CI #170) проходит.

## Тесты
- `CalendarApiServiceProgressTest` (Testcontainers/Postgres): happy (planned+done по дням), пустые дни не включаются, исключение `cancelled`-записей, и **два TZ-кейса на границе суток `Asia/Almaty`** (бакетинг в локальный день + границы окна `[from..to]`).
- `CalendarControllerTest` (web-слайс): 200 с прогрессом, пустая карта `{}`, 400 при диапазоне > 60 дней, 401 без юзера, сортировка ключей по возрастанию.
- Прогон на свежем контейнере: `mvn test -Dtest=CalendarControllerTest,CalendarApiServiceProgressTest,CareHistoryRepositoryTest -Dtestcontainers.reuse.enable=false` → **28 tests, 0 failures**.

## Чек
- [x] целевые тесты зелёные (полный `verify` не гонялся: в репо флакает/виснет `MonthlyReportServiceTest` не по нашей вине)
- [x] reviewer прошёл — 🟢 LGTM, 0 blocking / 0 should-fix (2 нита унаследованы из существующего `/calendar`, оставлены для консистентности)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
