### PR TITLE
feat: профиль и настройки пользователя GET + PATCH /api/v1/me (#182)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,15 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 | `PATCH` | `/api/v1/shopping/{id}` | 200 | Частичное обновление: передаются только изменяемые поля (`checked`, `title`) |
 | `DELETE` | `/api/v1/shopping/{id}` | 204 | Удалить позицию |
 
+### Me (issue #182)
+
+Профиль и настройки текущего пользователя. Скоуп — аутентифицированный пользователь.
+
+| Метод | Путь | Статус ответа | Описание |
+|---|---|---|---|
+| `GET` | `/api/v1/me` | 200 | Профиль: имя, аватар, счётчики для хедера (`plantsTotal`, `tasksToday`, `notificationsUnread`) и настройки (`quietHoursStart`, `quietHoursEnd`, `timezone`, `locale`). `tasksToday` — число невыполненных задач на сегодня в таймзоне пользователя. `avatar` — плейсхолдер (всегда `null`, колонки в схеме нет); `notificationsUnread` — плейсхолдер (всегда `0` до фида уведомлений, issue #183) |
+| `PATCH` | `/api/v1/me` | 200 | Частичное обновление настроек (`quietHoursStart`, `quietHoursEnd`, `timezone`, `locale`): меняются только переданные поля. Смена `timezone` пересчитывает активные расписания с сохранением локального времени дня. Невалидный IANA-`timezone` → 400 |
+
 ### Формат ошибок
 
 Все ошибки `/api/**` возвращаются в едином формате:

--- a/src/main/java/com/plantcare/api/v1/MeController.java
+++ b/src/main/java/com/plantcare/api/v1/MeController.java
@@ -1,0 +1,72 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.api.generated.MeApi;
+import com.plantcare.api.generated.model.MeResponse;
+import com.plantcare.api.generated.model.MeUpdateRequest;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.service.UserProfileService;
+import com.plantcare.core.service.UserProfileService.Profile;
+import com.plantcare.core.service.UserProfileService.ProfileUpdate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * REST API профиля и настроек текущего пользователя (issue #182, mobile G5 + G16).
+ *
+ * <p>Документация и валидация полей живут в сгенерированном {@link MeApi}.
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class MeController implements MeApi {
+
+    private static final DateTimeFormatter HH_MM = DateTimeFormatter.ofPattern("HH:mm");
+
+    private final UserProfileService userProfileService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    public MeResponse getMe() {
+        User user = currentUserProvider.currentUser();
+        log.info("GET /api/v1/me: userId={}", user.getId());
+
+        return toResponse(userProfileService.getProfile(user));
+    }
+
+    @Override
+    public MeResponse updateMe(MeUpdateRequest request) {
+        User user = currentUserProvider.currentUser();
+        log.info("PATCH /api/v1/me: userId={}", user.getId());
+
+        ProfileUpdate update = new ProfileUpdate(
+                parseTime(request.getQuietHoursStart()),
+                parseTime(request.getQuietHoursEnd()),
+                request.getTimezone(),
+                request.getLocale()
+        );
+
+        return toResponse(userProfileService.updateProfile(user, update));
+    }
+
+    private static MeResponse toResponse(Profile profile) {
+        return new MeResponse(
+                profile.name(),
+                profile.plantsTotal(),
+                profile.tasksToday(),
+                profile.notificationsUnread(),
+                profile.quietHoursStart().format(HH_MM),
+                profile.quietHoursEnd().format(HH_MM),
+                profile.timezone(),
+                MeResponse.LocaleEnum.fromValue(profile.locale())
+        ).avatar(profile.avatar());
+    }
+
+    private static LocalTime parseTime(String hhmm) {
+        return hhmm == null ? null : LocalTime.parse(hhmm, HH_MM);
+    }
+}

--- a/src/main/java/com/plantcare/core/domain/User.java
+++ b/src/main/java/com/plantcare/core/domain/User.java
@@ -65,6 +65,11 @@ public class User extends BaseEntity {
     @Builder.Default
     private String timezone = "Europe/Minsk";
 
+    /** Язык интерфейса/уведомлений мобильного клиента: {@code ru} | {@code en} (issue #182, V34). */
+    @Column(nullable = false, length = 8)
+    @Builder.Default
+    private String locale = "ru";
+
     @Column(name = "quiet_hours_start", nullable = false)
     @Builder.Default
     private LocalTime quietHoursStart = LocalTime.of(22, 0);

--- a/src/main/java/com/plantcare/core/service/UserProfileService.java
+++ b/src/main/java/com/plantcare/core/service/UserProfileService.java
@@ -1,0 +1,135 @@
+package com.plantcare.core.service;
+
+import com.plantcare.core.domain.User;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DateTimeException;
+import java.time.LocalTime;
+import java.time.ZoneId;
+
+/**
+ * Профиль и настройки пользователя для REST API {@code /api/v1/me} (issue #182,
+ * mobile G5 + G16).
+ *
+ * <p>Сборка профиля переиспользует существующие источники, а не дублирует логику:
+ * число неархивированных растений — {@link PlantRepository#countByUserIdAndArchivedAtIsNull(Long)},
+ * число задач на сегодня — pending-часть {@link TodayApiService#getTodayTasks(Long, String)}
+ * (выдача {@code GET /api/v1/today}, отфильтрованная по {@code doneAt == null}; считается в TZ пользователя).
+ *
+ * <p>Смена таймзоны делегируется {@link UserSettingsService#changeTimezone(User, ZoneId)},
+ * чтобы сохранить пересчёт активных расписаний (локальное время дня не «съезжает»).
+ * Внешних вызовов (Telegram) внутри транзакции нет — только чтение/запись БД.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserProfileService {
+
+    private final UserRepository userRepository;
+    private final PlantRepository plantRepository;
+    private final TodayApiService todayApiService;
+    private final UserSettingsService userSettingsService;
+
+    /**
+     * Собранный профиль пользователя для {@code GET /api/v1/me}.
+     *
+     * <p>{@code avatar} — плейсхолдер: в схеме нет колонки под аватар, поэтому
+     * всегда {@code null}. {@code notificationsUnread} — плейсхолдер {@code 0}:
+     * фид уведомлений (issue #183) ещё не влит в эту ветку.
+     */
+    public record Profile(
+            String name,
+            String avatar,
+            int plantsTotal,
+            int tasksToday,
+            int notificationsUnread,
+            LocalTime quietHoursStart,
+            LocalTime quietHoursEnd,
+            String timezone,
+            String locale
+    ) {
+    }
+
+    /**
+     * Частичный апдейт настроек: {@code null}-поле = «не менять».
+     * {@code timezone} — IANA-идентификатор, {@code locale} — {@code ru}|{@code en}.
+     */
+    public record ProfileUpdate(
+            LocalTime quietHoursStart,
+            LocalTime quietHoursEnd,
+            String timezone,
+            String locale
+    ) {
+    }
+
+    /** Собирает профиль и счётчики текущего пользователя. */
+    @Transactional(readOnly = true)
+    public Profile getProfile(User user) {
+        int plantsTotal = Math.toIntExact(
+                plantRepository.countByUserIdAndArchivedAtIsNull(user.getId()));
+        // tasksToday — только pending (дедлайн до конца сегодняшнего дня в TZ юзера).
+        // getTodayTasks возвращает UNION pending + done-сегодня (issue #184), поэтому
+        // отбрасываем выполненные (doneAt != null), чтобы бейдж не рос по мере отметок.
+        int tasksToday = (int) todayApiService.getTodayTasks(user.getId(), user.getTimezone())
+                .stream()
+                .filter(t -> t.doneAt() == null)
+                .count();
+
+        // notificationsUnread — плейсхолдер: фид уведомлений (issue #183) ещё не влит.
+        int notificationsUnread = 0;
+
+        return new Profile(
+                user.getUsername(),
+                null, // avatar — плейсхолдер, колонки в схеме нет.
+                plantsTotal,
+                tasksToday,
+                notificationsUnread,
+                user.getQuietHoursStart(),
+                user.getQuietHoursEnd(),
+                user.getTimezone(),
+                user.getLocale()
+        );
+    }
+
+    /**
+     * Применяет только переданные ({@code != null}) поля и возвращает обновлённый
+     * профиль. Невалидный IANA-{@code timezone} → {@link IllegalArgumentException}
+     * (маппится на 400). Формат {@code quietHours*}/{@code locale} проверяется
+     * Bean Validation на сгенерированном DTO до вызова сервиса.
+     */
+    @Transactional
+    public Profile updateProfile(User user, ProfileUpdate update) {
+        if (update.quietHoursStart() != null) {
+            userSettingsService.setQuietHoursStart(user, update.quietHoursStart());
+        }
+        if (update.quietHoursEnd() != null) {
+            userSettingsService.setQuietHoursEnd(user, update.quietHoursEnd());
+        }
+        if (update.timezone() != null) {
+            ZoneId zone = parseZone(update.timezone());
+            userSettingsService.changeTimezone(user, zone);
+        }
+        if (update.locale() != null) {
+            user.setLocale(update.locale());
+            userRepository.save(user);
+        }
+
+        log.info("PATCH /me applied: userId={}, tzChanged={}, localeChanged={}",
+                user.getId(), update.timezone() != null, update.locale() != null);
+
+        return getProfile(user);
+    }
+
+    private static ZoneId parseZone(String timezone) {
+        try {
+            return ZoneId.of(timezone);
+        } catch (DateTimeException e) {
+            throw new IllegalArgumentException("Invalid IANA timezone: " + timezone, e);
+        }
+    }
+}

--- a/src/main/resources/db/migration/V34__add_locale_to_users.sql
+++ b/src/main/resources/db/migration/V34__add_locale_to_users.sql
@@ -1,0 +1,28 @@
+-- V34__add_locale_to_users.sql
+-- Issue #182: GET/PATCH /api/v1/me.
+-- В users добавляется колонка locale — язык интерфейса/уведомлений мобильного
+-- клиента. Допустимые значения: 'ru', 'en'. Дефолт 'ru' (русскоязычный userbase,
+-- дефолтная таймзона Europe/Minsk — см. User entity).
+--
+-- Backward-compat note:
+--   * Колонка NOT NULL, но с DEFAULT 'ru' — Postgres проставит значение всем
+--     существующим строкам при ALTER, поэтому отдельный бэкфил не нужен.
+--   * Старый код, который вставляет в users без упоминания locale, продолжает
+--     работать: DEFAULT покрывает INSERT, а на чтение старый код колонку
+--     игнорирует. Поэтому это безопасно одной миграцией для rolling deploy —
+--     3-шаговый nullable-танец нужен только для NOT NULL БЕЗ дефолта.
+--   * CHECK chk_users_locale соответствует house style проекта: enum-ish колонки
+--     (seasonal_mode, seasonal_override, species.light_preference и т.д.)
+--     ограничиваются на уровне БД через CHECK IN (...).
+
+BEGIN;
+
+ALTER TABLE users
+    ADD COLUMN locale VARCHAR(8) NOT NULL DEFAULT 'ru',
+    ADD CONSTRAINT chk_users_locale
+        CHECK (locale IN ('ru', 'en'));
+
+COMMENT ON COLUMN users.locale IS
+    'Язык интерфейса/уведомлений мобильного клиента: ru | en. По умолчанию ru.';
+
+COMMIT;

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -86,6 +86,8 @@ tags:
     description: Публичный справочник типов ухода (полив, опрыскивание, и т.п.). Без авторизации.
   - name: Shopping
     description: Персональный список покупок пользователя — расходники для ухода за растениями.
+  - name: Me
+    description: Профиль и настройки текущего пользователя — имя, счётчики, тихие часы, таймзона, язык (mobile G5 + G16).
 
 paths:
   /api/v1/auth/apple:
@@ -150,6 +152,9 @@ paths:
     $ref: './resources/shopping.yaml#/paths/Collection'
   /api/v1/shopping/{id}:
     $ref: './resources/shopping.yaml#/paths/Item'
+
+  /api/v1/me:
+    $ref: './resources/me.yaml#/paths/Me'
 
 components:
   securitySchemes:
@@ -271,6 +276,11 @@ components:
       $ref: './resources/shopping.yaml#/schemas/ShoppingItemCreateRequest'
     ShoppingItemUpdateRequest:
       $ref: './resources/shopping.yaml#/schemas/ShoppingItemUpdateRequest'
+
+    MeResponse:
+      $ref: './resources/me.yaml#/schemas/MeResponse'
+    MeUpdateRequest:
+      $ref: './resources/me.yaml#/schemas/MeUpdateRequest'
 
     ApiErrorResponse:
       $ref: './_common/errors.yaml#/schemas/ApiErrorResponse'

--- a/src/main/resources/openapi/resources/me.yaml
+++ b/src/main/resources/openapi/resources/me.yaml
@@ -1,0 +1,160 @@
+# Профиль и настройки текущего пользователя (issue #182, mobile G5 + G16).
+# Скоуп — аутентифицированный пользователь (`sub` из bearer-токена).
+# `quietHours*` — локальное время в TZ юзера (HH:mm); все счётчики считаются
+# в таймзоне пользователя (users.timezone).
+
+paths:
+  Me:
+    get:
+      tags: [Me]
+      operationId: getMe
+      summary: Профиль и настройки пользователя
+      description: |
+        Возвращает профиль текущего пользователя: имя, аватар, счётчики для
+        хедера (растения, задачи на сегодня, непрочитанные уведомления) и
+        настройки (тихие часы, таймзона, язык).
+
+        `tasksToday` считается в **таймзоне пользователя** (`users.timezone`) —
+        число **невыполненных** (pending) задач ухода, дедлайн которых наступает
+        до конца сегодняшнего дня. Уже отмеченные сегодня задачи не учитываются.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Профиль пользователя.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/MeResponse'
+    patch:
+      tags: [Me]
+      operationId: updateMe
+      summary: Частичное обновление настроек пользователя
+      description: |
+        PATCH-семантика: обновляются только переданные поля, остальные остаются
+        без изменений. Имя и аватар через этот эндпоинт не меняются.
+
+        Смена `timezone` пересчитывает активные расписания так, чтобы локальное
+        время дня сохранилось (полить в 9:00 остаётся 9:00 в новой зоне).
+        Невалидный IANA-идентификатор → `400`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/MeUpdateRequest'
+            example:
+              quietHoursStart: '23:00'
+              quietHoursEnd: '07:30'
+              timezone: Europe/Belgrade
+              locale: en
+      responses:
+        '200':
+          description: Профиль обновлён.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/MeResponse'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+
+schemas:
+  MeResponse:
+    type: object
+    description: Профиль и настройки текущего пользователя (`GET /api/v1/me`).
+    required:
+      - name
+      - plantsTotal
+      - tasksToday
+      - notificationsUnread
+      - quietHoursStart
+      - quietHoursEnd
+      - timezone
+      - locale
+    properties:
+      name:
+        type: string
+        nullable: true
+        description: Отображаемое имя пользователя (из `users.username`). Может быть `null`.
+        example: Антон
+      avatar:
+        type: string
+        nullable: true
+        description: |
+          URL аватара пользователя. Плейсхолдер: на текущей схеме нет колонки
+          под аватар, поэтому поле всегда `null` до появления хранилища аватаров.
+        example: null
+      plantsTotal:
+        type: integer
+        format: int32
+        minimum: 0
+        description: Число неархивированных растений пользователя.
+        example: 12
+      tasksToday:
+        type: integer
+        format: int32
+        minimum: 0
+        description: |
+          Число невыполненных (pending) задач ухода на сегодня в таймзоне
+          пользователя: дедлайн до конца сегодняшнего дня, отметка «сделано»
+          ещё не проставлена. Это pending-подмножество `GET /api/v1/today`.
+        example: 3
+      notificationsUnread:
+        type: integer
+        format: int32
+        minimum: 0
+        description: |
+          Плейсхолдер: фид уведомлений (issue #183) ещё не влит, поэтому поле
+          всегда `0`. Будет считаться по-настоящему после появления фида.
+        example: 0
+      quietHoursStart:
+        type: string
+        pattern: '^([01]\d|2[0-3]):[0-5]\d$'
+        description: Начало тихих часов, локальное время `HH:mm`.
+        example: '22:00'
+      quietHoursEnd:
+        type: string
+        pattern: '^([01]\d|2[0-3]):[0-5]\d$'
+        description: Конец тихих часов, локальное время `HH:mm`.
+        example: '08:00'
+      timezone:
+        type: string
+        description: IANA-идентификатор таймзоны пользователя.
+        example: Europe/Moscow
+      locale:
+        type: string
+        enum: [ru, en]
+        description: Язык интерфейса/уведомлений.
+        example: ru
+
+  MeUpdateRequest:
+    type: object
+    description: |
+      Частичное обновление настроек. Все поля опциональны — отсутствующие
+      остаются без изменений.
+    properties:
+      quietHoursStart:
+        type: string
+        pattern: '^([01]\d|2[0-3]):[0-5]\d$'
+        nullable: true
+        description: Начало тихих часов, локальное время `HH:mm`.
+        example: '23:00'
+      quietHoursEnd:
+        type: string
+        pattern: '^([01]\d|2[0-3]):[0-5]\d$'
+        nullable: true
+        description: Конец тихих часов, локальное время `HH:mm`.
+        example: '07:30'
+      timezone:
+        type: string
+        nullable: true
+        description: IANA-идентификатор таймзоны. Невалидный → `400`.
+        example: Europe/Belgrade
+      locale:
+        type: string
+        pattern: '^(ru|en)$'
+        nullable: true
+        description: Язык интерфейса/уведомлений. Допустимые значения — `ru` или `en`.
+        example: en

--- a/src/test/java/com/plantcare/api/v1/MeControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/MeControllerTest.java
@@ -1,0 +1,301 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.api.auth.exception.AuthTokenException;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.service.UserProfileService;
+import com.plantcare.core.service.UserProfileService.Profile;
+import com.plantcare.core.service.UserProfileService.ProfileUpdate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Слайс-тест {@link MeController} (issue #182) — JSON-форма {@code GET /api/v1/me},
+ * PATCH-семантика частичного апдейта, маппинг ошибок (400 на невалидный IANA-tz и
+ * на нарушение {@code @Pattern} тихих часов), 401 без аутентификации.
+ *
+ * <p>{@link UserProfileService} замокан — здесь проверяется только веб-слой:
+ * сериализация {@link Profile} → {@code MeResponse}, парсинг/маппинг тела PATCH в
+ * {@link ProfileUpdate} и Bean Validation сгенерированного DTO до бизнес-логики.
+ * Зеркалит {@link ReportsControllerTest}/{@link ShoppingControllerTest}: фильтры
+ * выключены, импортируется {@link ApiExceptionHandler}, {@link CurrentUserProvider}
+ * застаблен на текущего пользователя.
+ */
+@WebMvcTest(MeController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserProfileService userProfileService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    @BeforeEach
+    void stubCurrentUser() {
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(7L);
+        when(currentUserProvider.currentUser()).thenReturn(user);
+    }
+
+    // ------------------------------------------------------------------ GET happy
+
+    @Test
+    void should_return_full_profile_shape_with_hhmm_quiet_hours_when_getting_me() throws Exception {
+        // arrange — AC #1: профиль + счётчики + настройки; quietHours форматируются в HH:mm
+        Profile profile = new Profile(
+                "Антон", null, 12, 3, 0,
+                LocalTime.of(22, 0), LocalTime.of(8, 0),
+                "Europe/Moscow", "ru");
+        when(userProfileService.getProfile(any(User.class))).thenReturn(profile);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Антон"))
+                .andExpect(jsonPath("$.avatar").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.plantsTotal").value(12))
+                .andExpect(jsonPath("$.tasksToday").value(3))
+                .andExpect(jsonPath("$.notificationsUnread").value(0))
+                .andExpect(jsonPath("$.quietHoursStart").value("22:00"))
+                .andExpect(jsonPath("$.quietHoursEnd").value("08:00"))
+                .andExpect(jsonPath("$.timezone").value("Europe/Moscow"))
+                .andExpect(jsonPath("$.locale").value("ru"));
+    }
+
+    @Test
+    void should_pass_current_user_not_request_to_service_when_getting_me() throws Exception {
+        // arrange — скоуп берётся из CurrentUserProvider
+        Profile profile = new Profile("Аноним", null, 0, 0, 0,
+                LocalTime.of(22, 0), LocalTime.of(9, 0), "UTC", "ru");
+        when(userProfileService.getProfile(any(User.class))).thenReturn(profile);
+
+        // act
+        mockMvc.perform(get("/api/v1/me")).andExpect(status().isOk());
+
+        // assert — сервис вызван с пользователем из провайдера (id=7)
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userProfileService).getProfile(captor.capture());
+        assertThat(captor.getValue().getId()).isEqualTo(7L);
+    }
+
+    // ------------------------------------------------------------------ PATCH partial
+
+    @Test
+    void should_send_only_locale_and_leave_other_fields_null_when_patching_locale_only() throws Exception {
+        // arrange — AC #2: тело только с locale; omitted-поля НЕ должны занулять остальное
+        stubUpdateEcho();
+
+        String body = """
+                {"locale": "en"}
+                """;
+
+        // act
+        mockMvc.perform(patch("/api/v1/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk());
+
+        // assert — в сервис ушёл ProfileUpdate с заполненным только locale
+        ProfileUpdate sent = captureUpdate();
+        assertThat(sent.locale()).isEqualTo("en");
+        assertThat(sent.quietHoursStart()).isNull();
+        assertThat(sent.quietHoursEnd()).isNull();
+        assertThat(sent.timezone()).isNull();
+    }
+
+    @Test
+    void should_send_only_quiet_hours_and_leave_tz_locale_null_when_patching_quiet_hours_only() throws Exception {
+        // arrange — AC #2: только тихие часы; tz/locale не трогаем
+        stubUpdateEcho();
+
+        String body = """
+                {"quietHoursStart": "23:00", "quietHoursEnd": "07:30"}
+                """;
+
+        // act
+        mockMvc.perform(patch("/api/v1/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk());
+
+        // assert — только quietHours заполнены, как LocalTime; tz/locale остались null
+        ProfileUpdate sent = captureUpdate();
+        assertThat(sent.quietHoursStart()).isEqualTo(LocalTime.of(23, 0));
+        assertThat(sent.quietHoursEnd()).isEqualTo(LocalTime.of(7, 30));
+        assertThat(sent.timezone()).isNull();
+        assertThat(sent.locale()).isNull();
+    }
+
+    @Test
+    void should_send_empty_update_when_patch_body_is_empty_object() throws Exception {
+        // arrange — AC #2 граница: пустое тело = ничего не менять, все поля null
+        stubUpdateEcho();
+
+        // act
+        mockMvc.perform(patch("/api/v1/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isOk());
+
+        // assert
+        ProfileUpdate sent = captureUpdate();
+        assertThat(sent.quietHoursStart()).isNull();
+        assertThat(sent.quietHoursEnd()).isNull();
+        assertThat(sent.timezone()).isNull();
+        assertThat(sent.locale()).isNull();
+    }
+
+    // ------------------------------------------------------------------ PATCH timezone
+
+    @Test
+    void should_pass_iana_timezone_through_and_reflect_in_response_when_patching_timezone() throws Exception {
+        // arrange — AC #3: валидный IANA tz прокидывается в сервис и возвращается в ответе
+        Profile updated = new Profile("Антон", null, 1, 0, 0,
+                LocalTime.of(22, 0), LocalTime.of(9, 0), "Asia/Almaty", "ru");
+        when(userProfileService.updateProfile(any(User.class), any(ProfileUpdate.class)))
+                .thenReturn(updated);
+
+        String body = """
+                {"timezone": "Asia/Almaty"}
+                """;
+
+        // act + assert — ответ отражает новую зону
+        mockMvc.perform(patch("/api/v1/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.timezone").value("Asia/Almaty"));
+
+        // assert — именно эта зона ушла в сервис
+        assertThat(captureUpdate().timezone()).isEqualTo("Asia/Almaty");
+    }
+
+    // ------------------------------------------------------------------ PATCH failures
+
+    @Test
+    void should_return_400_bad_request_when_timezone_is_not_valid_iana() throws Exception {
+        // arrange — AC #5: сервис кидает IllegalArgumentException на невалидный IANA-id
+        when(userProfileService.updateProfile(any(User.class), any(ProfileUpdate.class)))
+                .thenThrow(new IllegalArgumentException("Invalid IANA timezone: Mars/Phobos"));
+
+        String body = """
+                {"timezone": "Mars/Phobos"}
+                """;
+
+        // act + assert
+        mockMvc.perform(patch("/api/v1/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("BAD_REQUEST"));
+    }
+
+    @Test
+    void should_return_400_validation_error_when_quiet_hours_format_is_invalid() throws Exception {
+        // arrange — AC #6: "25:99" нарушает @Pattern(^([01]\d|2[0-3]):[0-5]\d$) на DTO,
+        // отбивается Bean Validation ДО сервиса
+        String body = """
+                {"quietHoursStart": "25:99"}
+                """;
+
+        // act + assert
+        mockMvc.perform(patch("/api/v1/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+
+        verify(userProfileService, never()).updateProfile(any(User.class), any(ProfileUpdate.class));
+    }
+
+    @Test
+    void should_return_400_validation_error_when_quiet_hours_end_has_bad_separator() throws Exception {
+        // arrange — AC #6: "08-00" (дефис вместо двоеточия) тоже не проходит @Pattern
+        String body = """
+                {"quietHoursEnd": "08-00"}
+                """;
+
+        // act + assert
+        mockMvc.perform(patch("/api/v1/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+
+        verify(userProfileService, never()).updateProfile(any(User.class), any(ProfileUpdate.class));
+    }
+
+    @Test
+    void should_return_400_when_locale_not_ru_or_en() throws Exception {
+        // arrange — AC #6 (locale): на DTO стоит @Pattern(^(ru|en)$), поэтому "de"
+        // отбивается Bean Validation ДО сервиса — тот же путь, что у тихих часов
+        String body = """
+                {"locale": "de"}
+                """;
+
+        // act + assert
+        mockMvc.perform(patch("/api/v1/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+
+        verify(userProfileService, never()).updateProfile(any(User.class), any(ProfileUpdate.class));
+    }
+
+    @Test
+    void should_return_401_when_no_authenticated_user_on_get() throws Exception {
+        // arrange — нет JWT в SecurityContext
+        when(currentUserProvider.currentUser())
+                .thenThrow(AuthTokenException.invalid("No authenticated user in security context"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("TOKEN_INVALID"));
+    }
+
+    // ===================== helpers =====================
+
+    /** Возвращает «как есть» собранный профиль, чтобы PATCH вернул 200 и не падал на null. */
+    private void stubUpdateEcho() {
+        Profile echo = new Profile("Антон", null, 0, 0, 0,
+                LocalTime.of(22, 0), LocalTime.of(9, 0), "Europe/Moscow", "ru");
+        when(userProfileService.updateProfile(any(User.class), any(ProfileUpdate.class)))
+                .thenReturn(echo);
+    }
+
+    private ProfileUpdate captureUpdate() {
+        ArgumentCaptor<ProfileUpdate> captor = ArgumentCaptor.forClass(ProfileUpdate.class);
+        verify(userProfileService).updateProfile(any(User.class), captor.capture());
+        return captor.getValue();
+    }
+}

--- a/src/test/java/com/plantcare/core/service/UserProfileServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/UserProfileServiceTest.java
@@ -1,0 +1,368 @@
+package com.plantcare.core.service;
+
+import com.plantcare.bot.support.IntegrationTestBase;
+import com.plantcare.core.domain.CareHistory;
+import com.plantcare.core.domain.CareSchedule;
+import com.plantcare.core.domain.Location;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.repository.CareHistoryRepository;
+import com.plantcare.core.repository.CareScheduleRepository;
+import com.plantcare.core.repository.LocationRepository;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.UserRepository;
+import com.plantcare.core.service.UserProfileService.Profile;
+import com.plantcare.core.service.UserProfileService.ProfileUpdate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+/**
+ * Интеграционные тесты {@link UserProfileService} (issue #182) на реальном Postgres
+ * через Testcontainers — счётчики профиля и частичный апдейт настроек проверяются на
+ * настоящих записях (растения, расписания, users), а не на моках репозиториев.
+ *
+ * <p>{@link Clock}-бин подменён фиксированным {@link #FIXED_NOW}, чтобы граница окна
+ * «сегодня» (для {@code tasksToday}, считающегося в TZ юзера через
+ * {@link TodayApiService}) была детерминированной.
+ *
+ * <p>Покрывает: happy GET (счётчики + настройки); частичный апдейт (locale-only,
+ * quietHours-only, tz-only — omitted-поля не зануляются); смена IANA-tz отражается
+ * в профиле; TZ-кейс на границе суток (tasksToday в зоне юзера, не UTC); невалидный
+ * IANA-tz → IllegalArgumentException.
+ */
+@DisplayName("UserProfileService — профиль и настройки /me (issue #182)")
+@Import(UserProfileServiceTest.FixedClockConfig.class)
+class UserProfileServiceTest extends IntegrationTestBase {
+
+    /**
+     * Фиксированный «сейчас» 00:30 UTC. Для восточных TZ (Almaty UTC+5) локальная дата
+     * уже «сегодня», а UTC-полночь и локальная-полночь расходятся на день — это и
+     * проверяет граничный TZ-кейс счётчика tasksToday.
+     */
+    static final Instant FIXED_NOW = Instant.parse("2026-05-25T00:30:00Z");
+
+    @TestConfiguration
+    static class FixedClockConfig {
+        @Bean
+        @Primary
+        Clock fixedClock() {
+            return Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+        }
+    }
+
+    @Autowired private UserProfileService service;
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private LocationRepository locationRepository;
+    @Autowired private PlantRepository plantRepository;
+    @Autowired private CareScheduleRepository careScheduleRepository;
+    @Autowired private CareHistoryRepository careHistoryRepository;
+
+    @AfterEach
+    void cleanup() {
+        careHistoryRepository.deleteAll();
+        careScheduleRepository.deleteAll();
+        plantRepository.deleteAll();
+        locationRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ------------------------------------------------------------------ GET happy
+
+    @Test
+    @DisplayName("should_return_counts_and_settings_when_building_profile")
+    void should_return_counts_and_settings_when_building_profile() {
+        // arrange — AC #1: 2 неархивированных растения, одно расписание с дедлайном сегодня
+        User user = savedUser(8001L, "UTC", LocalTime.of(22, 0), LocalTime.of(8, 0), "ru");
+        Plant monstera = savedPlant(user, "Монстера");
+        savedPlant(user, "Фикус");
+        savedSchedule(monstera, TaskType.WATERING, utc("2026-05-25T10:00:00"));
+
+        // act
+        Profile profile = service.getProfile(user);
+
+        // assert
+        assertSoftly(softly -> {
+            softly.assertThat(profile.name()).isEqualTo(user.getUsername());
+            softly.assertThat(profile.avatar()).isNull();
+            softly.assertThat(profile.plantsTotal()).isEqualTo(2);
+            softly.assertThat(profile.tasksToday()).isEqualTo(1);
+            softly.assertThat(profile.notificationsUnread()).isZero();
+            softly.assertThat(profile.quietHoursStart()).isEqualTo(LocalTime.of(22, 0));
+            softly.assertThat(profile.quietHoursEnd()).isEqualTo(LocalTime.of(8, 0));
+            softly.assertThat(profile.timezone()).isEqualTo("UTC");
+            softly.assertThat(profile.locale()).isEqualTo("ru");
+        });
+    }
+
+    @Test
+    @DisplayName("should_not_count_archived_plants_in_plantsTotal")
+    void should_not_count_archived_plants_in_plantsTotal() {
+        // arrange — edge: одно растение архивировано, считаем только активные
+        User user = savedUser(8002L, "UTC", LocalTime.of(22, 0), LocalTime.of(9, 0), "ru");
+        savedPlant(user, "Активная");
+        Plant archived = savedPlant(user, "Архивная");
+        archived.setArchivedAt(LocalDateTime.now());
+        plantRepository.save(archived);
+
+        // act
+        Profile profile = service.getProfile(user);
+
+        // assert
+        assertThat(profile.plantsTotal()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("should_return_zero_counts_when_user_has_no_plants_or_schedules")
+    void should_return_zero_counts_when_user_has_no_plants_or_schedules() {
+        // arrange — edge: пустой пользователь
+        User user = savedUser(8003L, "UTC", LocalTime.of(22, 0), LocalTime.of(9, 0), "ru");
+
+        // act
+        Profile profile = service.getProfile(user);
+
+        // assert
+        assertSoftly(softly -> {
+            softly.assertThat(profile.plantsTotal()).isZero();
+            softly.assertThat(profile.tasksToday()).isZero();
+            softly.assertThat(profile.notificationsUnread()).isZero();
+        });
+    }
+
+    @Test
+    @DisplayName("should_count_only_pending_tasks_today_excluding_done")
+    void should_count_only_pending_tasks_today_excluding_done() {
+        // arrange — два расписания с дедлайном сегодня; одно отмечаем выполненным сегодня.
+        // getTodayTasks вернёт UNION pending+done = 2 задачи (одна с doneAt!=null), а
+        // tasksToday фильтрует doneAt==null → бейдж не должен учитывать выполненную.
+        User user = savedUser(8011L, "UTC", LocalTime.of(22, 0), LocalTime.of(8, 0), "ru");
+        Plant monstera = savedPlant(user, "Монстера");
+        Plant fikus = savedPlant(user, "Фикус");
+        savedSchedule(monstera, TaskType.WATERING, utc("2026-05-25T10:00:00"));
+        savedSchedule(fikus, TaskType.MISTING, utc("2026-05-25T11:00:00"));
+        // отмечаем полив монстеры выполненным сегодня → выпадает из pending
+        savedCare(monstera, TaskType.WATERING, utc("2026-05-25T09:00:00"));
+
+        // act
+        Profile profile = service.getProfile(user);
+
+        // assert — только pending (опрыскивание фикуса), не union из двух
+        assertThat(profile.tasksToday()).isEqualTo(1);
+    }
+
+    // ------------------------------------------------------------------ non-UTC TZ (MANDATORY)
+
+    @Test
+    @DisplayName("should_count_tasksToday_in_user_timezone_not_utc_on_day_boundary")
+    void should_count_tasksToday_in_user_timezone_not_utc_on_day_boundary() {
+        // arrange — один и тот же дедлайн, два юзера в разных TZ. FIXED_NOW = 2026-05-25 00:30 UTC.
+        // tasksToday = pending: nextDueAt <= конец сегодняшнего дня В TZ ЮЗЕРА.
+        //   * UTC:         конец сегодня = 2026-05-25 23:59:59 UTC.
+        //   * Asia/Almaty (UTC+5): сейчас 05:30 локально, конец сегодня 2026-05-25 23:59:59 Алматы
+        //                  = 2026-05-25 18:59:59 UTC (раньше по UTC).
+        // Дедлайн nextDueAt = 2026-05-25 21:00 UTC попадает В окно UTC-юзера, но ПОЗЖЕ конца
+        // дня у Алматы → для Алматы это ещё не сегодня. Это и отличает TZ-расчёт от наивного UTC.
+        LocalDateTime deadline = utc("2026-05-25T21:00:00");
+
+        User utcUser = savedUser(8004L, "UTC", LocalTime.of(22, 0), LocalTime.of(9, 0), "ru");
+        savedSchedule(savedPlant(utcUser, "UTC монстера"), TaskType.WATERING, deadline);
+
+        User almatyUser = savedUser(8005L, "Asia/Almaty", LocalTime.of(22, 0), LocalTime.of(9, 0), "ru");
+        savedSchedule(savedPlant(almatyUser, "Алматинская монстера"), TaskType.WATERING, deadline);
+
+        // act
+        Profile utcProfile = service.getProfile(utcUser);
+        Profile almatyProfile = service.getProfile(almatyUser);
+
+        // assert — один и тот же момент: «сегодня» для UTC, ещё не «сегодня» для Алматы.
+        // Доказывает, что счётчик считается в TZ пользователя, а не в UTC.
+        assertSoftly(softly -> {
+            softly.assertThat(utcProfile.tasksToday())
+                    .as("UTC: дедлайн 21:00 UTC внутри сегодняшнего дня")
+                    .isEqualTo(1);
+            softly.assertThat(almatyProfile.tasksToday())
+                    .as("Almaty: 21:00 UTC = 02:00 завтра по Алматы → ещё не сегодня")
+                    .isZero();
+        });
+    }
+
+    // ------------------------------------------------------------------ PATCH partial
+
+    @Test
+    @DisplayName("should_change_only_locale_and_leave_tz_and_quiet_hours_untouched")
+    void should_change_only_locale_and_leave_tz_and_quiet_hours_untouched() {
+        // arrange — AC #2: меняем только locale
+        User user = savedUser(8006L, "Europe/Moscow", LocalTime.of(22, 0), LocalTime.of(8, 0), "ru");
+
+        // act
+        Profile updated = service.updateProfile(user,
+                new ProfileUpdate(null, null, null, "en"));
+
+        // assert — locale изменился, остальное на месте
+        assertSoftly(softly -> {
+            softly.assertThat(updated.locale()).isEqualTo("en");
+            softly.assertThat(updated.timezone()).isEqualTo("Europe/Moscow");
+            softly.assertThat(updated.quietHoursStart()).isEqualTo(LocalTime.of(22, 0));
+            softly.assertThat(updated.quietHoursEnd()).isEqualTo(LocalTime.of(8, 0));
+        });
+
+        // assert — изменение реально записано в БД
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(reloaded.getLocale()).isEqualTo("en");
+        assertThat(reloaded.getTimezone()).isEqualTo("Europe/Moscow");
+    }
+
+    @Test
+    @DisplayName("should_change_only_quiet_hours_and_leave_tz_and_locale_untouched")
+    void should_change_only_quiet_hours_and_leave_tz_and_locale_untouched() {
+        // arrange — AC #2: меняем только тихие часы
+        User user = savedUser(8007L, "Europe/Moscow", LocalTime.of(22, 0), LocalTime.of(8, 0), "ru");
+
+        // act
+        Profile updated = service.updateProfile(user,
+                new ProfileUpdate(LocalTime.of(23, 0), LocalTime.of(7, 30), null, null));
+
+        // assert
+        assertSoftly(softly -> {
+            softly.assertThat(updated.quietHoursStart()).isEqualTo(LocalTime.of(23, 0));
+            softly.assertThat(updated.quietHoursEnd()).isEqualTo(LocalTime.of(7, 30));
+            softly.assertThat(updated.timezone()).isEqualTo("Europe/Moscow");
+            softly.assertThat(updated.locale()).isEqualTo("ru");
+        });
+
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(reloaded.getQuietHoursStart()).isEqualTo(LocalTime.of(23, 0));
+            softly.assertThat(reloaded.getQuietHoursEnd()).isEqualTo(LocalTime.of(7, 30));
+            softly.assertThat(reloaded.getLocale()).isEqualTo("ru");
+        });
+    }
+
+    @Test
+    @DisplayName("should_not_null_any_field_when_update_is_empty")
+    void should_not_null_any_field_when_update_is_empty() {
+        // arrange — AC #2 граница: пустой апдейт = всё без изменений
+        User user = savedUser(8008L, "Europe/Moscow", LocalTime.of(21, 0), LocalTime.of(6, 0), "en");
+
+        // act
+        Profile updated = service.updateProfile(user,
+                new ProfileUpdate(null, null, null, null));
+
+        // assert
+        assertSoftly(softly -> {
+            softly.assertThat(updated.timezone()).isEqualTo("Europe/Moscow");
+            softly.assertThat(updated.locale()).isEqualTo("en");
+            softly.assertThat(updated.quietHoursStart()).isEqualTo(LocalTime.of(21, 0));
+            softly.assertThat(updated.quietHoursEnd()).isEqualTo(LocalTime.of(6, 0));
+        });
+    }
+
+    // ------------------------------------------------------------------ PATCH timezone
+
+    @Test
+    @DisplayName("should_update_timezone_to_valid_iana_and_reflect_in_profile")
+    void should_update_timezone_to_valid_iana_and_reflect_in_profile() {
+        // arrange — AC #3: Europe/Moscow → Asia/Almaty
+        User user = savedUser(8009L, "Europe/Moscow", LocalTime.of(22, 0), LocalTime.of(9, 0), "ru");
+
+        // act
+        Profile updated = service.updateProfile(user,
+                new ProfileUpdate(null, null, "Asia/Almaty", null));
+
+        // assert
+        assertThat(updated.timezone()).isEqualTo("Asia/Almaty");
+        assertThat(userRepository.findById(user.getId()).orElseThrow().getTimezone())
+                .isEqualTo("Asia/Almaty");
+    }
+
+    // ------------------------------------------------------------------ PATCH failure
+
+    @Test
+    @DisplayName("should_throw_illegal_argument_when_timezone_is_not_valid_iana")
+    void should_throw_illegal_argument_when_timezone_is_not_valid_iana() {
+        // arrange — AC #5: невалидный IANA-id → IllegalArgumentException (контроллер → 400)
+        User user = savedUser(8010L, "Europe/Moscow", LocalTime.of(22, 0), LocalTime.of(9, 0), "ru");
+
+        // act + assert
+        assertThatThrownBy(() -> service.updateProfile(user,
+                new ProfileUpdate(null, null, "Mars/Phobos", null)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Mars/Phobos");
+    }
+
+    // ===================== helpers =====================
+
+    private User savedUser(Long chatId, String timezone, LocalTime quietStart, LocalTime quietEnd, String locale) {
+        return userRepository.save(User.builder()
+                .telegramChatId(chatId)
+                .username("user-" + chatId)
+                .timezone(timezone)
+                .quietHoursStart(quietStart)
+                .quietHoursEnd(quietEnd)
+                .locale(locale)
+                .blocked(false)
+                .build());
+    }
+
+    private Location savedDefaultLocation(User user) {
+        return locationRepository.findByUserIdAndDefaultLocationTrue(user.getId())
+                .orElseGet(() -> locationRepository.save(Location.builder()
+                        .user(user)
+                        .name(Location.DEFAULT_NAME)
+                        .emoji(Location.DEFAULT_EMOJI)
+                        .defaultLocation(true)
+                        .build()));
+    }
+
+    private Plant savedPlant(User user, String name) {
+        return plantRepository.save(Plant.builder()
+                .user(user)
+                .location(savedDefaultLocation(user))
+                .name(name)
+                .acquiredAt(LocalDate.of(2024, 1, 1))
+                .build());
+    }
+
+    private CareSchedule savedSchedule(Plant plant, TaskType type, LocalDateTime nextDueAt) {
+        return careScheduleRepository.save(CareSchedule.builder()
+                .plant(plant)
+                .taskType(type)
+                .intervalDays(7)
+                .nextDueAt(nextDueAt)
+                .active(true)
+                .build());
+    }
+
+    private CareHistory savedCare(Plant plant, TaskType type, LocalDateTime doneAt) {
+        return careHistoryRepository.save(CareHistory.builder()
+                .plant(plant)
+                .taskType(type)
+                .doneAt(doneAt)
+                .onTime(true)
+                .cancelledBy(null)
+                .build());
+    }
+
+    private static LocalDateTime utc(String isoLocal) {
+        return LocalDateTime.parse(isoLocal).truncatedTo(ChronoUnit.MICROS);
+    }
+}


### PR DESCRIPTION
Closes #182

## Что сделано
- `GET /api/v1/me` (scope user) — профиль (`name` из `username`, `avatar` = null-плейсхолдер), счётчики (`plantsTotal`, `tasksToday`, `notificationsUnread`) и настройки (`quietHoursStart/End` в `HH:mm`, `timezone` IANA, `locale`).
- `PATCH /api/v1/me` — частичный апдейт `{quietHoursStart?, quietHoursEnd?, timezone?, locale?}`; опущенные поля не изменяются. Смена `timezone` идёт через `UserSettingsService.changeTimezone` (пересчёт активных расписаний), невалидный IANA → 400; `locale` валидируется `@Pattern(^(ru|en)$)` → 400 при `de`/прочем.
- OpenAPI: `resources/me.yaml` + регистрация пути/схем в `openapi.yaml` → эндпоинты в `/v3/api-docs` (кодген для мобилки).
- Поле `User.locale` (default `"ru"`).

### Семантика спорных полей (задокументирована в спеке и javadoc)
- `tasksToday` — **только pending** задачи с дедлайном до конца сегодня в таймзоне пользователя (уже выполненные сегодня не считаются; счётчик-бейдж не растёт по мере выполнения).
- `avatar` — всегда `null`: колонки нет, поле read-only вне scope этого issue.
- `notificationsUnread` — стабильный `0`-плейсхолдер, пока не влит фид уведомлений (#183). В PATCH этих полей нет.

## Миграции
`V34__add_locale_to_users.sql` — `locale VARCHAR(8) NOT NULL DEFAULT 'ru'` + `CHECK (locale IN ('ru','en'))`.

⚠️ **Внимание при мерже:** номер `V34` пересекается с другой открытой feature-веткой (`add_amount_ml_to_care_schedules`). Ветка отрезана от свежего `develop` (последняя там — V33), так что V34 корректен относительно `develop`. Тот, кто мержит вторым, должен перенумеровать одну из миграций.

## Backward-compat риски
**Safe, один релиз.** Колонка NOT NULL, но с `DEFAULT 'ru'` → Postgres сам заполняет существующие строки (metadata-only с PG11), старый код колонку игнорирует. 3-шаговый nullable-танец не нужен (он только для NOT NULL без default).

## Тесты
- `UserProfileServiceTest` (Testcontainers Postgres, не H2): профиль/счётчики, исключение archived из `plantsTotal`, partial-PATCH (locale-only / quietHours-only — поля не зануляются), смена timezone Europe/Moscow→Asia/Almaty, **не-UTC таймзона** (тот же `next_due_at` считается «сегодня» в UTC, но не в Asia/Almaty), невалидный IANA → исключение, **`tasksToday` исключает done-today** (2 задачи, одна выполнена → счётчик 1).
- `MeControllerTest` (`@WebMvcTest` + MockMvc): JSON-форма ответа, partial-семантика (capture `ProfileUpdate`), `timezone` Mars/Phobos → 400, `locale=de` → 400 `VALIDATION_ERROR`, `quietHours=25:99` → 400, 401 без авторизации.
- Таргетный прогон: **21 тест, 0 падений** (`MeControllerTest` 11, `UserProfileServiceTest` 10).

## Чек
- [x] таргетные тесты зелёные (`mvn -Dtest=MeControllerTest,UserProfileServiceTest test`); полный `verify` на develop известно-флаки (Species*/security ITs/MonthlyReport) — не связано с этим PR
- [x] reviewer прошёл: 0 BLOCKING; обе SHOULD-FIX (`tasksToday` pending-only + тест на done-today) исправлены и покрыты

🤖 Generated with [Claude Code](https://claude.com/claude-code)
