### PR TITLE
feat: logout + logout-all + per-user token epoch (#178)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 | `/swagger-ui.html` | — | Swagger UI (OpenAPI 3) |
 | `/v3/api-docs` | — | OpenAPI JSON |
 
+### Auth (issue #178)
+
+Управление сессией. `logout`/`logout-all` требуют bearer-токен (остальные `/api/v1/auth/**` — публичные).
+
+| Метод | Путь | Статус ответа | Описание |
+|---|---|---|---|
+| `POST` | `/api/v1/auth/logout` | 204 | Отзывает предъявленный refresh-токен (тело: `{ "refreshToken" }`). Идемпотентен и толерантен: повторный вызов, невалидный/просроченный/чужой токен — всё равно 204 |
+| `POST` | `/api/v1/auth/logout-all` | 204 | Инвалидирует **все** refresh-токены пользователя через эпоху `users.tokens_valid_from = now` |
+
+После `logout-all` refresh-токен, чья секунда выпуска (`iat`) предшествует `tokens_valid_from`, отклоняется при ротации с `TOKEN_REVOKED`. Токены, выданные до появления фичи (эпоха `null`, без claim `tvf`), остаются валидными.
+
 ### События ухода (issue #86)
 
 | Путь | Метод | Статус ответа | Описание |

--- a/src/main/java/com/plantcare/api/auth/service/LogoutService.java
+++ b/src/main/java/com/plantcare/api/auth/service/LogoutService.java
@@ -1,0 +1,73 @@
+package com.plantcare.api.auth.service;
+
+import com.plantcare.api.auth.exception.AuthTokenException;
+import com.plantcare.core.repository.RevokedRefreshTokenRepository;
+import com.plantcare.core.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Выход из сессии (issue #178).
+ *
+ * <ul>
+ *   <li>{@code logout} — отзывает предъявленный refresh-токен текущего
+ *       пользователя. Толерантен: невалидный/чужой/просроченный токен молча
+ *       игнорируется, повторный logout идемпотентен (rowcount не проверяем).</li>
+ *   <li>{@code logoutAll} — выставляет эпоху {@code tokens_valid_from = now},
+ *       одномоментно инвалидируя все ранее выданные refresh-токены юзера.</li>
+ * </ul>
+ *
+ * <p>Внешних HTTP-вызовов в транзакции нет — всё локально в БД.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LogoutService {
+
+    private final TokenService tokenService;
+    private final RevokedRefreshTokenRepository revokedRepository;
+    private final UserRepository userRepository;
+    private final Clock clock;
+
+    /**
+     * Отзывает refresh-токен текущего пользователя. Если токен не парсится,
+     * просрочен или принадлежит другому пользователю — ничего не делает.
+     * Всегда завершается без исключения (контроллер отвечает 204).
+     */
+    @Transactional
+    public void logout(Long currentUserId, String refreshToken) {
+        TokenService.RefreshToken parsed;
+        try {
+            parsed = tokenService.parseRefresh(refreshToken);
+        } catch (AuthTokenException e) {
+            // Толерантный logout: невалидный/просроченный токен → просто 204.
+            log.debug("Logout with non-parseable refresh token for userId={}", currentUserId);
+            return;
+        }
+
+        if (!parsed.userId().equals(currentUserId)) {
+            log.warn("Logout refresh token userId mismatch: tokenUserId={}, currentUserId={}",
+                    parsed.userId(), currentUserId);
+            return;
+        }
+
+        // rowcount игнорируем: повторный logout того же токена → всё ещё 204.
+        revokedRepository.revokeIfAbsent(parsed.jti(), parsed.expiresAt());
+        log.info("Logout: revoked refresh token for userId={}", currentUserId);
+    }
+
+    /**
+     * Инвалидирует все refresh-токены пользователя через эпоху
+     * {@code tokens_valid_from = now}.
+     */
+    @Transactional
+    public void logoutAll(Long currentUserId) {
+        userRepository.updateTokensValidFrom(currentUserId, clock.instant().truncatedTo(ChronoUnit.SECONDS));
+        log.info("Logout-all: bumped token epoch for userId={}", currentUserId);
+    }
+}

--- a/src/main/java/com/plantcare/api/auth/service/RefreshService.java
+++ b/src/main/java/com/plantcare/api/auth/service/RefreshService.java
@@ -27,11 +27,19 @@ public class RefreshService {
     public TokenPair rotate(String refreshToken) {
         TokenService.RefreshToken parsed = tokenService.parseRefresh(refreshToken);
 
-        // Атомарно отзываем предъявленный jti. 0 вставленных строк → уже отозван.
-        blacklistService.revokeOrThrow(parsed.jti(), parsed.expiresAt());
-
         User user = userRepository.findById(parsed.userId())
                 .orElseThrow(() -> AuthTokenException.invalid("User from refresh token not found"));
+
+        // Эпоха logout-all (issue #178): токен, выданный до tokens_valid_from,
+        // невалиден. NULL → проверка пропускается (backward-compat).
+        var tokensValidFrom = user.getTokensValidFrom();
+        if (tokensValidFrom != null && parsed.issuedAt().getEpochSecond() < tokensValidFrom.getEpochSecond()) {
+            log.warn("Refresh token issued before logout-all epoch for userId={}", user.getId());
+            throw AuthTokenException.revoked("Token issued before logout-all");
+        }
+
+        // Атомарно отзываем предъявленный jti. 0 вставленных строк → уже отозван.
+        blacklistService.revokeOrThrow(parsed.jti(), parsed.expiresAt());
 
         log.info("Rotated token pair for userId={}", user.getId());
         return tokenService.issuePair(user);

--- a/src/main/java/com/plantcare/api/auth/service/TokenService.java
+++ b/src/main/java/com/plantcare/api/auth/service/TokenService.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 public class TokenService {
 
     static final String CLAIM_TYPE = "typ";
+    static final String CLAIM_TOKENS_VALID_FROM = "tvf";
     static final String TYPE_ACCESS = "access";
     static final String TYPE_REFRESH = "refresh";
 
@@ -54,11 +55,12 @@ public class TokenService {
         Instant now = clock.instant();
         AuthProperties.Jwt cfg = authProperties.getJwt();
 
+        Instant tokensValidFrom = user.getTokensValidFrom();
         long accessTtlSeconds = cfg.getAccessTtl().toSeconds();
-        String access = encode(user.getId(), TYPE_ACCESS, now, cfg.getAccessTtl().toSeconds(), null);
+        String access = encode(user.getId(), TYPE_ACCESS, now, cfg.getAccessTtl().toSeconds(), null, tokensValidFrom);
 
         UUID refreshJti = UUID.randomUUID();
-        String refresh = encode(user.getId(), TYPE_REFRESH, now, cfg.getRefreshTtl().toSeconds(), refreshJti);
+        String refresh = encode(user.getId(), TYPE_REFRESH, now, cfg.getRefreshTtl().toSeconds(), refreshJti, tokensValidFrom);
 
         return new TokenPair(access, refresh, accessTtlSeconds);
     }
@@ -88,7 +90,11 @@ public class TokenService {
         if (expiresAt == null) {
             throw AuthTokenException.invalid("Refresh token has no exp");
         }
-        return new RefreshToken(userId, jti, expiresAt);
+        Instant issuedAt = jwt.getIssuedAt();
+        if (issuedAt == null) {
+            throw AuthTokenException.invalid("Refresh token has no iat");
+        }
+        return new RefreshToken(userId, jti, expiresAt, issuedAt);
     }
 
     private Jwt decode(String token) {
@@ -131,7 +137,8 @@ public class TokenService {
         }
     }
 
-    private String encode(Long userId, String type, Instant issuedAt, long ttlSeconds, UUID jti) {
+    private String encode(Long userId, String type, Instant issuedAt, long ttlSeconds, UUID jti,
+                          Instant tokensValidFrom) {
         JwtClaimsSet.Builder claims = JwtClaimsSet.builder()
                 .issuer(authProperties.getJwt().getIssuer())
                 .subject(String.valueOf(userId))
@@ -141,11 +148,16 @@ public class TokenService {
         if (jti != null) {
             claims.id(jti.toString());
         }
+        // tvf несём только когда эпоха задана; для старых юзеров (null) claim
+        // отсутствует и проверка на ротации пропускается (issue #178).
+        if (tokensValidFrom != null) {
+            claims.claim(CLAIM_TOKENS_VALID_FROM, tokensValidFrom.getEpochSecond());
+        }
         JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).build();
         return appJwtEncoder.encode(JwtEncoderParameters.from(header, claims.build())).getTokenValue();
     }
 
     /** Разобранный refresh-токен. */
-    public record RefreshToken(Long userId, UUID jti, Instant expiresAt) {
+    public record RefreshToken(Long userId, UUID jti, Instant expiresAt, Instant issuedAt) {
     }
 }

--- a/src/main/java/com/plantcare/api/config/ApiSecurityConfig.java
+++ b/src/main/java/com/plantcare/api/config/ApiSecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -40,6 +41,11 @@ public class ApiSecurityConfig {
         return http
                 .securityMatcher("/api/v1/**")
                 .authorizeHttpRequests(auth -> auth
+                        // logout/logout-all требуют bearer-токен (issue #178) — должны
+                        // идти ДО общего permitAll на /api/v1/auth/** (первое совпадение
+                        // выигрывает).
+                        .requestMatchers(HttpMethod.POST,
+                                "/api/v1/auth/logout", "/api/v1/auth/logout-all").authenticated()
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/species/**", "/api/v1/care-types/**").permitAll()
                         .requestMatchers("/api/v1/health").permitAll()

--- a/src/main/java/com/plantcare/api/v1/AuthController.java
+++ b/src/main/java/com/plantcare/api/v1/AuthController.java
@@ -4,12 +4,15 @@ import com.plantcare.api.generated.AuthApi;
 import com.plantcare.api.generated.model.AppleAuthRequest;
 import com.plantcare.api.generated.model.EmailRequest;
 import com.plantcare.api.generated.model.GoogleAuthRequest;
+import com.plantcare.api.generated.model.LogoutRequest;
 import com.plantcare.api.generated.model.MagicLinkVerifyRequest;
 import com.plantcare.api.generated.model.RefreshRequest;
 import com.plantcare.api.generated.model.TokenPairResponse;
+import com.plantcare.api.CurrentUserProvider;
 import com.plantcare.api.auth.exception.RateLimitExceededException;
 import com.plantcare.api.auth.ratelimit.MagicLinkRateLimiter;
 import com.plantcare.api.auth.service.AuthService;
+import com.plantcare.api.auth.service.LogoutService;
 import com.plantcare.api.auth.service.MagicLinkService;
 import com.plantcare.api.auth.service.RefreshService;
 import com.plantcare.api.auth.service.TokenPair;
@@ -40,6 +43,8 @@ public class AuthController implements AuthApi {
     private final TokenService tokenService;
     private final RefreshService refreshService;
     private final MagicLinkService magicLinkService;
+    private final LogoutService logoutService;
+    private final CurrentUserProvider currentUserProvider;
     private final MagicLinkRateLimiter rateLimiter;
     private final HttpServletRequest httpRequest;
 
@@ -82,6 +87,16 @@ public class AuthController implements AuthApi {
     @Override
     public TokenPairResponse refreshTokens(RefreshRequest request) {
         return toResponse(refreshService.rotate(request.getRefreshToken()));
+    }
+
+    @Override
+    public void logout(LogoutRequest request) {
+        logoutService.logout(currentUserProvider.currentUserId(), request.getRefreshToken());
+    }
+
+    @Override
+    public void logoutAll() {
+        logoutService.logoutAll(currentUserProvider.currentUserId());
     }
 
     private void enforceRateLimit(String key) {

--- a/src/main/java/com/plantcare/core/domain/User.java
+++ b/src/main/java/com/plantcare/core/domain/User.java
@@ -16,6 +16,7 @@ import lombok.Setter;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
@@ -60,6 +61,15 @@ public class User extends BaseEntity {
     /** Стабильный subject (sub) из Google ID token. NULL если Google не привязан. */
     @Column(name = "google_subject", length = 255)
     private String googleSubject;
+
+    /**
+     * Эпоха валидности refresh-токенов (issue #178, V37). Refresh с
+     * {@code iat < tokens_valid_from} считается невалидным (logout-all).
+     * NULL = эпоха не задана, проверка пропускается (backward-compat).
+     * Тип Instant — сравнивается с JWT {@code iat}.
+     */
+    @Column(name = "tokens_valid_from")
+    private Instant tokensValidFrom;
 
     @Column(nullable = false, length = 64)
     @Builder.Default

--- a/src/main/java/com/plantcare/core/repository/UserRepository.java
+++ b/src/main/java/com/plantcare/core/repository/UserRepository.java
@@ -126,5 +126,16 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Modifying
     @Query("UPDATE User u SET u.pausedUntil = NULL WHERE u.id = :id AND u.pausedUntil IS NOT NULL")
     int clearPausedUntilIfActive(@Param("id") Long id);
+
+    // ===== Logout-all / token epoch (issue #178) =====
+
+    /**
+     * Атомарно выставляет эпоху валидности refresh-токенов (logout-all):
+     * все refresh с {@code iat < now} перестают проходить ротацию. Делаем
+     * через UPDATE, чтобы не читать-модифицировать-писать с гонкой.
+     */
+    @Modifying
+    @Query("UPDATE User u SET u.tokensValidFrom = :now WHERE u.id = :id")
+    int updateTokensValidFrom(@Param("id") Long id, @Param("now") java.time.Instant now);
 }
 

--- a/src/main/resources/db/migration/V37__add_tokens_valid_from_to_users.sql
+++ b/src/main/resources/db/migration/V37__add_tokens_valid_from_to_users.sql
@@ -1,0 +1,38 @@
+-- V37__add_tokens_valid_from_to_users.sql
+-- Issue #178: logout + per-user token epoch ("logout-all").
+-- В users добавляется колонка tokens_valid_from — момент (UTC), начиная с
+-- которого refresh-токены данного пользователя считаются действительными.
+-- Проверка при предъявлении refresh: если tokens_valid_from задан и
+-- iat(refresh) < tokens_valid_from — токен невалиден. logout-all выставляет
+-- tokens_valid_from = now(), тем самым одномоментно инвалидируя все ранее
+-- выданные refresh-токены пользователя.
+--
+-- NULL == "эпоха не задана" == проверка iat < tokens_valid_from ПРОПУСКАЕТСЯ.
+-- Это намеренная backward-compat семантика, а не недосмотр:
+--   * все refresh-токены, выданные до этой фичи, остаются валидными;
+--   * пользователи, которые никогда не делали logout-all, не затрагиваются.
+-- Поэтому колонка СТРОГО NULLABLE и БЕЗ DEFAULT. NOT NULL или DEFAULT now()/
+-- CURRENT_TIMESTAMP проставил бы эпоху всем существующим строкам и
+-- инвалидировал бы каждый активный refresh-токен при деплое — это запрещено.
+--
+-- Backward-compat note:
+--   * NULLABLE ADD COLUMN без DEFAULT в Postgres — метаданные-онли, без
+--     переписывания таблицы (instant, no rewrite). Безопасно для rolling deploy.
+--   * Старый код вставляет/читает users без упоминания колонки и продолжает
+--     работать: новые строки получают NULL, что = "проверка пропускается".
+--   * Бэкфил НЕ нужен и НЕ допускается (NULL — рабочее значение по умолчанию).
+--   * Индекс не нужен: колонка читается по строке пользователя (PK lookup),
+--     а не используется как предикат в выборках.
+
+BEGIN;
+
+ALTER TABLE users
+    ADD COLUMN tokens_valid_from TIMESTAMPTZ;
+
+COMMENT ON COLUMN users.tokens_valid_from IS
+    'Эпоха валидности refresh-токенов пользователя (UTC). Refresh с '
+        'iat < tokens_valid_from считается невалидным. NULL = эпоха не задана, '
+        'проверка пропускается (backward-compat для старых токенов и юзеров без '
+        'logout-all). logout-all выставляет это поле в now().';
+
+COMMIT;

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -108,6 +108,10 @@ paths:
     $ref: './resources/auth.yaml#/paths/EmailVerify'
   /api/v1/auth/refresh:
     $ref: './resources/auth.yaml#/paths/Refresh'
+  /api/v1/auth/logout:
+    $ref: './resources/auth.yaml#/paths/Logout'
+  /api/v1/auth/logout-all:
+    $ref: './resources/auth.yaml#/paths/LogoutAll'
 
   /api/v1/health:
     $ref: './resources/health.yaml#/paths/Health'
@@ -223,6 +227,8 @@ components:
       $ref: './resources/auth.yaml#/schemas/MagicLinkVerifyRequest'
     RefreshRequest:
       $ref: './resources/auth.yaml#/schemas/RefreshRequest'
+    LogoutRequest:
+      $ref: './resources/auth.yaml#/schemas/LogoutRequest'
     TokenPairResponse:
       $ref: './resources/auth.yaml#/schemas/TokenPairResponse'
 

--- a/src/main/resources/openapi/resources/auth.yaml
+++ b/src/main/resources/openapi/resources/auth.yaml
@@ -140,6 +140,48 @@ paths:
         '401':
           $ref: '../_common/responses.yaml#/Unauthorized'
 
+  Logout:
+    post:
+      tags: [Auth]
+      operationId: logout
+      summary: Выйти из текущей сессии (отозвать refresh-токен)
+      description: |
+        Отзывает предъявленный refresh-токен текущего пользователя. Толерантен
+        и идемпотентен: повторный logout того же токена, а также невалидный/
+        просроченный/чужой токен возвращают `204` без ошибки.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/LogoutRequest'
+      responses:
+        '204':
+          description: Сессия завершена (refresh отозван либо уже был невалиден).
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+
+  LogoutAll:
+    post:
+      tags: [Auth]
+      operationId: logoutAll
+      summary: Выйти со всех устройств (инвалидировать все refresh-токены)
+      description: |
+        Выставляет эпоху валидности токенов пользователя в текущий момент,
+        одномоментно инвалидируя все ранее выданные refresh-токены. На следующей
+        ротации старый refresh получит `401 TOKEN_REVOKED`.
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Все refresh-токены пользователя инвалидированы.
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+
 schemas:
   AppleAuthRequest:
     type: object
@@ -192,6 +234,16 @@ schemas:
         type: string
         minLength: 1
         description: Refresh-токен, полученный при предыдущем входе/ротации.
+
+  LogoutRequest:
+    type: object
+    description: Тело POST /api/v1/auth/logout.
+    required: [refreshToken]
+    properties:
+      refreshToken:
+        type: string
+        minLength: 1
+        description: Refresh-токен текущей сессии, который нужно отозвать.
 
   TokenPairResponse:
     type: object

--- a/src/test/java/com/plantcare/api/auth/service/LogoutServiceIT.java
+++ b/src/test/java/com/plantcare/api/auth/service/LogoutServiceIT.java
@@ -1,0 +1,300 @@
+package com.plantcare.api.auth.service;
+
+import com.plantcare.api.auth.exception.AuthTokenException;
+import com.plantcare.bot.support.IntegrationTestBase;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.repository.RevokedRefreshTokenRepository;
+import com.plantcare.core.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.boot.test.context.TestConfiguration;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Интеграционный тест logout / logout-all и эпохи {@code tokens_valid_from}
+ * (issue #178, ADR-015). Реальный Postgres — отзыв jti в
+ * {@code revoked_refresh_tokens} и UPDATE эпохи через {@code UserRepository}.
+ *
+ * <p>Время контролируется {@link MutableClock} (@Primary), которым пользуются и
+ * {@link TokenService} (штамп {@code iat}/{@code tvf}), и {@link LogoutService}
+ * (штамп {@code tokens_valid_from}). Якорь — в будущем (2099), чтобы exp
+ * выпущенных токенов проходил валидацию реального системного декодера.
+ */
+@Import(LogoutServiceIT.FixedClockConfig.class)
+class LogoutServiceIT extends IntegrationTestBase {
+
+    // exp выпущенных токенов = anchor + TTL должен быть в будущем относительно
+    // СИСТЕМНЫХ часов на момент decode, иначе appRefreshJwtDecoder отвергнет как expired.
+    private static final Instant ANCHOR = Instant.parse("2099-05-22T10:00:00Z");
+
+    @Autowired
+    private LogoutService logoutService;
+
+    @Autowired
+    private RefreshService refreshService;
+
+    @Autowired
+    private TokenService tokenService;
+
+    @Autowired
+    private RevokedRefreshTokenRepository revokedRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private MutableClock clock;
+
+    @BeforeEach
+    void resetClock() {
+        clock.set(ANCHOR);
+    }
+
+    @AfterEach
+    void cleanup() {
+        revokedRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    private User persistUser() {
+        return userRepository.save(User.builder()
+                .telegramChatId(null)
+                .email("logout-" + UUID.randomUUID() + "@plantcare.test")
+                .emailVerified(true)
+                .build());
+    }
+
+    // ===================== AC1: logout отзывает предъявленный refresh =====================
+
+    @Test
+    void should_revoke_presented_refresh_when_logout_then_rotate_is_rejected() {
+        // arrange
+        User user = persistUser();
+        TokenPair pair = tokenService.issuePair(user);
+        UUID jti = tokenService.parseRefresh(pair.refreshToken()).jti();
+
+        // act
+        logoutService.logout(user.getId(), pair.refreshToken());
+
+        // assert — jti записан как отозванный
+        assertThat(revokedRepository.existsByJti(jti)).isTrue();
+
+        // assert — последующая ротация этим токеном → TOKEN_REVOKED
+        assertThatThrownBy(() -> refreshService.rotate(pair.refreshToken()))
+                .isInstanceOf(AuthTokenException.class)
+                .satisfies(e -> assertThat(((AuthTokenException) e).getCode())
+                        .isEqualTo(AuthTokenException.Code.TOKEN_REVOKED));
+    }
+
+    // ===================== AC2: повторный logout идемпотентен =====================
+
+    @Test
+    void should_stay_idempotent_when_logout_called_twice_with_same_token() {
+        // arrange
+        User user = persistUser();
+        TokenPair pair = tokenService.issuePair(user);
+        UUID jti = tokenService.parseRefresh(pair.refreshToken()).jti();
+
+        // act — дважды отзываем один и тот же токен
+        logoutService.logout(user.getId(), pair.refreshToken());
+
+        // assert — второй вызов не бросает (rowcount игнорируется)
+        assertThatCode(() -> logoutService.logout(user.getId(), pair.refreshToken()))
+                .doesNotThrowAnyException();
+
+        // assert — токен ровно один раз в таблице (PK по jti, дублей нет)
+        assertThat(revokedRepository.existsByJti(jti)).isTrue();
+        assertThat(revokedRepository.count()).isEqualTo(1);
+    }
+
+    // ===================== AC3: толерантность к мусору/просрочке =====================
+
+    @Test
+    void should_swallow_error_when_logout_with_garbage_token() {
+        // arrange
+        User user = persistUser();
+
+        // act + assert — невалидный токен → без исключения, ничего не отозвано
+        assertThatCode(() -> logoutService.logout(user.getId(), "not-a-jwt"))
+                .doesNotThrowAnyException();
+        assertThat(revokedRepository.count()).isEqualTo(0);
+    }
+
+    @Test
+    void should_swallow_error_when_logout_with_expired_token() {
+        // arrange — токен выпущен далеко в прошлом → exp в прошлом относительно decode
+        User user = persistUser();
+        clock.set(Instant.parse("2020-01-01T00:00:00Z"));
+        TokenPair expiredPair = tokenService.issuePair(user);
+        clock.set(ANCHOR);
+
+        // act + assert — просроченный refresh → 204-семантика, без исключения и без отзыва
+        assertThatCode(() -> logoutService.logout(user.getId(), expiredPair.refreshToken()))
+                .doesNotThrowAnyException();
+        assertThat(revokedRepository.count()).isEqualTo(0);
+    }
+
+    // ===================== AC4: чужой токен не отзывается =====================
+
+    @Test
+    void should_not_revoke_token_when_it_belongs_to_another_user() {
+        // arrange — токен принадлежит userB, logout делает userA
+        User userA = persistUser();
+        User userB = persistUser();
+        TokenPair bPair = tokenService.issuePair(userB);
+        UUID bJti = tokenService.parseRefresh(bPair.refreshToken()).jti();
+
+        // act — userA пытается отозвать чужой токен
+        logoutService.logout(userA.getId(), bPair.refreshToken());
+
+        // assert — токен userB НЕ отозван
+        assertThat(revokedRepository.existsByJti(bJti)).isFalse();
+
+        // assert — токен userB всё ещё ротируется штатно
+        TokenPair rotated = refreshService.rotate(bPair.refreshToken());
+        assertThat(rotated.refreshToken()).isNotBlank();
+    }
+
+    // ===================== AC5: logout-all выставляет эпоху =====================
+
+    @Test
+    void should_set_epoch_and_reject_old_refresh_when_logout_all() {
+        // arrange — токен выпущен в ANCHOR
+        User user = persistUser();
+        TokenPair oldPair = tokenService.issuePair(user);
+
+        // act — спустя час делаем logout-all (эпоха = ANCHOR + 1h > iat токена)
+        clock.set(ANCHOR.plusSeconds(3600));
+        logoutService.logoutAll(user.getId());
+
+        // assert — эпоха записана в users.tokens_valid_from
+        Instant storedEpoch = userRepository.findById(user.getId()).orElseThrow().getTokensValidFrom();
+        assertThat(storedEpoch).isEqualTo(ANCHOR.plusSeconds(3600));
+
+        // assert — старый refresh (iat < эпоха) → TOKEN_REVOKED при ротации
+        assertThatThrownBy(() -> refreshService.rotate(oldPair.refreshToken()))
+                .isInstanceOf(AuthTokenException.class)
+                .satisfies(e -> assertThat(((AuthTokenException) e).getCode())
+                        .isEqualTo(AuthTokenException.Code.TOKEN_REVOKED));
+    }
+
+    // ===================== AC5 (regression #178): суб-секундная точность эпохи =====================
+
+    @Test
+    void should_allow_rotation_for_token_issued_same_second_as_logout_all() {
+        // arrange — часы на момент С суб-секундной компонентой (.300):
+        // iat токена флорится до целой секунды (...:05.000) при кодировании в JWT NumericDate.
+        Instant subSecond = Instant.parse("2099-05-22T10:00:05.300Z");
+        User user = persistUser();
+        clock.set(subSecond);
+        TokenPair samePair = tokenService.issuePair(user);
+
+        // act — logout-all В ТОТ ЖЕ instant: tokens_valid_from = ...:05 (truncatedTo SECONDS).
+        logoutService.logoutAll(user.getId());
+
+        // assert — эпоха усечена до секунды (.300 отброшено), а не сохранена как микросекунды
+        Instant storedEpoch = userRepository.findById(user.getId()).orElseThrow().getTokensValidFrom();
+        assertThat(storedEpoch).isEqualTo(Instant.parse("2099-05-22T10:00:05Z"));
+
+        // assert — токен той же секунды (iat ...:05 == эпоха ...:05) валиден, ротация проходит.
+        // На дореформенном коде (микросекундный tvf + isBefore) ротация была бы ошибочно отклонена.
+        TokenPair rotated = refreshService.rotate(samePair.refreshToken());
+        assertThat(rotated.refreshToken()).isNotBlank();
+        assertThat(rotated.refreshToken()).isNotEqualTo(samePair.refreshToken());
+    }
+
+    // ===================== AC6: backward-compat (tokens_valid_from = NULL) =====================
+
+    @Test
+    void should_allow_rotation_when_tokens_valid_from_is_null() {
+        // arrange — юзер без эпохи (NULL), токен без tvf claim
+        User user = persistUser();
+        assertThat(user.getTokensValidFrom()).isNull();
+        TokenPair pair = tokenService.issuePair(user);
+
+        // act — ротация при NULL-эпохе: проверка пропускается
+        TokenPair rotated = refreshService.rotate(pair.refreshToken());
+
+        // assert — новая пара выдана штатно (критичный edge backward-compat)
+        assertThat(rotated.refreshToken()).isNotBlank();
+        assertThat(rotated.refreshToken()).isNotEqualTo(pair.refreshToken());
+    }
+
+    // ===================== AC8: новый токен после logout-all валиден =====================
+
+    @Test
+    void should_rotate_fine_for_pair_issued_after_logout_all() {
+        // arrange — logout-all выставил эпоху в ANCHOR
+        User user = persistUser();
+        logoutService.logoutAll(user.getId());
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(reloaded.getTokensValidFrom()).isEqualTo(ANCHOR);
+
+        // act — пара выпущена ПОСЛЕ эпохи (iat = ANCHOR+1мин >= tokens_valid_from)
+        clock.set(ANCHOR.plusSeconds(60));
+        TokenPair freshPair = tokenService.issuePair(reloaded);
+
+        // assert — свежая пара ротируется без TOKEN_REVOKED
+        TokenPair rotated = refreshService.rotate(freshPair.refreshToken());
+        assertThat(rotated.refreshToken()).isNotBlank();
+    }
+
+    // ====================================================================
+    // test infra: подменяемый Clock, общий для TokenService и LogoutService
+    // ====================================================================
+
+    @TestConfiguration
+    static class FixedClockConfig {
+        @Bean
+        @Primary
+        MutableClock testClock() {
+            // UTC как в проде (ClockConfig = systemUTC).
+            return new MutableClock(ANCHOR, ZoneOffset.UTC);
+        }
+    }
+
+    /** Clock с изменяемым instant — позволяет «двигать» время между шагами теста. */
+    static final class MutableClock extends Clock {
+        private final AtomicReference<Instant> now;
+        private final ZoneId zone;
+
+        MutableClock(Instant initial, ZoneId zone) {
+            this.now = new AtomicReference<>(initial);
+            this.zone = zone;
+        }
+
+        void set(Instant instant) {
+            now.set(instant);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return zone;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return new MutableClock(now.get(), zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return now.get();
+        }
+    }
+}

--- a/src/test/java/com/plantcare/api/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/plantcare/api/auth/service/TokenServiceTest.java
@@ -86,9 +86,17 @@ class TokenServiceTest {
 
     private static User userWithId(long id) {
         // id назначается БД и не имеет сеттера (BaseEntity @Getter-only) — мок оправдан,
-        // нам нужен предсказуемый id без поднятия контейнера.
+        // нам нужен предсказуемый id без поднятия контейнера. tokensValidFrom = null
+        // (мок по умолчанию) — backward-compat ветка без tvf claim.
         User user = org.mockito.Mockito.mock(User.class);
         org.mockito.Mockito.when(user.getId()).thenReturn(id);
+        return user;
+    }
+
+    private static User userWithTokensValidFrom(long id, Instant tokensValidFrom) {
+        User user = org.mockito.Mockito.mock(User.class);
+        org.mockito.Mockito.when(user.getId()).thenReturn(id);
+        org.mockito.Mockito.when(user.getTokensValidFrom()).thenReturn(tokensValidFrom);
         return user;
     }
 
@@ -137,6 +145,43 @@ class TokenServiceTest {
         String firstJti = decoder.decode(first.refreshToken()).getId();
         String secondJti = decoder.decode(second.refreshToken()).getId();
         assertThat(firstJti).isNotEqualTo(secondJti);
+    }
+
+    // ===================== tvf claim (issue #178) =====================
+
+    @Test
+    void should_carry_tvf_claim_as_epoch_seconds_when_tokens_valid_from_set() {
+        // arrange — эпоха задана (logout-all уже был); ожидаем claim tvf = epoch-сек
+        Instant epoch = Instant.parse("2099-05-22T09:00:00Z");
+        TokenService service = tokenServiceAt(fixedUtc(FIXED_NOW));
+        JwtDecoder decoder = decoder();
+
+        // act
+        TokenPair pair = service.issuePair(userWithTokensValidFrom(11L, epoch));
+
+        // assert — tvf присутствует и равен epoch-секундам, и на access, и на refresh
+        var access = decoder.decode(pair.accessToken());
+        var refresh = decoder.decode(pair.refreshToken());
+        Object accessTvf = access.getClaim("tvf");
+        Object refreshTvf = refresh.getClaim("tvf");
+        assertThat(accessTvf).isEqualTo(epoch.getEpochSecond());
+        assertThat(refreshTvf).isEqualTo(epoch.getEpochSecond());
+    }
+
+    @Test
+    void should_omit_tvf_claim_when_tokens_valid_from_null() {
+        // arrange — старый юзер без эпохи (backward-compat) → claim tvf не должен попасть в токен
+        TokenService service = tokenServiceAt(fixedUtc(FIXED_NOW));
+        JwtDecoder decoder = decoder();
+
+        // act
+        TokenPair pair = service.issuePair(userWithId(12L));
+
+        // assert
+        Object accessTvf = decoder.decode(pair.accessToken()).getClaim("tvf");
+        Object refreshTvf = decoder.decode(pair.refreshToken()).getClaim("tvf");
+        assertThat(accessTvf).isNull();
+        assertThat(refreshTvf).isNull();
     }
 
     // ===================== parseRefresh =====================

--- a/src/test/java/com/plantcare/api/v1/AuthControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/AuthControllerTest.java
@@ -4,6 +4,7 @@ import com.plantcare.api.auth.exception.AuthTokenException;
 import com.plantcare.api.auth.exception.RateLimitExceededException;
 import com.plantcare.api.auth.ratelimit.MagicLinkRateLimiter;
 import com.plantcare.api.auth.service.AuthService;
+import com.plantcare.api.auth.service.LogoutService;
 import com.plantcare.api.auth.service.MagicLinkService;
 import com.plantcare.api.auth.service.RefreshService;
 import com.plantcare.api.auth.service.TokenPair;
@@ -12,6 +13,7 @@ import com.plantcare.api.auth.verifier.AppleTokenVerifier;
 import com.plantcare.api.auth.verifier.ExternalIdentity;
 import com.plantcare.api.auth.verifier.GoogleTokenVerifier;
 import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
 import com.plantcare.core.domain.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +29,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -66,6 +69,12 @@ class AuthControllerTest {
 
     @MockitoBean
     private MagicLinkService magicLinkService;
+
+    @MockitoBean
+    private LogoutService logoutService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
 
     @MockitoBean
     private MagicLinkRateLimiter rateLimiter;
@@ -306,5 +315,64 @@ class AuthControllerTest {
                         .content("{\"refreshToken\": \"reused-refresh\"}"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.error.code").value("TOKEN_REVOKED"));
+    }
+
+    // ===================== POST /auth/logout (issue #178) =====================
+
+    @Test
+    void should_return_204_and_delegate_to_service_when_logout_called() throws Exception {
+        // arrange — текущий юзер резолвится из контекста, сервис отзывает токен
+        when(currentUserProvider.currentUserId()).thenReturn(42L);
+
+        // act + assert — 204 No Content, тело пустое
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"refreshToken\": \"some-refresh\"}"))
+                .andExpect(status().isNoContent());
+
+        // отзыв делегирован сервису с парой (currentUserId, предъявленный токен)
+        verify(logoutService).logout(42L, "some-refresh");
+    }
+
+    @Test
+    void should_return_204_when_logout_called_twice_with_same_token() throws Exception {
+        // arrange — идемпотентность: сервис не бросает на повторный logout
+        when(currentUserProvider.currentUserId()).thenReturn(7L);
+
+        // act + assert — оба вызова 204
+        for (int i = 0; i < 2; i++) {
+            mockMvc.perform(post("/api/v1/auth/logout")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"refreshToken\": \"repeat-refresh\"}"))
+                    .andExpect(status().isNoContent());
+        }
+
+        verify(logoutService, times(2)).logout(7L, "repeat-refresh");
+    }
+
+    @Test
+    void should_return_400_when_logout_body_missing_refresh_token() throws Exception {
+        // act + assert — refreshToken обязателен (@NotBlank в сгенерированной модели) → 400
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+
+        verify(logoutService, never()).logout(any(), anyString());
+    }
+
+    // ===================== POST /auth/logout-all (issue #178) =====================
+
+    @Test
+    void should_return_204_and_bump_epoch_when_logout_all_called() throws Exception {
+        // arrange
+        when(currentUserProvider.currentUserId()).thenReturn(99L);
+
+        // act + assert — 204, делегирование с currentUserId
+        mockMvc.perform(post("/api/v1/auth/logout-all"))
+                .andExpect(status().isNoContent());
+
+        verify(logoutService).logoutAll(99L);
     }
 }


### PR DESCRIPTION
Closes #178

## Что сделано
- `POST /api/v1/auth/logout` — отзыв предъявленного refresh-токена (`revokeIfAbsent`, rowcount игнорируется → **идемпотентно**); проверка принадлежности текущему юзеру; невалидный/протухший/чужой токен → тоже **204** (tolerant, без 500/401).
- `POST /api/v1/auth/logout-all` — `UPDATE users SET tokens_valid_from = now()` → **204**. Отзывает ВСЕ refresh пользователя разом через эпоч.
- Per-user token epoch: refresh несёт claim `tvf` (= `tokens_valid_from` в epoch-сек). `RefreshService.rotate` short-circuit: refresh с `iat`-секундой < `tokens_valid_from` → `TOKEN_REVOKED`.
- Логаут-эндпоинты требуют bearer (`authenticated()`-матчеры перед `permitAll` для `/auth/**`); apple/google/email/refresh остаются публичными.

## Миграции
`V37__add_tokens_valid_from_to_users.sql` — `tokens_valid_from TIMESTAMPTZ` **nullable, без default**.

## Backward-compat риски
**Safe, один релиз.** Nullable `ADD COLUMN` без default = metadata-only, мгновенно. `NULL`-эпоч и токены без `tvf` (выпущенные до фичи) **проверку пропускают** — остаются валидными до `exp`. Ничего не инвалидируется на деплое.

## Решения, на которые стоит обратить внимание ревьюера
- **Granularity = epoch-секунды.** `tvf` хранится в секундах, JWT `iat` тоже округляется до секунды. `logout-all` пишет `tokens_valid_from` усечённым до секунды, а сравнение идёт по `getEpochSecond()` со строгим `<`. Это сделано осознанно: иначе свежий токен, выпущенный в ту же секунду, что и `logout-all` (нормальный re-login flow), ошибочно получал `TOKEN_REVOKED` (поймано ревью как 🔴, исправлено + regression-тест). Компромисс: токен, выпущенный в ту же секунду *до* `logout-all`, переживает отзыв (окно ≤1с) — приемлемо при коротком TTL access-токена.
- **Порядок в `rotate`:** эпоч-проверка теперь ПЕРЕД blacklist-проверкой — токен, протухший по эпоче, не расходует свой `jti`. Поведенческое изменение, не баг.

## Тесты
`LogoutServiceIT` (Testcontainers, `@Primary MutableClock`): отзыв презентованного токена → последующий rotate = TOKEN_REVOKED; идемпотентность повторного logout; tolerant на garbage/expired; чужой токен не отзывается; logout-all ставит эпоч и рубит старый refresh; backward-compat (NULL-эпоч rotate OK); **same-second regression** (свежий токен в ту же секунду, что logout-all, → rotate OK); токен после logout-all валиден. `TokenServiceTest`: `tvf` присутствует/отсутствует. `AuthControllerTest`: 204 + делегирование, 400 на пустой body, logout-all 204.

Полный `mvn clean verify`: **1470 тестов, 0 failures, 0 errors, BUILD SUCCESS**.

## Чек
- [x] `mvn clean verify` зелёное (1470/0/0)
- [x] reviewer прошёл (1 🔴 sub-second precision — исправлен + regression-тест; 0 SHOULD-FIX)
- [x] OpenAPI: оба пути И схема `LogoutRequest` зарегистрированы в openapi.yaml (`MeApi`-урок #182), `AuthApi` генерится на чистой сборке

🤖 Generated with [Claude Code](https://claude.com/claude-code)
