### PR TITLE
feat: расширение профиля /me — аккаунт, настройки, привязки (#180)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,14 +159,14 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 | `PATCH` | `/api/v1/shopping/{id}` | 200 | Частичное обновление: передаются только изменяемые поля (`checked`, `title`) |
 | `DELETE` | `/api/v1/shopping/{id}` | 204 | Удалить позицию |
 
-### Me (issue #182)
+### Me (issue #182, расширено #180)
 
 Профиль и настройки текущего пользователя. Скоуп — аутентифицированный пользователь.
 
 | Метод | Путь | Статус ответа | Описание |
 |---|---|---|---|
-| `GET` | `/api/v1/me` | 200 | Профиль: имя, аватар, счётчики для хедера (`plantsTotal`, `tasksToday`, `notificationsUnread`) и настройки (`quietHoursStart`, `quietHoursEnd`, `timezone`, `locale`). `tasksToday` — число невыполненных задач на сегодня в таймзоне пользователя. `avatar` — плейсхолдер (всегда `null`, колонки в схеме нет); `notificationsUnread` — плейсхолдер (всегда `0` до фида уведомлений, issue #183) |
-| `PATCH` | `/api/v1/me` | 200 | Частичное обновление настроек (`quietHoursStart`, `quietHoursEnd`, `timezone`, `locale`): меняются только переданные поля. Смена `timezone` пересчитывает активные расписания с сохранением локального времени дня. Невалидный IANA-`timezone` → 400 |
+| `GET` | `/api/v1/me` | 200 | Профиль: `id`, `email`, `emailVerified`, `createdAt` (UTC), имя, аватар, счётчики для хедера (`plantsTotal`, `tasksToday`, `notificationsUnread`), настройки (`quietHoursStart`, `quietHoursEnd`, `timezone`, `locale`, `seasonalEnabled`, `seasonalMode`, `weatherEnabled`), `featureFlags` и привязки входа (`appleLinked`, `googleLinked`, `emailLinked`, `telegramLinked`). `tasksToday` — число невыполненных задач на сегодня в таймзоне пользователя. `avatar` — плейсхолдер (всегда `null`, колонки в схеме нет); `notificationsUnread` — плейсхолдер (всегда `0` до фида уведомлений, issue #183) |
+| `PATCH` | `/api/v1/me` | 200 | Частичное обновление настроек (`quietHoursStart`, `quietHoursEnd`, `timezone`, `locale`, `seasonalEnabled`, `seasonalMode`, `weatherEnabled`): меняются только переданные поля. Смена `timezone` пересчитывает активные расписания с сохранением локального времени дня. Невалидный IANA-`timezone` → 400. Совпадение тихих часов (`quietHoursStart == quietHoursEnd`, с учётом текущего значения, если передано только одно поле) → 400 |
 ### Notifications (issue #183)
 
 Персистентный inbox уведомлений пользователя для мобильного клиента. Все эндпоинты user-scoped. Наполнение ленты добавят отдельные issue — текущая реализация даёт только чтение и отметку прочтения.

--- a/src/main/java/com/plantcare/api/v1/MeController.java
+++ b/src/main/java/com/plantcare/api/v1/MeController.java
@@ -5,6 +5,7 @@ import com.plantcare.api.generated.MeApi;
 import com.plantcare.api.generated.model.MeResponse;
 import com.plantcare.api.generated.model.MeUpdateRequest;
 import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.SeasonalMode;
 import com.plantcare.core.service.UserProfileService;
 import com.plantcare.core.service.UserProfileService.Profile;
 import com.plantcare.core.service.UserProfileService.ProfileUpdate;
@@ -47,7 +48,10 @@ public class MeController implements MeApi {
                 parseTime(request.getQuietHoursStart()),
                 parseTime(request.getQuietHoursEnd()),
                 request.getTimezone(),
-                request.getLocale()
+                request.getLocale(),
+                request.getSeasonalEnabled(),
+                toSeasonalMode(request.getSeasonalMode()),
+                request.getWeatherEnabled()
         );
 
         return toResponse(userProfileService.updateProfile(user, update));
@@ -55,6 +59,9 @@ public class MeController implements MeApi {
 
     private static MeResponse toResponse(Profile profile) {
         return new MeResponse(
+                profile.id(),
+                profile.emailVerified(),
+                profile.createdAt(),
                 profile.name(),
                 profile.plantsTotal(),
                 profile.tasksToday(),
@@ -62,8 +69,23 @@ public class MeController implements MeApi {
                 profile.quietHoursStart().format(HH_MM),
                 profile.quietHoursEnd().format(HH_MM),
                 profile.timezone(),
-                MeResponse.LocaleEnum.fromValue(profile.locale())
-        ).avatar(profile.avatar());
+                MeResponse.LocaleEnum.fromValue(profile.locale()),
+                profile.seasonalEnabled(),
+                MeResponse.SeasonalModeEnum.fromValue(profile.seasonalMode().name()),
+                profile.weatherEnabled(),
+                profile.featureFlags(),
+                profile.appleLinked(),
+                profile.googleLinked(),
+                profile.emailLinked(),
+                profile.telegramLinked()
+        )
+                .email(profile.email())
+                .avatar(profile.avatar());
+    }
+
+    private static SeasonalMode toSeasonalMode(String value) {
+        // @Pattern на DTO гарантирует MULTIPLIER|FIXED до вызова сервиса, поэтому valueOf безопасен.
+        return value == null ? null : SeasonalMode.valueOf(value);
     }
 
     private static LocalTime parseTime(String hhmm) {

--- a/src/main/java/com/plantcare/core/service/UserProfileService.java
+++ b/src/main/java/com/plantcare/core/service/UserProfileService.java
@@ -1,6 +1,7 @@
 package com.plantcare.core.service;
 
 import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.SeasonalMode;
 import com.plantcare.core.repository.PlantRepository;
 import com.plantcare.core.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +11,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DateTimeException;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Map;
 
 /**
  * Профиль и настройки пользователя для REST API {@code /api/v1/me} (issue #182,
@@ -43,6 +47,10 @@ public class UserProfileService {
      * фид уведомлений (issue #183) ещё не влит в эту ветку.
      */
     public record Profile(
+            long id,
+            String email,
+            boolean emailVerified,
+            OffsetDateTime createdAt,
             String name,
             String avatar,
             int plantsTotal,
@@ -51,19 +59,32 @@ public class UserProfileService {
             LocalTime quietHoursStart,
             LocalTime quietHoursEnd,
             String timezone,
-            String locale
+            String locale,
+            boolean seasonalEnabled,
+            SeasonalMode seasonalMode,
+            boolean weatherEnabled,
+            Map<String, Object> featureFlags,
+            boolean appleLinked,
+            boolean googleLinked,
+            boolean emailLinked,
+            boolean telegramLinked
     ) {
     }
 
     /**
      * Частичный апдейт настроек: {@code null}-поле = «не менять».
      * {@code timezone} — IANA-идентификатор, {@code locale} — {@code ru}|{@code en}.
+     * {@code seasonalEnabled}/{@code seasonalMode}/{@code weatherEnabled} — простые
+     * тогглы (read-only для остальных полей профиля).
      */
     public record ProfileUpdate(
             LocalTime quietHoursStart,
             LocalTime quietHoursEnd,
             String timezone,
-            String locale
+            String locale,
+            Boolean seasonalEnabled,
+            SeasonalMode seasonalMode,
+            Boolean weatherEnabled
     ) {
     }
 
@@ -83,7 +104,16 @@ public class UserProfileService {
         // notificationsUnread — плейсхолдер: фид уведомлений (issue #183) ещё не влит.
         int notificationsUnread = 0;
 
+        // createdAt в БД — LocalDateTime в UTC wall-clock; отдаём наружу как UTC OffsetDateTime.
+        OffsetDateTime createdAt = user.getCreatedAt() == null
+                ? null
+                : user.getCreatedAt().atOffset(ZoneOffset.UTC);
+
         return new Profile(
+                user.getId(),
+                user.getEmail(),
+                user.isEmailVerified(),
+                createdAt,
                 user.getUsername(),
                 null, // avatar — плейсхолдер, колонки в схеме нет.
                 plantsTotal,
@@ -92,7 +122,15 @@ public class UserProfileService {
                 user.getQuietHoursStart(),
                 user.getQuietHoursEnd(),
                 user.getTimezone(),
-                user.getLocale()
+                user.getLocale(),
+                user.isSeasonalEnabled(),
+                user.getSeasonalMode(),
+                user.isWeatherEnabled(),
+                Map.copyOf(user.getFeatureFlags()),
+                user.getAppleSubject() != null,
+                user.getGoogleSubject() != null,
+                user.getEmail() != null,
+                user.getTelegramChatId() != null
         );
     }
 
@@ -104,6 +142,18 @@ public class UserProfileService {
      */
     @Transactional
     public Profile updateProfile(User user, ProfileUpdate update) {
+        // Тихие часы: эффективные значения с учётом текущих (если передано только одно поле).
+        // Совпадение начала и конца недопустимо (пустой/неоднозначный интервал) → 400.
+        LocalTime effectiveStart = update.quietHoursStart() != null
+                ? update.quietHoursStart() : user.getQuietHoursStart();
+        LocalTime effectiveEnd = update.quietHoursEnd() != null
+                ? update.quietHoursEnd() : user.getQuietHoursEnd();
+        if ((update.quietHoursStart() != null || update.quietHoursEnd() != null)
+                && effectiveStart.equals(effectiveEnd)) {
+            throw new IllegalArgumentException(
+                    "quietHoursStart must not equal quietHoursEnd: " + effectiveStart);
+        }
+
         if (update.quietHoursStart() != null) {
             userSettingsService.setQuietHoursStart(user, update.quietHoursStart());
         }
@@ -116,11 +166,25 @@ public class UserProfileService {
         }
         if (update.locale() != null) {
             user.setLocale(update.locale());
-            userRepository.save(user);
         }
+        // Сезонность/погода — простые тогглы, влияют только на ленивый расчёт next_due_at,
+        // пересчёт расписаний не нужен (в отличие от смены таймзоны).
+        if (update.seasonalEnabled() != null) {
+            user.setSeasonalEnabled(update.seasonalEnabled());
+        }
+        if (update.seasonalMode() != null) {
+            user.setSeasonalMode(update.seasonalMode());
+        }
+        if (update.weatherEnabled() != null) {
+            user.setWeatherEnabled(update.weatherEnabled());
+        }
+        userRepository.save(user);
 
-        log.info("PATCH /me applied: userId={}, tzChanged={}, localeChanged={}",
-                user.getId(), update.timezone() != null, update.locale() != null);
+        log.info("PATCH /me applied: userId={}, tzChanged={}, localeChanged={}, "
+                        + "seasonalEnabledChanged={}, seasonalModeChanged={}, weatherEnabledChanged={}",
+                user.getId(), update.timezone() != null, update.locale() != null,
+                update.seasonalEnabled() != null, update.seasonalMode() != null,
+                update.weatherEnabled() != null);
 
         return getProfile(user);
     }

--- a/src/main/resources/openapi/resources/me.yaml
+++ b/src/main/resources/openapi/resources/me.yaml
@@ -36,7 +36,9 @@ paths:
 
         Смена `timezone` пересчитывает активные расписания так, чтобы локальное
         время дня сохранилось (полить в 9:00 остаётся 9:00 в новой зоне).
-        Невалидный IANA-идентификатор → `400`.
+        Невалидный IANA-идентификатор → `400`. Совпадение тихих часов
+        (`quietHoursStart == quietHoursEnd`, в т.ч. с учётом текущего значения,
+        если передано только одно поле) → `400`.
       security:
         - bearerAuth: []
       requestBody:
@@ -65,6 +67,9 @@ schemas:
     type: object
     description: Профиль и настройки текущего пользователя (`GET /api/v1/me`).
     required:
+      - id
+      - emailVerified
+      - createdAt
       - name
       - plantsTotal
       - tasksToday
@@ -73,7 +78,34 @@ schemas:
       - quietHoursEnd
       - timezone
       - locale
+      - seasonalEnabled
+      - seasonalMode
+      - weatherEnabled
+      - featureFlags
+      - appleLinked
+      - googleLinked
+      - emailLinked
+      - telegramLinked
     properties:
+      id:
+        type: integer
+        format: int64
+        description: Идентификатор пользователя.
+        example: 42
+      email:
+        type: string
+        nullable: true
+        description: Email пользователя. `null` для чисто Telegram-юзеров.
+        example: user@example.com
+      emailVerified:
+        type: boolean
+        description: Подтверждён ли email (magic link / verified OAuth-провайдером).
+        example: false
+      createdAt:
+        type: string
+        format: date-time
+        description: Момент регистрации пользователя (UTC).
+        example: '2026-01-15T08:30:00Z'
       name:
         type: string
         nullable: true
@@ -128,6 +160,43 @@ schemas:
         enum: [ru, en]
         description: Язык интерфейса/уведомлений.
         example: ru
+      seasonalEnabled:
+        type: boolean
+        description: Учитывать сезоны при расчёте следующего полива.
+        example: false
+      seasonalMode:
+        type: string
+        enum: [MULTIPLIER, FIXED]
+        description: |
+          Режим сезонности: `MULTIPLIER` (коэффициент к базовому интервалу) или
+          `FIXED` (фиксированные интервалы на сезон).
+        example: MULTIPLIER
+      weatherEnabled:
+        type: boolean
+        description: Учитывать погоду в рекомендациях.
+        example: false
+      featureFlags:
+        type: object
+        additionalProperties: true
+        description: 'Per-user feature flags, например `{ "sharing": "true" }`.'
+        example:
+          sharing: 'true'
+      appleLinked:
+        type: boolean
+        description: Привязан ли Sign in with Apple.
+        example: false
+      googleLinked:
+        type: boolean
+        description: Привязан ли Google.
+        example: false
+      emailLinked:
+        type: boolean
+        description: Задан ли email для входа.
+        example: true
+      telegramLinked:
+        type: boolean
+        description: Привязан ли Telegram-аккаунт.
+        example: true
 
   MeUpdateRequest:
     type: object
@@ -158,3 +227,19 @@ schemas:
         nullable: true
         description: Язык интерфейса/уведомлений. Допустимые значения — `ru` или `en`.
         example: en
+      seasonalEnabled:
+        type: boolean
+        nullable: true
+        description: Учитывать сезоны при расчёте следующего полива.
+        example: true
+      seasonalMode:
+        type: string
+        pattern: '^(MULTIPLIER|FIXED)$'
+        nullable: true
+        description: Режим сезонности. Допустимые значения — `MULTIPLIER` или `FIXED`.
+        example: MULTIPLIER
+      weatherEnabled:
+        type: boolean
+        nullable: true
+        description: Учитывать погоду в рекомендациях.
+        example: true

--- a/src/test/java/com/plantcare/api/v1/MeControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/MeControllerTest.java
@@ -4,6 +4,7 @@ import com.plantcare.api.ApiExceptionHandler;
 import com.plantcare.api.CurrentUserProvider;
 import com.plantcare.api.auth.exception.AuthTokenException;
 import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.SeasonalMode;
 import com.plantcare.core.service.UserProfileService;
 import com.plantcare.core.service.UserProfileService.Profile;
 import com.plantcare.core.service.UserProfileService.ProfileUpdate;
@@ -19,10 +20,12 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -33,21 +36,26 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * Слайс-тест {@link MeController} (issue #182) — JSON-форма {@code GET /api/v1/me},
- * PATCH-семантика частичного апдейта, маппинг ошибок (400 на невалидный IANA-tz и
- * на нарушение {@code @Pattern} тихих часов), 401 без аутентификации.
+ * Слайс-тест {@link MeController} (issue #182 + расширение #180) — JSON-форма
+ * {@code GET /api/v1/me} (включая новые поля профиля и linkage-booleans), allow-list
+ * (наружу не утекают чувствительные колонки), PATCH-семантика частичного апдейта
+ * (включая seasonal/weather тогглы), маппинг ошибок (400 на невалидный IANA-tz, на
+ * совпадение тихих часов, на нарушение {@code @Pattern}, на плохой enum), 401 без
+ * аутентификации.
  *
  * <p>{@link UserProfileService} замокан — здесь проверяется только веб-слой:
  * сериализация {@link Profile} → {@code MeResponse}, парсинг/маппинг тела PATCH в
  * {@link ProfileUpdate} и Bean Validation сгенерированного DTO до бизнес-логики.
- * Зеркалит {@link ReportsControllerTest}/{@link ShoppingControllerTest}: фильтры
- * выключены, импортируется {@link ApiExceptionHandler}, {@link CurrentUserProvider}
- * застаблен на текущего пользователя.
+ * Фильтры выключены, импортируется {@link ApiExceptionHandler},
+ * {@link CurrentUserProvider} застаблен на текущего пользователя.
  */
 @WebMvcTest(MeController.class)
 @Import(ApiExceptionHandler.class)
 @AutoConfigureMockMvc(addFilters = false)
 class MeControllerTest {
+
+    private static final OffsetDateTime CREATED_AT =
+            OffsetDateTime.of(2026, 1, 15, 8, 30, 0, 0, ZoneOffset.UTC);
 
     @Autowired
     private MockMvc mockMvc;
@@ -68,17 +76,26 @@ class MeControllerTest {
     // ------------------------------------------------------------------ GET happy
 
     @Test
-    void should_return_full_profile_shape_with_hhmm_quiet_hours_when_getting_me() throws Exception {
-        // arrange — AC #1: профиль + счётчики + настройки; quietHours форматируются в HH:mm
+    void should_return_full_extended_profile_shape_with_linkage_booleans_when_getting_me() throws Exception {
+        // arrange — AC #1: расширенная форма #180 — id/email/emailVerified/createdAt,
+        // seasonalMode-строка, featureFlags-map и linkage booleans
         Profile profile = new Profile(
+                42L, "user@example.com", true, CREATED_AT,
                 "Антон", null, 12, 3, 0,
                 LocalTime.of(22, 0), LocalTime.of(8, 0),
-                "Europe/Moscow", "ru");
+                "Europe/Moscow", "ru",
+                true, SeasonalMode.FIXED, true,
+                Map.of("sharing", "true"),
+                true, false, true, true);
         when(userProfileService.getProfile(any(User.class))).thenReturn(profile);
 
         // act + assert
         mockMvc.perform(get("/api/v1/me"))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(42))
+                .andExpect(jsonPath("$.email").value("user@example.com"))
+                .andExpect(jsonPath("$.emailVerified").value(true))
+                .andExpect(jsonPath("$.createdAt").exists())
                 .andExpect(jsonPath("$.name").value("Антон"))
                 .andExpect(jsonPath("$.avatar").value(org.hamcrest.Matchers.nullValue()))
                 .andExpect(jsonPath("$.plantsTotal").value(12))
@@ -87,15 +104,73 @@ class MeControllerTest {
                 .andExpect(jsonPath("$.quietHoursStart").value("22:00"))
                 .andExpect(jsonPath("$.quietHoursEnd").value("08:00"))
                 .andExpect(jsonPath("$.timezone").value("Europe/Moscow"))
-                .andExpect(jsonPath("$.locale").value("ru"));
+                .andExpect(jsonPath("$.locale").value("ru"))
+                .andExpect(jsonPath("$.seasonalEnabled").value(true))
+                .andExpect(jsonPath("$.seasonalMode").value("FIXED"))
+                .andExpect(jsonPath("$.weatherEnabled").value(true))
+                .andExpect(jsonPath("$.featureFlags.sharing").value("true"))
+                .andExpect(jsonPath("$.appleLinked").value(true))
+                .andExpect(jsonPath("$.googleLinked").value(false))
+                .andExpect(jsonPath("$.emailLinked").value(true))
+                .andExpect(jsonPath("$.telegramLinked").value(true));
+    }
+
+    @Test
+    void should_not_leak_sensitive_columns_in_me_response_when_getting_me() throws Exception {
+        // arrange — AC #2 (CRITICAL, leak-regression guard): наружу НЕ должны утекать
+        // appleSubject/googleSubject/telegramChatId/calendarToken/stateData/
+        // conversationState/isBlocked/weatherLat/weatherLon. Профиль их даже не несёт —
+        // assert на отсутствие JSON-путей ловит регрессию, если кто-то добавит их в MeResponse.
+        Profile profile = new Profile(
+                42L, "user@example.com", true, CREATED_AT,
+                "Антон", null, 1, 0, 0,
+                LocalTime.of(22, 0), LocalTime.of(8, 0),
+                "Europe/Moscow", "ru",
+                false, SeasonalMode.MULTIPLIER, false,
+                Map.of(),
+                true, false, true, true);
+        when(userProfileService.getProfile(any(User.class))).thenReturn(profile);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.appleSubject").doesNotExist())
+                .andExpect(jsonPath("$.googleSubject").doesNotExist())
+                .andExpect(jsonPath("$.telegramChatId").doesNotExist())
+                .andExpect(jsonPath("$.calendarToken").doesNotExist())
+                .andExpect(jsonPath("$.stateData").doesNotExist())
+                .andExpect(jsonPath("$.conversationState").doesNotExist())
+                .andExpect(jsonPath("$.isBlocked").doesNotExist())
+                .andExpect(jsonPath("$.blocked").doesNotExist())
+                .andExpect(jsonPath("$.weatherLat").doesNotExist())
+                .andExpect(jsonPath("$.weatherLon").doesNotExist());
+    }
+
+    @Test
+    void should_serialize_null_email_when_telegram_only_user() throws Exception {
+        // arrange — edge: чисто Telegram-юзер, email == null, emailLinked == false
+        Profile profile = new Profile(
+                42L, null, false, CREATED_AT,
+                "Аноним", null, 0, 0, 0,
+                LocalTime.of(22, 0), LocalTime.of(9, 0),
+                "UTC", "ru",
+                false, SeasonalMode.MULTIPLIER, false,
+                Map.of(),
+                false, false, false, true);
+        when(userProfileService.getProfile(any(User.class))).thenReturn(profile);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.emailLinked").value(false))
+                .andExpect(jsonPath("$.telegramLinked").value(true));
     }
 
     @Test
     void should_pass_current_user_not_request_to_service_when_getting_me() throws Exception {
         // arrange — скоуп берётся из CurrentUserProvider
-        Profile profile = new Profile("Аноним", null, 0, 0, 0,
-                LocalTime.of(22, 0), LocalTime.of(9, 0), "UTC", "ru");
-        when(userProfileService.getProfile(any(User.class))).thenReturn(profile);
+        when(userProfileService.getProfile(any(User.class))).thenReturn(sampleProfile());
 
         // act
         mockMvc.perform(get("/api/v1/me")).andExpect(status().isOk());
@@ -110,7 +185,7 @@ class MeControllerTest {
 
     @Test
     void should_send_only_locale_and_leave_other_fields_null_when_patching_locale_only() throws Exception {
-        // arrange — AC #2: тело только с locale; omitted-поля НЕ должны занулять остальное
+        // arrange — AC #3: тело только с locale; omitted-поля НЕ должны занулять остальное
         stubUpdateEcho();
 
         String body = """
@@ -129,11 +204,14 @@ class MeControllerTest {
         assertThat(sent.quietHoursStart()).isNull();
         assertThat(sent.quietHoursEnd()).isNull();
         assertThat(sent.timezone()).isNull();
+        assertThat(sent.seasonalEnabled()).isNull();
+        assertThat(sent.seasonalMode()).isNull();
+        assertThat(sent.weatherEnabled()).isNull();
     }
 
     @Test
     void should_send_only_quiet_hours_and_leave_tz_locale_null_when_patching_quiet_hours_only() throws Exception {
-        // arrange — AC #2: только тихие часы; tz/locale не трогаем
+        // arrange — AC #3: только тихие часы; tz/locale/seasonal/weather не трогаем
         stubUpdateEcho();
 
         String body = """
@@ -155,8 +233,47 @@ class MeControllerTest {
     }
 
     @Test
+    void should_send_only_seasonal_and_weather_toggles_when_patching_them() throws Exception {
+        // arrange — AC #3: {seasonalEnabled, seasonalMode, weatherEnabled} обновляют только себя,
+        // остальные поля апдейта остаются null (partial semantics)
+        Profile updated = new Profile(
+                42L, "user@example.com", true, CREATED_AT,
+                "Антон", null, 1, 0, 0,
+                LocalTime.of(22, 0), LocalTime.of(8, 0),
+                "Europe/Moscow", "ru",
+                true, SeasonalMode.FIXED, true,
+                Map.of(),
+                false, false, true, true);
+        when(userProfileService.updateProfile(any(User.class), any(ProfileUpdate.class)))
+                .thenReturn(updated);
+
+        String body = """
+                {"seasonalEnabled": true, "seasonalMode": "FIXED", "weatherEnabled": true}
+                """;
+
+        // act + assert — ответ отражает новые тогглы
+        mockMvc.perform(patch("/api/v1/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.seasonalEnabled").value(true))
+                .andExpect(jsonPath("$.seasonalMode").value("FIXED"))
+                .andExpect(jsonPath("$.weatherEnabled").value(true));
+
+        // assert — в сервис ушли только тогглы, остальное null
+        ProfileUpdate sent = captureUpdate();
+        assertThat(sent.seasonalEnabled()).isTrue();
+        assertThat(sent.seasonalMode()).isEqualTo(SeasonalMode.FIXED);
+        assertThat(sent.weatherEnabled()).isTrue();
+        assertThat(sent.quietHoursStart()).isNull();
+        assertThat(sent.quietHoursEnd()).isNull();
+        assertThat(sent.timezone()).isNull();
+        assertThat(sent.locale()).isNull();
+    }
+
+    @Test
     void should_send_empty_update_when_patch_body_is_empty_object() throws Exception {
-        // arrange — AC #2 граница: пустое тело = ничего не менять, все поля null
+        // arrange — AC #3 граница: пустое тело = ничего не менять, все поля null
         stubUpdateEcho();
 
         // act
@@ -171,15 +288,24 @@ class MeControllerTest {
         assertThat(sent.quietHoursEnd()).isNull();
         assertThat(sent.timezone()).isNull();
         assertThat(sent.locale()).isNull();
+        assertThat(sent.seasonalEnabled()).isNull();
+        assertThat(sent.seasonalMode()).isNull();
+        assertThat(sent.weatherEnabled()).isNull();
     }
 
     // ------------------------------------------------------------------ PATCH timezone
 
     @Test
     void should_pass_iana_timezone_through_and_reflect_in_response_when_patching_timezone() throws Exception {
-        // arrange — AC #3: валидный IANA tz прокидывается в сервис и возвращается в ответе
-        Profile updated = new Profile("Антон", null, 1, 0, 0,
-                LocalTime.of(22, 0), LocalTime.of(9, 0), "Asia/Almaty", "ru");
+        // arrange — AC: валидный IANA tz прокидывается в сервис и возвращается в ответе
+        Profile updated = new Profile(
+                42L, "user@example.com", true, CREATED_AT,
+                "Антон", null, 1, 0, 0,
+                LocalTime.of(22, 0), LocalTime.of(9, 0),
+                "Asia/Almaty", "ru",
+                false, SeasonalMode.MULTIPLIER, false,
+                Map.of(),
+                false, false, true, true);
         when(userProfileService.updateProfile(any(User.class), any(ProfileUpdate.class)))
                 .thenReturn(updated);
 
@@ -202,7 +328,7 @@ class MeControllerTest {
 
     @Test
     void should_return_400_bad_request_when_timezone_is_not_valid_iana() throws Exception {
-        // arrange — AC #5: сервис кидает IllegalArgumentException на невалидный IANA-id
+        // arrange — сервис кидает IllegalArgumentException на невалидный IANA-id
         when(userProfileService.updateProfile(any(User.class), any(ProfileUpdate.class)))
                 .thenThrow(new IllegalArgumentException("Invalid IANA timezone: Mars/Phobos"));
 
@@ -219,8 +345,27 @@ class MeControllerTest {
     }
 
     @Test
+    void should_return_400_bad_request_when_quiet_hours_start_equals_end() throws Exception {
+        // arrange — AC #4(a): сервис кидает IllegalArgumentException при равных тихих часах
+        when(userProfileService.updateProfile(any(User.class), any(ProfileUpdate.class)))
+                .thenThrow(new IllegalArgumentException(
+                        "quietHoursStart must not equal quietHoursEnd: 22:00"));
+
+        String body = """
+                {"quietHoursStart": "22:00", "quietHoursEnd": "22:00"}
+                """;
+
+        // act + assert — оба поля прошли @Pattern, бизнес-валидация в сервисе → 400 BAD_REQUEST
+        mockMvc.perform(patch("/api/v1/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("BAD_REQUEST"));
+    }
+
+    @Test
     void should_return_400_validation_error_when_quiet_hours_format_is_invalid() throws Exception {
-        // arrange — AC #6: "25:99" нарушает @Pattern(^([01]\d|2[0-3]):[0-5]\d$) на DTO,
+        // arrange — "25:99" нарушает @Pattern(^([01]\d|2[0-3]):[0-5]\d$) на DTO,
         // отбивается Bean Validation ДО сервиса
         String body = """
                 {"quietHoursStart": "25:99"}
@@ -238,7 +383,7 @@ class MeControllerTest {
 
     @Test
     void should_return_400_validation_error_when_quiet_hours_end_has_bad_separator() throws Exception {
-        // arrange — AC #6: "08-00" (дефис вместо двоеточия) тоже не проходит @Pattern
+        // arrange — "08-00" (дефис вместо двоеточия) тоже не проходит @Pattern
         String body = """
                 {"quietHoursEnd": "08-00"}
                 """;
@@ -255,10 +400,29 @@ class MeControllerTest {
 
     @Test
     void should_return_400_when_locale_not_ru_or_en() throws Exception {
-        // arrange — AC #6 (locale): на DTO стоит @Pattern(^(ru|en)$), поэтому "de"
+        // arrange — на DTO стоит @Pattern(^(ru|en)$), поэтому "de"
         // отбивается Bean Validation ДО сервиса — тот же путь, что у тихих часов
         String body = """
                 {"locale": "de"}
+                """;
+
+        // act + assert
+        mockMvc.perform(patch("/api/v1/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+
+        verify(userProfileService, never()).updateProfile(any(User.class), any(ProfileUpdate.class));
+    }
+
+    @Test
+    void should_return_400_when_seasonal_mode_not_multiplier_or_fixed() throws Exception {
+        // arrange — AC #5: на DTO теперь стоит @Pattern(^(MULTIPLIER|FIXED)$) (как у locale),
+        // поэтому "WEEKLY" (вне допустимых режимов) отбивается Bean Validation ДО сервиса —
+        // тот же путь 400 VALIDATION_ERROR, что у плохого locale и тихих часов.
+        String body = """
+                {"seasonalMode": "WEEKLY"}
                 """;
 
         // act + assert
@@ -287,10 +451,19 @@ class MeControllerTest {
 
     /** Возвращает «как есть» собранный профиль, чтобы PATCH вернул 200 и не падал на null. */
     private void stubUpdateEcho() {
-        Profile echo = new Profile("Антон", null, 0, 0, 0,
-                LocalTime.of(22, 0), LocalTime.of(9, 0), "Europe/Moscow", "ru");
         when(userProfileService.updateProfile(any(User.class), any(ProfileUpdate.class)))
-                .thenReturn(echo);
+                .thenReturn(sampleProfile());
+    }
+
+    private static Profile sampleProfile() {
+        return new Profile(
+                42L, "user@example.com", true, CREATED_AT,
+                "Антон", null, 0, 0, 0,
+                LocalTime.of(22, 0), LocalTime.of(9, 0),
+                "Europe/Moscow", "ru",
+                false, SeasonalMode.MULTIPLIER, false,
+                Map.of(),
+                false, false, true, true);
     }
 
     private ProfileUpdate captureUpdate() {

--- a/src/test/java/com/plantcare/core/service/UserProfileServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/UserProfileServiceTest.java
@@ -6,6 +6,7 @@ import com.plantcare.core.domain.CareSchedule;
 import com.plantcare.core.domain.Location;
 import com.plantcare.core.domain.Plant;
 import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.SeasonalMode;
 import com.plantcare.core.domain.enums.TaskType;
 import com.plantcare.core.repository.CareHistoryRepository;
 import com.plantcare.core.repository.CareScheduleRepository;
@@ -30,6 +31,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -49,7 +51,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
  * в профиле; TZ-кейс на границе суток (tasksToday в зоне юзера, не UTC); невалидный
  * IANA-tz → IllegalArgumentException.
  */
-@DisplayName("UserProfileService — профиль и настройки /me (issue #182)")
+@DisplayName("UserProfileService — профиль и настройки /me (issue #182 + #180)")
 @Import(UserProfileServiceTest.FixedClockConfig.class)
 class UserProfileServiceTest extends IntegrationTestBase {
 
@@ -111,6 +113,49 @@ class UserProfileServiceTest extends IntegrationTestBase {
             softly.assertThat(profile.quietHoursEnd()).isEqualTo(LocalTime.of(8, 0));
             softly.assertThat(profile.timezone()).isEqualTo("UTC");
             softly.assertThat(profile.locale()).isEqualTo("ru");
+        });
+    }
+
+    @Test
+    @DisplayName("should_map_extended_profile_fields_and_linkage_booleans_when_building_profile")
+    void should_map_extended_profile_fields_and_linkage_booleans_when_building_profile() {
+        // arrange — AC #1 (#180): email + appleSubject заданы, googleSubject null,
+        // telegramChatId задан; featureFlags непустой; seasonalEnabled/mode/weatherEnabled заданы
+        User user = userRepository.save(User.builder()
+                .telegramChatId(8100L)
+                .username("Антон")
+                .email("anton@example.com")
+                .emailVerified(true)
+                .appleSubject("apple-sub-123")
+                .googleSubject(null)
+                .timezone("Europe/Moscow")
+                .quietHoursStart(LocalTime.of(22, 0))
+                .quietHoursEnd(LocalTime.of(8, 0))
+                .locale("ru")
+                .seasonalEnabled(true)
+                .seasonalMode(SeasonalMode.FIXED)
+                .weatherEnabled(true)
+                .featureFlags(Map.of("sharing", "true"))
+                .blocked(false)
+                .build());
+
+        // act
+        Profile profile = service.getProfile(user);
+
+        // assert — новые поля и linkage-booleans смаплены корректно
+        assertSoftly(softly -> {
+            softly.assertThat(profile.id()).isEqualTo(user.getId());
+            softly.assertThat(profile.email()).isEqualTo("anton@example.com");
+            softly.assertThat(profile.emailVerified()).isTrue();
+            softly.assertThat(profile.createdAt()).isNotNull();
+            softly.assertThat(profile.seasonalEnabled()).isTrue();
+            softly.assertThat(profile.seasonalMode()).isEqualTo(SeasonalMode.FIXED);
+            softly.assertThat(profile.weatherEnabled()).isTrue();
+            softly.assertThat(profile.featureFlags()).containsEntry("sharing", "true");
+            softly.assertThat(profile.appleLinked()).as("appleSubject задан").isTrue();
+            softly.assertThat(profile.googleLinked()).as("googleSubject null").isFalse();
+            softly.assertThat(profile.emailLinked()).as("email задан").isTrue();
+            softly.assertThat(profile.telegramLinked()).as("telegramChatId задан").isTrue();
         });
     }
 
@@ -215,7 +260,7 @@ class UserProfileServiceTest extends IntegrationTestBase {
 
         // act
         Profile updated = service.updateProfile(user,
-                new ProfileUpdate(null, null, null, "en"));
+                new ProfileUpdate(null, null, null, "en", null, null, null));
 
         // assert — locale изменился, остальное на месте
         assertSoftly(softly -> {
@@ -239,7 +284,7 @@ class UserProfileServiceTest extends IntegrationTestBase {
 
         // act
         Profile updated = service.updateProfile(user,
-                new ProfileUpdate(LocalTime.of(23, 0), LocalTime.of(7, 30), null, null));
+                new ProfileUpdate(LocalTime.of(23, 0), LocalTime.of(7, 30), null, null, null, null, null));
 
         // assert
         assertSoftly(softly -> {
@@ -265,7 +310,7 @@ class UserProfileServiceTest extends IntegrationTestBase {
 
         // act
         Profile updated = service.updateProfile(user,
-                new ProfileUpdate(null, null, null, null));
+                new ProfileUpdate(null, null, null, null, null, null, null));
 
         // assert
         assertSoftly(softly -> {
@@ -273,6 +318,37 @@ class UserProfileServiceTest extends IntegrationTestBase {
             softly.assertThat(updated.locale()).isEqualTo("en");
             softly.assertThat(updated.quietHoursStart()).isEqualTo(LocalTime.of(21, 0));
             softly.assertThat(updated.quietHoursEnd()).isEqualTo(LocalTime.of(6, 0));
+        });
+    }
+
+    @Test
+    @DisplayName("should_update_only_seasonal_and_weather_toggles_and_leave_others_untouched")
+    void should_update_only_seasonal_and_weather_toggles_and_leave_others_untouched() {
+        // arrange — AC #3 (#180): юзер с дефолтными тогглами (seasonal off, MULTIPLIER, weather off)
+        User user = savedUser(8012L, "Europe/Moscow", LocalTime.of(22, 0), LocalTime.of(8, 0), "ru");
+
+        // act — включаем seasonal+weather, режим FIXED; остальное не трогаем
+        Profile updated = service.updateProfile(user,
+                new ProfileUpdate(null, null, null, null, true, SeasonalMode.FIXED, true));
+
+        // assert — изменились только тогглы; tz/locale/quietHours без изменений
+        assertSoftly(softly -> {
+            softly.assertThat(updated.seasonalEnabled()).isTrue();
+            softly.assertThat(updated.seasonalMode()).isEqualTo(SeasonalMode.FIXED);
+            softly.assertThat(updated.weatherEnabled()).isTrue();
+            softly.assertThat(updated.timezone()).isEqualTo("Europe/Moscow");
+            softly.assertThat(updated.locale()).isEqualTo("ru");
+            softly.assertThat(updated.quietHoursStart()).isEqualTo(LocalTime.of(22, 0));
+            softly.assertThat(updated.quietHoursEnd()).isEqualTo(LocalTime.of(8, 0));
+        });
+
+        // assert — изменения реально записаны в БД
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(reloaded.isSeasonalEnabled()).isTrue();
+            softly.assertThat(reloaded.getSeasonalMode()).isEqualTo(SeasonalMode.FIXED);
+            softly.assertThat(reloaded.isWeatherEnabled()).isTrue();
+            softly.assertThat(reloaded.getTimezone()).isEqualTo("Europe/Moscow");
         });
     }
 
@@ -286,7 +362,7 @@ class UserProfileServiceTest extends IntegrationTestBase {
 
         // act
         Profile updated = service.updateProfile(user,
-                new ProfileUpdate(null, null, "Asia/Almaty", null));
+                new ProfileUpdate(null, null, "Asia/Almaty", null, null, null, null));
 
         // assert
         assertThat(updated.timezone()).isEqualTo("Asia/Almaty");
@@ -304,9 +380,59 @@ class UserProfileServiceTest extends IntegrationTestBase {
 
         // act + assert
         assertThatThrownBy(() -> service.updateProfile(user,
-                new ProfileUpdate(null, null, "Mars/Phobos", null)))
+                new ProfileUpdate(null, null, "Mars/Phobos", null, null, null, null)))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Mars/Phobos");
+    }
+
+    @Test
+    @DisplayName("should_throw_when_both_quiet_hours_start_and_end_are_equal")
+    void should_throw_when_both_quiet_hours_start_and_end_are_equal() {
+        // arrange — AC #4(a): оба поля переданы и совпадают → пустой/неоднозначный интервал
+        User user = savedUser(8013L, "Europe/Moscow", LocalTime.of(22, 0), LocalTime.of(8, 0), "ru");
+
+        // act + assert
+        assertThatThrownBy(() -> service.updateProfile(user,
+                new ProfileUpdate(LocalTime.of(7, 0), LocalTime.of(7, 0), null, null, null, null, null)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("quietHoursStart");
+
+        // assert — ничего не записалось (значения остались исходными)
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(reloaded.getQuietHoursStart()).isEqualTo(LocalTime.of(22, 0));
+        assertThat(reloaded.getQuietHoursEnd()).isEqualTo(LocalTime.of(8, 0));
+    }
+
+    @Test
+    @DisplayName("should_throw_when_only_start_passed_and_it_equals_current_end")
+    void should_throw_when_only_start_passed_and_it_equals_current_end() {
+        // arrange — AC #4(b): single-field кейс — передан только start, равный ТЕКУЩЕМУ end юзера.
+        // Эффективный интервал получается пустым → 400, хотя в теле всего одно поле.
+        User user = savedUser(8014L, "Europe/Moscow", LocalTime.of(22, 0), LocalTime.of(8, 0), "ru");
+
+        // act + assert — start = 08:00 совпадёт с текущим end = 08:00
+        assertThatThrownBy(() -> service.updateProfile(user,
+                new ProfileUpdate(LocalTime.of(8, 0), null, null, null, null, null, null)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("quietHoursStart");
+
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(reloaded.getQuietHoursStart()).isEqualTo(LocalTime.of(22, 0));
+    }
+
+    @Test
+    @DisplayName("should_not_throw_when_quiet_hours_start_differs_from_end")
+    void should_not_throw_when_quiet_hours_start_differs_from_end() {
+        // arrange — AC #4(c): start != end → апдейт проходит
+        User user = savedUser(8015L, "Europe/Moscow", LocalTime.of(22, 0), LocalTime.of(8, 0), "ru");
+
+        // act
+        Profile updated = service.updateProfile(user,
+                new ProfileUpdate(LocalTime.of(23, 0), LocalTime.of(7, 0), null, null, null, null, null));
+
+        // assert
+        assertThat(updated.quietHoursStart()).isEqualTo(LocalTime.of(23, 0));
+        assertThat(updated.quietHoursEnd()).isEqualTo(LocalTime.of(7, 0));
     }
 
     // ===================== helpers =====================


### PR DESCRIPTION
Closes #180

## Что сделано
Расширяет **существующий** `GET`/`PATCH /api/v1/me` (из #182), как договорились — единый эндпоинт, **без** отдельного `PATCH /me/settings`.

**`GET /me`** дополнительно отдаёт: `id`, `email`, `emailVerified`, `createdAt` (UTC), `seasonalEnabled`, `seasonalMode`, `weatherEnabled`, `featureFlags`, и булевы привязки `appleLinked`/`googleLinked`/`emailLinked`/`telegramLinked`.

**`PATCH /me`** дополнительно принимает опциональные `seasonalEnabled`, `seasonalMode`, `weatherEnabled` (partial-update, null = без изменений). timezone по-прежнему через `UserSettingsService.changeTimezone` (пересчёт расписаний), quietHours через `UserSettingsService`.

**Новая валидация:** `quietHoursStart == quietHoursEnd` → **400** (учитывает текущее значение, когда передано только одно из полей). `seasonalMode` на request-стороне — `@Pattern(^(MULTIPLIER|FIXED)$)` → 400 на мусор (как `locale` в #182), без тихого drop.

## Решения для ревьюера
- **Allow-list (безопасность):** `appleSubject`/`googleSubject`/`telegramChatId`/`calendarToken`/`stateData`/`conversationState`/`isBlocked`/`weatherLat`/`weatherLon` наружу не уходят — структурно отсутствуют в сгенерированном `MeResponse`; есть тест-регрессия на `doesNotExist()`.
- **`username` vs `name`:** #180 называет `username`, но #182 уже отдаёт его полем `name` (= username). Отдельное дублирующее поле не вводил.
- **Эндпоинт vs `/me/settings`:** AC #180 буквально называет `PATCH /me/settings`, реализовано как расширение `PATCH /me` (продуктовое решение по реконсиляции с #182).
- **featureFlags** — сырой passthrough опт-ин флагов юзера (его собственных). Сейчас ок; на будущее: внутренний ops-флаг в этой колонке утёк бы клиенту (nit от ревьюера).

## Миграции
Нет (все поля уже есть на `users`).

## Backward-compat риски
Safe. Только добавление полей в ответ + опциональных в PATCH; контракт #182 сохранён.

## Тесты
`MeControllerTest` (@WebMvcTest): расширенная форма ответа + привязки, **allow-list `doesNotExist()`**, seasonal/weather тогглы, 400 на `quietHoursStart==End` и на плохой `seasonalMode`. `UserProfileServiceTest` (Testcontainers): маппинг полей/привязок, partial-апдейт тогглов, quietHours-equal (вкл. single-field кейс), не-UTC TZ.

Полный `mvn clean verify`: **1474 теста, 0 failures, 0 errors, BUILD SUCCESS**.

## Чек
- [x] `mvn clean verify` зелёное (1474/0/0)
- [x] reviewer прошёл (0 BLOCKING, 0 SHOULD-FIX, 2 nit)
- [x] allow-list секретов проверен на уровне DTO + тестом

🤖 Generated with [Claude Code](https://claude.com/claude-code)
