### PR TITLE
feat: POST /plants принимает schedules при создании (#216)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 |---|---|---|
 | `GET` | `/api/v1/plants` | Список растений. Параметры: `locationId` (фильтр), `offset` (по умолч. 0), `limit` (по умолч. 20, макс. 100) |
 | `GET` | `/api/v1/plants/{id}` | Одно растение |
-| `POST` | `/api/v1/plants` | Создать растение (без расписания полива) |
+| `POST` | `/api/v1/plants` | Создать растение. Опциональное поле `schedules` позволяет задать расписания сразу при создании |
 | `PUT` | `/api/v1/plants/{id}` | Обновить растение. PATCH-семантика: обновляются только переданные поля (`name`, `notes`, `locationId`) |
 | `DELETE` | `/api/v1/plants/{id}` | Soft-delete: выставляет `archivedAt`, из выборок не возвращается |
 
-При создании растения через REST засеваются все четыре расписания ухода (`WATERING`/`MISTING`/`FERTILIZING`/`SOIL_CHECK`) из дефолтов вида; включён по умолчанию только `WATERING`.
+При создании растения через REST засеваются все четыре расписания ухода (`WATERING`/`MISTING`/`FERTILIZING`/`SOIL_CHECK`). Если массив `schedules` не передан или пуст — применяются дефолты вида, включён по умолчанию только `WATERING`. Если `schedules` передан — переданные типы создаются с `enabled=true` и указанными параметрами (`every`, `unit`, `amountMl?`); отсутствующие типы получают дефолтный интервал с `enabled=false`. Дублирующийся тип в массиве → 400.
 
 ### Schedules (issue #185)
 

--- a/src/main/java/com/plantcare/api/v1/PlantController.java
+++ b/src/main/java/com/plantcare/api/v1/PlantController.java
@@ -11,11 +11,14 @@ import com.plantcare.api.generated.model.PlantFamilyMemberDto;
 import com.plantcare.api.generated.model.PlantFamilyResponse;
 import com.plantcare.api.generated.model.PlantHealthDto;
 import com.plantcare.api.generated.model.PlantUpdateRequest;
+import com.plantcare.api.generated.model.ScheduleInput;
 import com.plantcare.core.domain.Plant;
 import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.TaskType;
 import com.plantcare.core.service.HealthScoreService;
 import com.plantcare.core.service.PlantDiagnosisReportService;
 import com.plantcare.core.service.PlantService;
+import com.plantcare.core.service.PlantService.ScheduleInputDto;
 import com.plantcare.core.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
@@ -66,16 +69,32 @@ public class PlantController implements PlantsApi {
     public PlantDto createPlant(PlantCreateRequest request) {
         User user = userService.getByIdOrThrow(currentUserProvider.currentUserId());
 
+        List<ScheduleInputDto> schedules = toScheduleInputDtos(request.getSchedules());
+
         Plant plant = plantService.createPlant(
                 user,
                 request.getName(),
                 request.getNotes(),
                 request.getLocationId(),
                 request.getSpeciesId(),
-                request.getParentPlantId()
+                request.getParentPlantId(),
+                schedules
         );
 
         return toDto(plant);
+    }
+
+    private static List<ScheduleInputDto> toScheduleInputDtos(List<ScheduleInput> raw) {
+        if (raw == null || raw.isEmpty()) {
+            return null;
+        }
+        return raw.stream()
+                .map(s -> new ScheduleInputDto(
+                        TaskType.valueOf(s.getType().getValue()),
+                        s.getEvery(),
+                        s.getAmountMl()
+                ))
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/plantcare/core/service/PlantService.java
+++ b/src/main/java/com/plantcare/core/service/PlantService.java
@@ -22,6 +22,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -40,6 +41,7 @@ public class PlantService {
     private final com.plantcare.core.seasonal.service.SeasonalIntervalService seasonalIntervalService;
     private final HealthScoreService healthScoreService;
     private final PlantDiagnosisReportService plantDiagnosisReportService;
+    private final Clock clock;
 
     @Transactional(readOnly = true)
     public List<Plant> listPlants(Long userId, Long locationId, int offset, int limit) {
@@ -165,6 +167,112 @@ public class PlantService {
         return createPlant(user, name, notes, locationId, speciesId, null);
     }
 
+    /**
+     * Создаёт растение и расписания ухода в одной транзакции.
+     *
+     * <p>Если {@code schedules} null или пуст — применяются дефолтные расписания вида
+     * (как в {@link #createPlantWithDefaultSchedules}). Иначе создаются только
+     * переданные типы с {@code enabled=true}; остальные типы получают дефолтный
+     * интервал с {@code enabled=false}.
+     *
+     * @param schedules опциональные расписания при создании; null или пустой список = дефолты вида
+     * @throws IllegalArgumentException если в {@code schedules} присутствует два элемента с одинаковым {@code type}
+     */
+    @Transactional
+    public Plant createPlant(
+            User user,
+            String name,
+            String notes,
+            Long locationId,
+            Long speciesId,
+            Long parentPlantId,
+            List<ScheduleInputDto> schedules
+    ) {
+        // internal call — already within @Transactional boundary, proxy bypass is intentional
+        Plant plant = createPlant(user, name, notes, locationId, speciesId, parentPlantId);
+
+        if (schedules == null || schedules.isEmpty()) {
+            LocalDateTime now = LocalDateTime.now(clock);
+            for (TaskType type : SCHEDULE_ORDER) {
+                int interval = defaultIntervalFor(plant, type);
+                boolean active = type == TaskType.WATERING;
+                LocalDateTime nextDueAt = active
+                        ? now.plusDays(seasonalIntervalService.effectiveIntervalDays(plant, user, interval))
+                        : now.plusDays(interval);
+                CareSchedule schedule = CareSchedule.builder()
+                        .plant(plant)
+                        .taskType(type)
+                        .intervalDays(interval)
+                        .nextDueAt(nextDueAt)
+                        .active(active)
+                        .build();
+                careScheduleRepository.save(schedule);
+            }
+            log.info("Seeded default schedules for plant {} (user {})", plant.getId(), user.getId());
+        } else {
+            long distinctCount = schedules.stream()
+                    .map(ScheduleInputDto::type)
+                    .distinct()
+                    .count();
+            if (distinctCount != schedules.size()) {
+                throw new IllegalArgumentException("Дублирующийся тип расписания в массиве schedules");
+            }
+
+            java.util.Map<TaskType, ScheduleInputDto> inputMap = schedules.stream()
+                    .collect(java.util.stream.Collectors.toMap(
+                            ScheduleInputDto::type,
+                            s -> s
+                    ));
+
+            LocalDateTime now = LocalDateTime.now(clock);
+            for (TaskType type : SCHEDULE_ORDER) {
+                ScheduleInputDto input = inputMap.get(type);
+                if (input != null) {
+                    int every = input.every();
+                    if (!isValidInterval(every)) {
+                        throw new IllegalArgumentException("Интервал должен быть от 1 до 365 дней: " + type);
+                    }
+                    Integer amountMl = type == TaskType.WATERING ? input.amountMl() : null;
+                    int effectiveInterval = seasonalIntervalService.effectiveIntervalDays(plant, user, every);
+                    CareSchedule schedule = CareSchedule.builder()
+                            .plant(plant)
+                            .taskType(type)
+                            .intervalDays(every)
+                            .amountMl(amountMl)
+                            .nextDueAt(now.plusDays(effectiveInterval))
+                            .active(true)
+                            .build();
+                    careScheduleRepository.save(schedule);
+                } else {
+                    int interval = defaultIntervalFor(plant, type);
+                    CareSchedule schedule = CareSchedule.builder()
+                            .plant(plant)
+                            .taskType(type)
+                            .intervalDays(interval)
+                            .nextDueAt(now.plusDays(interval))
+                            .active(false)
+                            .build();
+                    careScheduleRepository.save(schedule);
+                }
+            }
+            log.info(
+                    "Created {} custom schedule(s) for plant {} (user {})",
+                    schedules.size(),
+                    plant.getId(),
+                    user.getId()
+            );
+        }
+
+        return plant;
+    }
+
+    public record ScheduleInputDto(
+            TaskType type,
+            int every,
+            Integer amountMl
+    ) {
+    }
+
     public record ScheduleView(
             TaskType type,
             int every,
@@ -243,7 +351,7 @@ public class PlantService {
                 every
         );
 
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now(clock);
 
         CareSchedule schedule = careScheduleRepository
                 .findByPlantIdAndTaskType(plant.getId(), type)
@@ -299,7 +407,7 @@ public class PlantService {
     ) {
         Plant plant = createPlant(user, name, notes, locationId, speciesId, null);
 
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now(clock);
 
         for (TaskType type : SCHEDULE_ORDER) {
             int interval = defaultIntervalFor(plant, type);
@@ -763,14 +871,14 @@ public class PlantService {
 
             if (existing.isActive()
                     && existing.getNextDueAt() != null
-                    && existing.getNextDueAt().isBefore(LocalDateTime.now())) {
+                    && existing.getNextDueAt().isBefore(LocalDateTime.now(clock))) {
                 int effective = seasonalIntervalService.effectiveIntervalDays(
                         plant,
                         plant.getUser(),
                         existing.getIntervalDays()
                 );
 
-                existing.rescheduleFrom(LocalDateTime.now(), effective);
+                existing.rescheduleFrom(LocalDateTime.now(clock), effective);
             }
 
             CareSchedule saved = careScheduleRepository.save(existing);
@@ -793,7 +901,7 @@ public class PlantService {
                 defaultInterval
         );
 
-        LocalDateTime nextDueAt = LocalDateTime.now().plusDays(effectiveInterval);
+        LocalDateTime nextDueAt = LocalDateTime.now(clock).plusDays(effectiveInterval);
 
         CareSchedule fresh = CareSchedule.builder()
                 .plant(plant)
@@ -884,7 +992,7 @@ public class PlantService {
             return null;
         }
 
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now(clock);
 
         Optional<CareHistory> lastEntry = careHistoryRepository
                 .findFirstByPlantIdAndTaskTypeOrderByDoneAtDesc(plant.getId(), taskType);
@@ -939,7 +1047,7 @@ public class PlantService {
 
         String locationName = schedules.get(0).getPlant().getLocation().getDisplayName();
 
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now(clock);
         int updated = 0;
         int deduped = 0;
 

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -307,6 +307,8 @@ components:
       $ref: './resources/schedules.yaml#/schemas/CareScheduleDto'
     CareScheduleUpdateRequest:
       $ref: './resources/schedules.yaml#/schemas/CareScheduleUpdateRequest'
+    ScheduleInput:
+      $ref: './resources/schedules.yaml#/schemas/ScheduleInput'
 
     ShoppingItemDto:
       $ref: './resources/shopping.yaml#/schemas/ShoppingItemDto'

--- a/src/main/resources/openapi/resources/plants.yaml
+++ b/src/main/resources/openapi/resources/plants.yaml
@@ -470,6 +470,14 @@ schemas:
           отводком/потомком этого растения. Родитель должен принадлежать текущему
           пользователю и не быть архивированным, иначе 404/403.
         example: 10
+      schedules:
+        type: array
+        nullable: true
+        description: |
+          Опциональные расписания ухода. Если не передан или пуст — применяются
+          дефолты вида (как при обычном создании).
+        items:
+          $ref: '../resources/schedules.yaml#/schemas/ScheduleInput'
 
   PlantUpdateRequest:
     type: object

--- a/src/main/resources/openapi/resources/schedules.yaml
+++ b/src/main/resources/openapi/resources/schedules.yaml
@@ -132,3 +132,30 @@ schemas:
       enabled:
         type: boolean
         example: true
+
+  ScheduleInput:
+    type: object
+    description: Расписание ухода при создании растения.
+    required: [type, every, unit]
+    properties:
+      type:
+        type: string
+        enum: [WATERING, MISTING, FERTILIZING, SOIL_CHECK]
+        example: WATERING
+      every:
+        type: integer
+        format: int32
+        minimum: 1
+        maximum: 365
+        example: 7
+      unit:
+        type: string
+        enum: [DAY]
+        example: DAY
+      amountMl:
+        type: integer
+        format: int32
+        nullable: true
+        minimum: 1
+        description: Объём полива в мл. Только для WATERING.
+        example: 200

--- a/src/test/java/com/plantcare/api/v1/PlantControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/PlantControllerTest.java
@@ -163,6 +163,7 @@ class PlantControllerTest {
                 isNull(),
                 isNull(),
                 isNull(),
+                isNull(),
                 isNull()
         )).thenReturn(plant);
 
@@ -195,6 +196,7 @@ class PlantControllerTest {
                 isNull(),
                 isNull(),
                 eq(7L),
+                isNull(),
                 isNull()
         )).thenReturn(plant);
 
@@ -223,7 +225,8 @@ class PlantControllerTest {
                 isNull(),
                 isNull(),
                 isNull(),
-                eq(10L)
+                eq(10L),
+                isNull()
         )).thenReturn(plant);
 
         String body = """
@@ -428,5 +431,103 @@ class PlantControllerTest {
         mockMvc.perform(get("/api/v1/plants/999/diagnosis"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // ==================== POST /plants with schedules ====================
+
+    @Test
+    void should_create_plant_passing_null_schedules_when_schedules_field_absent() throws Exception {
+        User user = User.builder().telegramChatId(1L).build();
+        Plant plant = mockPlant(20L, 1L, "Ficus");
+
+        when(userService.getByIdOrThrow(1L)).thenReturn(user);
+        when(plantService.createPlant(
+                eq(user),
+                eq("Ficus"),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull()
+        )).thenReturn(plant);
+
+        String body = """
+                {"name": "Ficus"}
+                """;
+
+        mockMvc.perform(post("/api/v1/plants")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(20));
+    }
+
+    @Test
+    void should_create_plant_passing_null_to_service_when_schedules_is_empty_array() throws Exception {
+        // The controller coalesces empty[] → null before calling the service,
+        // so the service receives null (triggering default-schedule creation).
+        User user = User.builder().telegramChatId(1L).build();
+        Plant plant = mockPlant(21L, 1L, "Rose");
+
+        when(userService.getByIdOrThrow(1L)).thenReturn(user);
+        when(plantService.createPlant(
+                eq(user),
+                eq("Rose"),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull()
+        )).thenReturn(plant);
+
+        String body = """
+                {"name": "Rose", "schedules": []}
+                """;
+
+        mockMvc.perform(post("/api/v1/plants")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(21));
+    }
+
+    @Test
+    void should_create_plant_forwarding_schedule_list_to_service_when_schedules_provided() throws Exception {
+        User user = User.builder().telegramChatId(1L).build();
+        Plant plant = mockPlant(22L, 1L, "Monstera");
+
+        var expectedSchedules = java.util.List.of(
+                new PlantService.ScheduleInputDto(
+                        com.plantcare.core.domain.enums.TaskType.WATERING,
+                        5,
+                        150
+                )
+        );
+
+        when(userService.getByIdOrThrow(1L)).thenReturn(user);
+        when(plantService.createPlant(
+                eq(user),
+                eq("Monstera"),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                eq(expectedSchedules)
+        )).thenReturn(plant);
+
+        String body = """
+                {
+                  "name": "Monstera",
+                  "schedules": [
+                    {"type": "WATERING", "every": 5, "unit": "DAY", "amountMl": 150}
+                  ]
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/plants")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(22));
     }
 }

--- a/src/test/java/com/plantcare/api/v1/PlantCreateWithSchedulesIT.java
+++ b/src/test/java/com/plantcare/api/v1/PlantCreateWithSchedulesIT.java
@@ -1,0 +1,261 @@
+package com.plantcare.api.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.plantcare.bot.support.IntegrationTestBase;
+import com.plantcare.core.domain.CareSchedule;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.repository.CareScheduleRepository;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for POST /api/v1/plants with the optional {@code schedules} field.
+ *
+ * <p>Covers issue #216: when a caller supplies explicit schedule types,
+ * only those are created as active; all remaining standard types are
+ * created with {@code active=false} and a default interval.
+ */
+@AutoConfigureMockMvc
+class PlantCreateWithSchedulesIT extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PlantRepository plantRepository;
+
+    @Autowired
+    private CareScheduleRepository scheduleRepository;
+
+    @AfterEach
+    void cleanup() {
+        scheduleRepository.deleteAll();
+        plantRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ==================== happy path ====================
+
+    @Test
+    void should_create_active_watering_schedule_and_inactive_others_when_single_watering_schedule_supplied() throws Exception {
+        // arrange
+        User user = userRepository.save(User.builder()
+                .telegramChatId(9_216_001L)
+                .username("it_schedules_user1")
+                .timezone("UTC")
+                .build());
+
+        String body = """
+                {
+                  "name": "Cactus",
+                  "schedules": [
+                    {"type": "WATERING", "every": 5, "unit": "DAY", "amountMl": 150}
+                  ]
+                }
+                """;
+
+        // act
+        MvcResult result = mockMvc.perform(post("/api/v1/plants")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId()))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Cactus"))
+                .andReturn();
+
+        JsonNode json = objectMapper.readTree(result.getResponse().getContentAsString());
+        long plantId = json.get("id").asLong();
+
+        // assert — plant created
+        assertThat(plantId).isPositive();
+
+        List<CareSchedule> all = scheduleRepository.findAllByPlantId(plantId);
+        Map<TaskType, CareSchedule> byType = all.stream()
+                .collect(Collectors.toMap(CareSchedule::getTaskType, s -> s));
+
+        // all 4 standard types must be present
+        assertThat(byType).containsOnlyKeys(
+                TaskType.WATERING, TaskType.MISTING, TaskType.FERTILIZING, TaskType.SOIL_CHECK);
+
+        // watering: active, interval=5, amountMl=150
+        CareSchedule watering = byType.get(TaskType.WATERING);
+        assertThat(watering.isActive()).isTrue();
+        assertThat(watering.getIntervalDays()).isEqualTo(5);
+        assertThat(watering.getAmountMl()).isEqualTo(150);
+
+        // rest: inactive
+        assertThat(byType.get(TaskType.MISTING).isActive()).isFalse();
+        assertThat(byType.get(TaskType.FERTILIZING).isActive()).isFalse();
+        assertThat(byType.get(TaskType.SOIL_CHECK).isActive()).isFalse();
+    }
+
+    // ==================== edge case: no schedules field ====================
+
+    @Test
+    void should_create_4_schedules_with_watering_active_when_schedules_field_absent() throws Exception {
+        // arrange
+        User user = userRepository.save(User.builder()
+                .telegramChatId(9_216_002L)
+                .username("it_schedules_user2")
+                .timezone("UTC")
+                .build());
+
+        String body = """
+                {"name": "Monstera"}
+                """;
+
+        // act
+        MvcResult result = mockMvc.perform(post("/api/v1/plants")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId()))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        JsonNode json = objectMapper.readTree(result.getResponse().getContentAsString());
+        long plantId = json.get("id").asLong();
+
+        // assert
+        List<CareSchedule> all = scheduleRepository.findAllByPlantId(plantId);
+        Map<TaskType, CareSchedule> byType = all.stream()
+                .collect(Collectors.toMap(CareSchedule::getTaskType, s -> s));
+
+        assertThat(byType).containsOnlyKeys(
+                TaskType.WATERING, TaskType.MISTING, TaskType.FERTILIZING, TaskType.SOIL_CHECK);
+
+        // default behaviour: WATERING active, others inactive
+        assertThat(byType.get(TaskType.WATERING).isActive()).isTrue();
+        assertThat(byType.get(TaskType.MISTING).isActive()).isFalse();
+        assertThat(byType.get(TaskType.FERTILIZING).isActive()).isFalse();
+        assertThat(byType.get(TaskType.SOIL_CHECK).isActive()).isFalse();
+
+        // all schedules have a sensible interval
+        assertThat(byType.get(TaskType.WATERING).getIntervalDays()).isPositive();
+        assertThat(byType.get(TaskType.MISTING).getIntervalDays()).isPositive();
+        assertThat(byType.get(TaskType.FERTILIZING).getIntervalDays()).isPositive();
+        assertThat(byType.get(TaskType.SOIL_CHECK).getIntervalDays()).isPositive();
+    }
+
+    // ==================== edge case: multiple schedules ====================
+
+    @Test
+    void should_mark_only_specified_types_active_when_multiple_schedules_supplied() throws Exception {
+        // arrange
+        User user = userRepository.save(User.builder()
+                .telegramChatId(9_216_003L)
+                .username("it_schedules_user3")
+                .timezone("UTC")
+                .build());
+
+        String body = """
+                {
+                  "name": "Fern",
+                  "schedules": [
+                    {"type": "WATERING",    "every": 3, "unit": "DAY"},
+                    {"type": "FERTILIZING", "every": 14, "unit": "DAY"}
+                  ]
+                }
+                """;
+
+        // act
+        MvcResult result = mockMvc.perform(post("/api/v1/plants")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId()))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        JsonNode json = objectMapper.readTree(result.getResponse().getContentAsString());
+        long plantId = json.get("id").asLong();
+
+        // assert
+        List<CareSchedule> all = scheduleRepository.findAllByPlantId(plantId);
+        Map<TaskType, CareSchedule> byType = all.stream()
+                .collect(Collectors.toMap(CareSchedule::getTaskType, s -> s));
+
+        assertThat(byType).containsOnlyKeys(
+                TaskType.WATERING, TaskType.MISTING, TaskType.FERTILIZING, TaskType.SOIL_CHECK);
+
+        // explicitly supplied → active
+        assertThat(byType.get(TaskType.WATERING).isActive()).isTrue();
+        assertThat(byType.get(TaskType.WATERING).getIntervalDays()).isEqualTo(3);
+
+        assertThat(byType.get(TaskType.FERTILIZING).isActive()).isTrue();
+        assertThat(byType.get(TaskType.FERTILIZING).getIntervalDays()).isEqualTo(14);
+
+        // not supplied → inactive
+        assertThat(byType.get(TaskType.MISTING).isActive()).isFalse();
+        assertThat(byType.get(TaskType.SOIL_CHECK).isActive()).isFalse();
+    }
+
+    // ==================== timezone: non-UTC user ====================
+
+    @Test
+    void should_create_schedule_with_positive_nextDueAt_when_user_has_non_utc_timezone() throws Exception {
+        // arrange
+        User user = userRepository.save(User.builder()
+                .telegramChatId(9_216_004L)
+                .username("it_schedules_user4")
+                .timezone("Asia/Almaty")
+                .build());
+
+        String body = """
+                {
+                  "name": "Aloe",
+                  "schedules": [
+                    {"type": "WATERING", "every": 7, "unit": "DAY"}
+                  ]
+                }
+                """;
+
+        // act
+        MvcResult result = mockMvc.perform(post("/api/v1/plants")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId()))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Aloe"))
+                .andReturn();
+
+        JsonNode json = objectMapper.readTree(result.getResponse().getContentAsString());
+        long plantId = json.get("id").asLong();
+
+        // assert
+        List<CareSchedule> all = scheduleRepository.findAllByPlantId(plantId);
+        Map<TaskType, CareSchedule> byType = all.stream()
+                .collect(Collectors.toMap(CareSchedule::getTaskType, s -> s));
+
+        CareSchedule watering = byType.get(TaskType.WATERING);
+        assertThat(watering).isNotNull();
+        assertThat(watering.isActive()).isTrue();
+        assertThat(watering.getIntervalDays()).isEqualTo(7);
+        assertThat(watering.getNextDueAt()).isAfter(LocalDateTime.now(ZoneOffset.UTC));
+    }
+}


### PR DESCRIPTION
Closes #216

## Что сделано
- `POST /api/v1/plants` принимает опциональный массив `schedules` (WATERING / MISTING / FERTILIZING / SOIL_CHECK)
- Расписания создаются атомарно с растением в одной транзакции
- Если `schedules` отсутствует или пуст — применяются дефолты вида (поведение без изменений)
- Переданные типы получают `enabled=true`, остальные — дефолтный интервал с `enabled=false`
- Дублирующийся тип в массиве возвращает 400 с понятным сообщением
- Весь `PlantService` переведён на инжектируемый `Clock` (было `LocalDateTime.now()` россыпью)

## Миграции
нет

## Backward-compat риски
safe — поле `schedules` опциональное, существующие клиенты без него получают поведение как раньше

## Тесты
- `PlantControllerTest` — 3 новых unit-теста: без schedules, пустой массив, непустой массив
- `PlantCreateWithSchedulesIT` — 4 IT с Testcontainers:
  - happy path: один WATERING, остальные inactive
  - без schedules → 4 записи, только WATERING active
  - несколько типов → только переданные active
  - не-UTC таймзона (Asia/Almaty) → `nextDueAt` в будущем

## Чек
- [x] `mvn test -Dtest=PlantControllerTest,LayeredArchitectureTest` зелёное (27/27)
- [x] PlantCreateWithSchedulesIT компилируется (Docker недоступен на машине — pre-existing)
- [x] reviewer прошёл (2 итерации, все BLOCKING закрыты)