### PR TITLE
feat: сезонные коэффициенты в CareScheduleDto и per-plant toggle (#188)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 
 При создании растения через REST засеваются все четыре расписания ухода (`WATERING`/`MISTING`/`FERTILIZING`/`SOIL_CHECK`) из дефолтов вида; включён по умолчанию только `WATERING`.
 
-### Schedules (issue #185)
+### Schedules (issue #185, #188)
 
 Расписания ухода конкретного растения. У каждого растения ровно четыре расписания по числу типов ухода. Все эндпоинты user-scoped (JWT).
 
@@ -141,13 +141,21 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 | `GET` | `/api/v1/plants/{id}/schedules` | Все четыре расписания в фиксированном порядке. Если расписание ещё не настроено — отдаётся дефолтный интервал вида с `enabled=false` |
 | `PUT` | `/api/v1/plants/{id}/schedules/{type}` | Создать/обновить расписание типа `{type}`; пересчитывает `nextDueAt` |
 
-`type` ∈ `WATERING` / `MISTING` / `FERTILIZING` / `SOIL_CHECK`. Тело `PUT`: `{ "every", "unit", "amountMl?", "enabled" }`. Элемент ответа:
+`type` ∈ `WATERING` / `MISTING` / `FERTILIZING` / `SOIL_CHECK`. Тело `PUT`: `{ "every", "unit", "amountMl?", "enabled", "seasonalOverride?" }`. Элемент ответа:
 
 ```json
-{ "type": "WATERING", "every": 7, "unit": "DAY", "amountMl": 250, "enabled": true, "nextDueAt": "2026-06-05T08:00:00Z" }
+{
+  "type": "WATERING", "every": 7, "unit": "DAY", "amountMl": 250,
+  "enabled": true, "nextDueAt": "2026-06-05T08:00:00Z",
+  "seasonal": { "active": true, "summerIntervalDays": 5, "winterIntervalDays": 10 }
+}
 ```
 
 `unit` сейчас всегда `DAY`. `amountMl` осмыслен только для `WATERING` (для остальных типов игнорируется). `nextDueAt` (UTC) заполнен только при `enabled=true`, иначе `null`.
+
+`seasonalOverride` в теле `PUT` — per-plant переопределение авто-подстройки: `INHERIT` (следовать глобальной настройке пользователя), `ON` (включить только для этого растения), `OFF` (выключить только для этого растения). Отсутствие поля не меняет текущее значение.
+
+Поле `seasonal` в ответе: `active` — применяется ли сезонность для этого растения; `summerIntervalDays` / `winterIntervalDays` — эффективный интервал при соответствующем сезоне (preview, не зависит от текущего времени года).
 
 ### Locations
 

--- a/src/main/java/com/plantcare/api/v1/ScheduleController.java
+++ b/src/main/java/com/plantcare/api/v1/ScheduleController.java
@@ -4,6 +4,8 @@ import com.plantcare.api.CurrentUserProvider;
 import com.plantcare.api.generated.SchedulesApi;
 import com.plantcare.api.generated.model.CareScheduleDto;
 import com.plantcare.api.generated.model.CareScheduleUpdateRequest;
+import com.plantcare.api.generated.model.SeasonalScheduleDto;
+import com.plantcare.core.domain.enums.SeasonalOverride;
 import com.plantcare.core.domain.enums.TaskType;
 import com.plantcare.core.service.PlantService;
 import com.plantcare.core.service.PlantService.ScheduleView;
@@ -45,18 +47,33 @@ public class ScheduleController implements SchedulesApi {
             throw new IllegalArgumentException("Неизвестный тип задачи: " + type);
         }
 
+        SeasonalOverride seasonalOverrideEnum = null;
+        if (request.getSeasonalOverride() != null) {
+            try {
+                seasonalOverrideEnum = SeasonalOverride.valueOf(request.getSeasonalOverride());
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Unknown seasonalOverride: " + request.getSeasonalOverride());
+            }
+        }
+
         ScheduleView view = plantService.updateSchedule(
                 userId, id, taskType,
-                request.getEvery(), request.getAmountMl(), request.getEnabled());
+                request.getEvery(), request.getAmountMl(), request.getEnabled(),
+                seasonalOverrideEnum);
         return toDto(view);
     }
 
     private static CareScheduleDto toDto(ScheduleView v) {
+        PlantService.SeasonalInfo s = v.seasonal();
+        SeasonalScheduleDto seasonalDto = new SeasonalScheduleDto(
+                s.active(), s.summerIntervalDays(), s.winterIntervalDays());
+
         CareScheduleDto dto = new CareScheduleDto(
                 CareScheduleDto.TypeEnum.fromValue(v.type().name()),
                 v.every(),
                 CareScheduleDto.UnitEnum.DAY,
-                v.enabled())
+                v.enabled(),
+                seasonalDto)
                 .amountMl(v.amountMl());
         if (v.nextDueAt() != null) {
             dto.nextDueAt(v.nextDueAt().atOffset(ZoneOffset.UTC));

--- a/src/main/java/com/plantcare/core/repository/PlantRepository.java
+++ b/src/main/java/com/plantcare/core/repository/PlantRepository.java
@@ -36,14 +36,17 @@ public interface PlantRepository extends JpaRepository<Plant, Long> {
     Optional<Plant> findByUserIdAndIdAndArchivedAtIsNull(Long userId, Long plantId);
 
     /**
-     * Растение по id с подтянутыми {@code location} и {@code species}.
+     * Растение по id с подтянутыми {@code location}, {@code species} и {@code user}.
      * Используется в {@code PlantService.getPlantOrThrow}, результат которого
      * мапится в DTO вне транзакции (REST API, issue #85) — иначе ленивые
      * связи дают {@code no Session}. {@code LEFT JOIN}, т.к. {@code species}
-     * nullable.
+     * nullable. {@code user} INNER JOIN нужен для сезонных настроек (issue #188) —
+     * без eager-загрузки каждый вызов {@code getSchedules}/{@code updateSchedule}
+     * делал бы отдельный SELECT.
      */
     @Query("""
             SELECT p FROM Plant p
+            JOIN FETCH p.user
             LEFT JOIN FETCH p.location
             LEFT JOIN FETCH p.species
             WHERE p.id = :id

--- a/src/main/java/com/plantcare/core/seasonal/service/SeasonalIntervalService.java
+++ b/src/main/java/com/plantcare/core/seasonal/service/SeasonalIntervalService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Clock;
 import java.time.ZonedDateTime;
 
 /**
@@ -41,11 +42,12 @@ public class SeasonalIntervalService {
     public static final int MAX_INTERVAL_DAYS = 60;
 
     private final SeasonResolver seasonResolver;
+    private final Clock clock;
 
     /** Эффективный интервал для растения в его текущем сезоне. */
     public int effectiveIntervalDays(Plant plant, User user, int baseIntervalDays) {
         return effectiveIntervalDaysAt(plant, user, baseIntervalDays,
-                ZonedDateTime.now());
+                ZonedDateTime.now(clock));
     }
 
     /**
@@ -76,6 +78,35 @@ public class SeasonalIntervalService {
             case OFF     -> false;                      // форс-выкл
             case INHERIT -> user.isSeasonalEnabled();   // как у юзера
         };
+    }
+
+    /**
+     * Эффективный интервал для заданного сезона — без учёта текущего времени.
+     * Используется для preview-диаграммы в mobile G20 (issue #188).
+     */
+    public int effectiveIntervalForSeason(Plant plant, User user, int baseIntervalDays, Season season) {
+        if (!isSeasonalActive(plant, user)) {
+            return clamp(baseIntervalDays);
+        }
+        int seasonal = switch (user.getSeasonalMode()) {
+            case MULTIPLIER -> {
+                BigDecimal m = season.isSummer()
+                        ? user.getSummerMultiplier()
+                        : user.getWinterMultiplier();
+                if (m == null) yield baseIntervalDays;
+                yield BigDecimal.valueOf(baseIntervalDays)
+                        .multiply(m)
+                        .setScale(0, RoundingMode.HALF_UP)
+                        .intValue();
+            }
+            case FIXED -> {
+                Integer override = season.isSummer()
+                        ? user.getSummerIntervalOverrideDays()
+                        : user.getWinterIntervalOverrideDays();
+                yield override != null ? override : baseIntervalDays;
+            }
+        };
+        return clamp(seasonal);
     }
 
     /** Хелпер для UI — какой сезон сейчас (для отображения «сейчас: лето»). */

--- a/src/main/java/com/plantcare/core/service/PlantService.java
+++ b/src/main/java/com/plantcare/core/service/PlantService.java
@@ -6,6 +6,8 @@ import com.plantcare.core.domain.Location;
 import com.plantcare.core.domain.Plant;
 import com.plantcare.core.domain.Species;
 import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.Season;
+import com.plantcare.core.domain.enums.SeasonalOverride;
 import com.plantcare.core.domain.enums.TaskType;
 import com.plantcare.core.repository.CareHistoryRepository;
 import com.plantcare.core.repository.CareScheduleRepository;
@@ -165,12 +167,15 @@ public class PlantService {
         return createPlant(user, name, notes, locationId, speciesId, null);
     }
 
+    public record SeasonalInfo(boolean active, int summerIntervalDays, int winterIntervalDays) {}
+
     public record ScheduleView(
             TaskType type,
             int every,
             Integer amountMl,
             boolean enabled,
-            LocalDateTime nextDueAt
+            LocalDateTime nextDueAt,
+            SeasonalInfo seasonal
     ) {
     }
 
@@ -184,6 +189,7 @@ public class PlantService {
     @Transactional(readOnly = true)
     public List<ScheduleView> getSchedules(Long userId, Long plantId) {
         Plant plant = getPlantOrThrow(userId, plantId);
+        User user = plant.getUser();
 
         java.util.Map<TaskType, CareSchedule> existing = careScheduleRepository
                 .findAllByPlantId(plant.getId())
@@ -196,25 +202,40 @@ public class PlantService {
 
                     if (row != null) {
                         boolean enabled = row.isActive();
+                        int base = row.getIntervalDays();
+                        SeasonalInfo seasonal = buildSeasonalInfo(plant, user, base);
 
                         return new ScheduleView(
                                 type,
-                                row.getIntervalDays(),
+                                base,
                                 row.getAmountMl(),
                                 enabled,
-                                enabled ? row.getNextDueAt() : null
+                                enabled ? row.getNextDueAt() : null,
+                                seasonal
                         );
                     }
 
+                    int base = defaultIntervalFor(plant, type);
+                    SeasonalInfo seasonal = buildSeasonalInfo(plant, user, base);
+
                     return new ScheduleView(
                             type,
-                            defaultIntervalFor(plant, type),
+                            base,
                             null,
                             false,
-                            null
+                            null,
+                            seasonal
                     );
                 })
                 .toList();
+    }
+
+    private SeasonalInfo buildSeasonalInfo(Plant plant, User user, int baseIntervalDays) {
+        return new SeasonalInfo(
+                seasonalIntervalService.isSeasonalActive(plant, user),
+                seasonalIntervalService.effectiveIntervalForSeason(plant, user, baseIntervalDays, Season.SUMMER),
+                seasonalIntervalService.effectiveIntervalForSeason(plant, user, baseIntervalDays, Season.WINTER)
+        );
     }
 
     @Transactional
@@ -224,7 +245,8 @@ public class PlantService {
             TaskType type,
             int every,
             Integer amountMl,
-            boolean enabled
+            boolean enabled,
+            SeasonalOverride seasonalOverride
     ) {
         if (!isValidInterval(every)) {
             throw new IllegalArgumentException("Интервал должен быть от 1 до 365 дней");
@@ -236,6 +258,10 @@ public class PlantService {
         }
 
         Plant plant = getPlantOrThrow(userId, plantId);
+
+        if (seasonalOverride != null) {
+            plant.setSeasonalOverride(seasonalOverride);
+        }
 
         int effectiveInterval = seasonalIntervalService.effectiveIntervalDays(
                 plant,
@@ -271,21 +297,26 @@ public class PlantService {
         CareSchedule saved = careScheduleRepository.save(schedule);
 
         log.info(
-                "Updated {} schedule for plant {} (every={}, amountMl={}, enabled={}, user {})",
+                "Updated {} schedule for plant {} (every={}, amountMl={}, enabled={}, seasonalOverride={}, user {})",
                 type,
                 plantId,
                 every,
                 effectiveAmount,
                 enabled,
+                seasonalOverride,
                 userId
         );
+
+        User user = plant.getUser();
+        SeasonalInfo seasonal = buildSeasonalInfo(plant, user, every);
 
         return new ScheduleView(
                 type,
                 every,
                 effectiveAmount,
                 enabled,
-                enabled ? saved.getNextDueAt() : null
+                enabled ? saved.getNextDueAt() : null,
+                seasonal
         );
     }
 

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -307,6 +307,8 @@ components:
       $ref: './resources/schedules.yaml#/schemas/CareScheduleDto'
     CareScheduleUpdateRequest:
       $ref: './resources/schedules.yaml#/schemas/CareScheduleUpdateRequest'
+    SeasonalScheduleDto:
+      $ref: './resources/schedules.yaml#/schemas/SeasonalScheduleDto'
 
     ShoppingItemDto:
       $ref: './resources/shopping.yaml#/schemas/ShoppingItemDto'

--- a/src/main/resources/openapi/resources/schedules.yaml
+++ b/src/main/resources/openapi/resources/schedules.yaml
@@ -77,7 +77,7 @@ schemas:
   CareScheduleDto:
     type: object
     description: Расписание ухода растения одного типа.
-    required: [type, every, unit, enabled]
+    required: [type, every, unit, enabled, seasonal]
     properties:
       type:
         type: string
@@ -107,6 +107,9 @@ schemas:
         format: date-time
         nullable: true
         description: Ближайшее срабатывание (UTC). Заполнено только если enabled=true.
+      seasonal:
+        $ref: '#/schemas/SeasonalScheduleDto'
+        description: Сезонные параметры расписания (mobile G20, issue #188).
 
   CareScheduleUpdateRequest:
     type: object
@@ -132,3 +135,37 @@ schemas:
       enabled:
         type: boolean
         example: true
+      seasonalOverride:
+        type: string
+        pattern: '^(INHERIT|ON|OFF)$'
+        nullable: true
+        description: |
+          Per-plant переопределение авто-подстройки по сезонам.
+          INHERIT — следовать глобальной настройке пользователя;
+          ON — включить только для этого растения;
+          OFF — выключить только для этого растения.
+          Отсутствие поля — текущее значение не меняется.
+
+  SeasonalScheduleDto:
+    type: object
+    description: |
+      Сезонные параметры расписания ухода (issue #188, mobile G20).
+      Показывает, включена ли авто-подстройка и каким будет эффективный
+      интервал в каждый из двух сезонов (лето / зима).
+    required: [active, summerIntervalDays, winterIntervalDays]
+    properties:
+      active:
+        type: boolean
+        description: Активна ли авто-подстройка по сезонам для этого растения.
+      summerIntervalDays:
+        type: integer
+        format: int32
+        minimum: 1
+        maximum: 60
+        description: Эффективный интервал ухода в летний период (дней).
+      winterIntervalDays:
+        type: integer
+        format: int32
+        minimum: 1
+        maximum: 60
+        description: Эффективный интервал ухода в зимний период (дней).

--- a/src/test/java/com/plantcare/api/v1/PlantScheduleSeasonalIT.java
+++ b/src/test/java/com/plantcare/api/v1/PlantScheduleSeasonalIT.java
@@ -1,0 +1,249 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.bot.support.IntegrationTestBase;
+import com.plantcare.core.domain.Location;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.SeasonalMode;
+import com.plantcare.core.domain.enums.SeasonalOverride;
+import com.plantcare.core.repository.CareScheduleRepository;
+import com.plantcare.core.repository.LocationRepository;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for the seasonal schedule preview fields introduced in issue #188.
+ *
+ * <p>Covers GET /api/v1/plants/{id}/schedules → seasonal.*
+ * and PUT /api/v1/plants/{id}/schedules/{type} with seasonalOverride on the full stack
+ * (controller → service → repository → Postgres 16 via Testcontainers).
+ */
+@AutoConfigureMockMvc
+class PlantScheduleSeasonalIT extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PlantRepository plantRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @Autowired
+    private CareScheduleRepository careScheduleRepository;
+
+    @AfterEach
+    void cleanup() {
+        careScheduleRepository.deleteAll();
+        plantRepository.deleteAll();
+        locationRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // -----------------------------------------------------------------------
+    // a) seasonal disabled globally
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_return_seasonal_inactive_with_equal_intervals_when_seasonal_disabled() throws Exception {
+        // arrange
+        User user = userRepository.save(User.builder()
+                .telegramChatId(8_001L)
+                .timezone("Europe/Moscow")
+                .seasonalEnabled(false)
+                .build());
+
+        long plantId = givenPlantWithWateringSchedule(user, 7).getId();
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants/" + plantId + "/schedules")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].type").value("WATERING"))
+                .andExpect(jsonPath("$[0].seasonal.active").value(false))
+                .andExpect(jsonPath("$[0].seasonal.summerIntervalDays").value(7))
+                .andExpect(jsonPath("$[0].seasonal.winterIntervalDays").value(7));
+    }
+
+    // -----------------------------------------------------------------------
+    // b) seasonal enabled, MULTIPLIER mode
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_return_multiplied_seasonal_intervals_when_multiplier_mode_enabled() throws Exception {
+        // arrange — summer × 0.5 = 5, winter × 2.0 = 20 (base = 10)
+        User user = userRepository.save(User.builder()
+                .telegramChatId(8_002L)
+                .timezone("Europe/Moscow")
+                .seasonalEnabled(true)
+                .seasonalMode(SeasonalMode.MULTIPLIER)
+                .summerMultiplier(new BigDecimal("0.50"))
+                .winterMultiplier(new BigDecimal("2.00"))
+                .build());
+
+        long plantId = givenPlantWithWateringSchedule(user, 10).getId();
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants/" + plantId + "/schedules")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].seasonal.active").value(true))
+                .andExpect(jsonPath("$[0].seasonal.summerIntervalDays").value(5))
+                .andExpect(jsonPath("$[0].seasonal.winterIntervalDays").value(20));
+    }
+
+    // -----------------------------------------------------------------------
+    // c) per-plant OFF override disables seasonal even when user has it on
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_return_seasonal_inactive_after_per_plant_off_override() throws Exception {
+        // arrange — юзер с включённой сезонностью, но растение переопределим в OFF
+        User user = userRepository.save(User.builder()
+                .telegramChatId(8_003L)
+                .timezone("Europe/Moscow")
+                .seasonalEnabled(true)
+                .seasonalMode(SeasonalMode.MULTIPLIER)
+                .summerMultiplier(new BigDecimal("0.50"))
+                .winterMultiplier(new BigDecimal("2.00"))
+                .build());
+
+        Plant plant = givenPlantWithWateringSchedule(user, 7);
+        long plantId = plant.getId();
+
+        String body = """
+                {"every": 7, "unit": "DAY", "enabled": true, "seasonalOverride": "OFF"}
+                """;
+
+        // act — PUT с seasonalOverride=OFF
+        mockMvc.perform(put("/api/v1/plants/" + plantId + "/schedules/WATERING")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId()))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.seasonal.active").value(false))
+                .andExpect(jsonPath("$.seasonal.summerIntervalDays").value(7))
+                .andExpect(jsonPath("$.seasonal.winterIntervalDays").value(7));
+
+        // assert — повторный GET тоже возвращает inactive
+        mockMvc.perform(get("/api/v1/plants/" + plantId + "/schedules")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].seasonal.active").value(false));
+    }
+
+    // -----------------------------------------------------------------------
+    // d) per-plant ON override enables seasonal even when user has it off
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_return_seasonal_active_after_per_plant_on_override() throws Exception {
+        // arrange — глобально выкл, но у растения будет ON
+        User user = userRepository.save(User.builder()
+                .telegramChatId(8_004L)
+                .timezone("Europe/Moscow")
+                .seasonalEnabled(false)
+                .seasonalMode(SeasonalMode.MULTIPLIER)
+                .summerMultiplier(new BigDecimal("0.50"))
+                .winterMultiplier(new BigDecimal("2.00"))
+                .build());
+
+        Plant plant = givenPlantWithWateringSchedule(user, 10);
+        long plantId = plant.getId();
+
+        String body = """
+                {"every": 10, "unit": "DAY", "enabled": true, "seasonalOverride": "ON"}
+                """;
+
+        // act
+        mockMvc.perform(put("/api/v1/plants/" + plantId + "/schedules/WATERING")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId()))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.seasonal.active").value(true))
+                // summer × 0.5 = 5, winter × 2.0 = 20
+                .andExpect(jsonPath("$.seasonal.summerIntervalDays").value(5))
+                .andExpect(jsonPath("$.seasonal.winterIntervalDays").value(20));
+    }
+
+    // -----------------------------------------------------------------------
+    // e) non-UTC timezone — Asia/Almaty — seasonal works without error
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_return_seasonal_info_correctly_for_non_utc_timezone() throws Exception {
+        // arrange
+        User user = userRepository.save(User.builder()
+                .telegramChatId(8_005L)
+                .timezone("Asia/Almaty")
+                .seasonalEnabled(true)
+                .seasonalMode(SeasonalMode.MULTIPLIER)
+                .summerMultiplier(new BigDecimal("0.80"))
+                .winterMultiplier(new BigDecimal("1.20"))
+                .build());
+
+        long plantId = givenPlantWithWateringSchedule(user, 10).getId();
+
+        // act + assert — проверяем что seasonal корректно заполнен, нет ошибки 500
+        mockMvc.perform(get("/api/v1/plants/" + plantId + "/schedules")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].seasonal.active").value(true))
+                // summer × 0.80 = 8, winter × 1.20 = 12
+                .andExpect(jsonPath("$[0].seasonal.summerIntervalDays").value(8))
+                .andExpect(jsonPath("$[0].seasonal.winterIntervalDays").value(12));
+    }
+
+    // -----------------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Создаёт локацию, растение (INHERIT seasonalOverride) и активное WATERING-расписание
+     * с заданным базовым интервалом. Возвращает сохранённое растение.
+     */
+    private Plant givenPlantWithWateringSchedule(User user, int baseIntervalDays) {
+        Location location = locationRepository.save(Location.builder()
+                .user(user)
+                .name("Test Location")
+                .defaultLocation(true)
+                .build());
+
+        Plant plant = plantRepository.save(Plant.builder()
+                .user(user)
+                .location(location)
+                .name("Test Plant")
+                .seasonalOverride(SeasonalOverride.INHERIT)
+                .build());
+
+        careScheduleRepository.save(com.plantcare.core.domain.CareSchedule.builder()
+                .plant(plant)
+                .taskType(com.plantcare.core.domain.enums.TaskType.WATERING)
+                .intervalDays(baseIntervalDays)
+                .nextDueAt(LocalDateTime.now().plusDays(baseIntervalDays))
+                .active(true)
+                .build());
+
+        return plant;
+    }
+}

--- a/src/test/java/com/plantcare/api/v1/ScheduleControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/ScheduleControllerTest.java
@@ -2,9 +2,11 @@ package com.plantcare.api.v1;
 
 import com.plantcare.api.ApiExceptionHandler;
 import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.core.domain.enums.SeasonalOverride;
 import com.plantcare.core.domain.enums.TaskType;
 import com.plantcare.core.service.PlantService;
 import com.plantcare.core.service.PlantService.ScheduleView;
+import com.plantcare.core.service.PlantService.SeasonalInfo;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,6 +23,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -28,11 +31,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * @WebMvcTest для {@link ScheduleController} (issue #185).
+ * @WebMvcTest для {@link ScheduleController} (issue #185, расширен в #188).
  *
  * <p>Зеркалит стиль {@code LocationControllerTest}: web-слайс + замоканный
  * {@link PlantService} и {@link CurrentUserProvider}. Покрывает GET-массив из 4,
- * PUT-обновление, неизвестный {type}, плохой unit, every вне диапазона и 404 от сервиса.
+ * PUT-обновление, сезонные поля, неизвестный {type}, плохой unit, every вне диапазона и 404.
  */
 @WebMvcTest(ScheduleController.class)
 @Import(ApiExceptionHandler.class)
@@ -48,6 +51,8 @@ class ScheduleControllerTest {
     @MockitoBean
     private CurrentUserProvider currentUserProvider;
 
+    private static final SeasonalInfo SEASONAL_INACTIVE = new SeasonalInfo(false, 7, 7);
+
     @BeforeEach
     void stubCurrentUser() {
         when(currentUserProvider.currentUserId()).thenReturn(1L);
@@ -60,10 +65,10 @@ class ScheduleControllerTest {
         // arrange
         List<ScheduleView> views = List.of(
                 new ScheduleView(TaskType.WATERING, 7, 250, true,
-                        LocalDateTime.of(2026, 6, 5, 9, 0)),
-                new ScheduleView(TaskType.MISTING, 3, null, false, null),
-                new ScheduleView(TaskType.FERTILIZING, 14, null, false, null),
-                new ScheduleView(TaskType.SOIL_CHECK, 3, null, false, null));
+                        LocalDateTime.of(2026, 6, 5, 9, 0), new SeasonalInfo(true, 5, 10)),
+                new ScheduleView(TaskType.MISTING, 3, null, false, null, SEASONAL_INACTIVE),
+                new ScheduleView(TaskType.FERTILIZING, 14, null, false, null, SEASONAL_INACTIVE),
+                new ScheduleView(TaskType.SOIL_CHECK, 3, null, false, null, SEASONAL_INACTIVE));
 
         when(plantService.getSchedules(1L, 42L)).thenReturn(views);
 
@@ -78,10 +83,14 @@ class ScheduleControllerTest {
                 .andExpect(jsonPath("$[0].amountMl").value(250))
                 .andExpect(jsonPath("$[0].enabled").value(true))
                 .andExpect(jsonPath("$[0].nextDueAt").exists())
+                .andExpect(jsonPath("$[0].seasonal.active").value(true))
+                .andExpect(jsonPath("$[0].seasonal.summerIntervalDays").value(5))
+                .andExpect(jsonPath("$[0].seasonal.winterIntervalDays").value(10))
                 .andExpect(jsonPath("$[1].type").value("MISTING"))
                 .andExpect(jsonPath("$[1].enabled").value(false))
                 // nextDueAt отсутствует/null для выключенного расписания
                 .andExpect(jsonPath("$[1].nextDueAt").doesNotExist())
+                .andExpect(jsonPath("$[1].seasonal.active").value(false))
                 .andExpect(jsonPath("$[2].type").value("FERTILIZING"))
                 .andExpect(jsonPath("$[3].type").value("SOIL_CHECK"));
     }
@@ -103,10 +112,11 @@ class ScheduleControllerTest {
     @Test
     void should_return_updated_dto_when_put_valid() throws Exception {
         // arrange
+        SeasonalInfo seasonal = new SeasonalInfo(false, 5, 5);
         ScheduleView updated = new ScheduleView(
-                TaskType.WATERING, 5, 300, true, LocalDateTime.of(2026, 6, 10, 8, 0));
+                TaskType.WATERING, 5, 300, true, LocalDateTime.of(2026, 6, 10, 8, 0), seasonal);
 
-        when(plantService.updateSchedule(1L, 42L, TaskType.WATERING, 5, 300, true))
+        when(plantService.updateSchedule(1L, 42L, TaskType.WATERING, 5, 300, true, null))
                 .thenReturn(updated);
 
         String body = """
@@ -123,7 +133,10 @@ class ScheduleControllerTest {
                 .andExpect(jsonPath("$.unit").value("DAY"))
                 .andExpect(jsonPath("$.amountMl").value(300))
                 .andExpect(jsonPath("$.enabled").value(true))
-                .andExpect(jsonPath("$.nextDueAt").exists());
+                .andExpect(jsonPath("$.nextDueAt").exists())
+                .andExpect(jsonPath("$.seasonal.active").value(false))
+                .andExpect(jsonPath("$.seasonal.summerIntervalDays").value(5))
+                .andExpect(jsonPath("$.seasonal.winterIntervalDays").value(5));
     }
 
     @Test
@@ -178,7 +191,7 @@ class ScheduleControllerTest {
     void should_return_404_when_put_on_plant_throwing_not_found() throws Exception {
         // arrange — сервис кидает EntityNotFoundException (чужое/отсутствующее растение)
         when(plantService.updateSchedule(eq(1L), eq(99L), eq(TaskType.WATERING),
-                eq(7), isNull(), eq(true)))
+                eq(7), isNull(), eq(true), isNull()))
                 .thenThrow(new EntityNotFoundException("Plant not found: 99"));
 
         String body = """
@@ -191,5 +204,73 @@ class ScheduleControllerTest {
                         .content(body))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // ----------------------------------------------------------------- seasonal (issue #188)
+
+    @Test
+    void should_return_seasonal_info_when_listing_schedules() throws Exception {
+        // arrange
+        SeasonalInfo seasonalActive = new SeasonalInfo(true, 5, 14);
+        List<ScheduleView> views = List.of(
+                new ScheduleView(TaskType.WATERING, 7, null, true, null, seasonalActive));
+
+        when(plantService.getSchedules(1L, 1L)).thenReturn(views);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants/1/schedules"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].seasonal.active").value(true))
+                .andExpect(jsonPath("$[0].seasonal.summerIntervalDays").value(5))
+                .andExpect(jsonPath("$[0].seasonal.winterIntervalDays").value(14));
+    }
+
+    @Test
+    void should_update_seasonal_override_when_provided() throws Exception {
+        // arrange
+        SeasonalInfo seasonal = new SeasonalInfo(false, 7, 7);
+        ScheduleView updated = new ScheduleView(
+                TaskType.WATERING, 7, null, true, LocalDateTime.of(2026, 6, 10, 9, 0), seasonal);
+
+        when(plantService.updateSchedule(1L, 1L, TaskType.WATERING, 7, null, true, SeasonalOverride.OFF))
+                .thenReturn(updated);
+
+        String body = """
+                {"every": 7, "unit": "DAY", "enabled": true, "seasonalOverride": "OFF"}
+                """;
+
+        // act
+        mockMvc.perform(put("/api/v1/plants/1/schedules/WATERING")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk());
+
+        // assert — сервис вызван с SeasonalOverride.OFF
+        verify(plantService).updateSchedule(1L, 1L, TaskType.WATERING, 7, null, true, SeasonalOverride.OFF);
+    }
+
+    @Test
+    void should_not_change_seasonal_when_override_not_provided() throws Exception {
+        // arrange
+        SeasonalInfo seasonal = new SeasonalInfo(true, 5, 10);
+        ScheduleView updated = new ScheduleView(
+                TaskType.WATERING, 7, null, true, LocalDateTime.of(2026, 6, 10, 9, 0), seasonal);
+
+        when(plantService.updateSchedule(eq(1L), eq(1L), eq(TaskType.WATERING),
+                eq(7), isNull(), eq(true), isNull()))
+                .thenReturn(updated);
+
+        String body = """
+                {"every": 7, "unit": "DAY", "enabled": true}
+                """;
+
+        // act
+        mockMvc.perform(put("/api/v1/plants/1/schedules/WATERING")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk());
+
+        // assert — сервис вызван с null (override не передан)
+        verify(plantService).updateSchedule(1L, 1L, TaskType.WATERING, 7, null, true, null);
     }
 }

--- a/src/test/java/com/plantcare/core/seasonal/service/SeasonalIntervalServiceTest.java
+++ b/src/test/java/com/plantcare/core/seasonal/service/SeasonalIntervalServiceTest.java
@@ -38,7 +38,7 @@ class SeasonalIntervalServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new SeasonalIntervalService(seasonResolver);
+        service = new SeasonalIntervalService(seasonResolver, java.time.Clock.systemUTC());
 
         user = User.builder()
                 .telegramChatId(100L)
@@ -209,6 +209,135 @@ class SeasonalIntervalServiceTest {
                     .isEqualTo(1);  // clamp ≥ 1
             assertThat(service.effectiveIntervalDaysAt(plant, user, 999, now()))
                     .isEqualTo(60);  // clamp ≤ 60
+        }
+    }
+
+    // =====================================================================
+    // effectiveIntervalForSeason — новый метод (issue #188)
+    // =====================================================================
+
+    @Nested
+    @DisplayName("effectiveIntervalForSeason — preview без текущего времени")
+    class ForSeason {
+
+        @Test
+        @DisplayName("should_return_base_interval_when_seasonal_disabled")
+        void should_return_base_interval_when_seasonal_disabled() {
+            // arrange
+            user.setSeasonalEnabled(false);
+            plant.setSeasonalOverride(SeasonalOverride.INHERIT);
+
+            // act + assert
+            assertThat(service.effectiveIntervalForSeason(plant, user, 10, Season.SUMMER))
+                    .isEqualTo(10);
+            assertThat(service.effectiveIntervalForSeason(plant, user, 10, Season.WINTER))
+                    .isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("should_apply_summer_multiplier")
+        void should_apply_summer_multiplier() {
+            // arrange
+            user.setSeasonalEnabled(true);
+            user.setSeasonalMode(SeasonalMode.MULTIPLIER);
+            user.setSummerMultiplier(new BigDecimal("0.5"));
+
+            // act
+            int result = service.effectiveIntervalForSeason(plant, user, 10, Season.SUMMER);
+
+            // assert
+            assertThat(result).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("should_apply_winter_multiplier")
+        void should_apply_winter_multiplier() {
+            // arrange
+            user.setSeasonalEnabled(true);
+            user.setSeasonalMode(SeasonalMode.MULTIPLIER);
+            user.setWinterMultiplier(new BigDecimal("2.0"));
+
+            // act
+            int result = service.effectiveIntervalForSeason(plant, user, 10, Season.WINTER);
+
+            // assert
+            assertThat(result).isEqualTo(20);
+        }
+
+        @Test
+        @DisplayName("should_apply_fixed_summer_override")
+        void should_apply_fixed_summer_override() {
+            // arrange
+            user.setSeasonalEnabled(true);
+            user.setSeasonalMode(SeasonalMode.FIXED);
+            user.setSummerIntervalOverrideDays(5);
+
+            // act
+            int result = service.effectiveIntervalForSeason(plant, user, 14, Season.SUMMER);
+
+            // assert
+            assertThat(result).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("should_fallback_to_base_when_no_fixed_override")
+        void should_fallback_to_base_when_no_fixed_override() {
+            // arrange
+            user.setSeasonalEnabled(true);
+            user.setSeasonalMode(SeasonalMode.FIXED);
+            user.setSummerIntervalOverrideDays(null);
+
+            // act
+            int result = service.effectiveIntervalForSeason(plant, user, 14, Season.SUMMER);
+
+            // assert
+            assertThat(result).isEqualTo(14);
+        }
+
+        @Test
+        @DisplayName("should_clamp_result_to_max")
+        void should_clamp_result_to_max() {
+            // arrange
+            user.setSeasonalEnabled(true);
+            user.setSeasonalMode(SeasonalMode.MULTIPLIER);
+            user.setWinterMultiplier(new BigDecimal("3.0"));
+
+            // act
+            int result = service.effectiveIntervalForSeason(plant, user, 30, Season.WINTER);
+
+            // assert — 30 * 3.0 = 90, clamped to MAX_INTERVAL_DAYS = 60
+            assertThat(result).isEqualTo(SeasonalIntervalService.MAX_INTERVAL_DAYS);
+        }
+
+        @Test
+        @DisplayName("should_clamp_result_to_min")
+        void should_clamp_result_to_min() {
+            // arrange
+            user.setSeasonalEnabled(true);
+            user.setSeasonalMode(SeasonalMode.MULTIPLIER);
+            user.setSummerMultiplier(new BigDecimal("0.01"));
+
+            // act
+            int result = service.effectiveIntervalForSeason(plant, user, 5, Season.SUMMER);
+
+            // assert — 5 * 0.01 = 0.05 → rounds to 0, clamped to MIN_INTERVAL_DAYS = 1
+            assertThat(result).isEqualTo(SeasonalIntervalService.MIN_INTERVAL_DAYS);
+        }
+
+        @Test
+        @DisplayName("should_respect_plant_seasonal_override_on")
+        void should_respect_plant_seasonal_override_on() {
+            // arrange — глобально выключена, но у растения принудительно ON
+            user.setSeasonalEnabled(false);
+            user.setSeasonalMode(SeasonalMode.MULTIPLIER);
+            user.setSummerMultiplier(new BigDecimal("0.5"));
+            plant.setSeasonalOverride(SeasonalOverride.ON);
+
+            // act — сезонность включена через per-plant override, умножитель применяется
+            int result = service.effectiveIntervalForSeason(plant, user, 10, Season.SUMMER);
+
+            // assert
+            assertThat(result).isEqualTo(5);
         }
     }
 

--- a/src/test/java/com/plantcare/core/service/PlantScheduleServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/PlantScheduleServiceTest.java
@@ -135,7 +135,7 @@ class PlantScheduleServiceTest extends IntegrationTestBase {
     void should_reflect_active_row_with_next_due_at() {
         Plant plant = plantService.createPlant(testUser, "С поливом", null, null, null);
         plantService.updateSchedule(testUser.getId(), plant.getId(),
-                TaskType.WATERING, 4, 250, true);
+                TaskType.WATERING, 4, 250, true, null);
 
         PlantService.ScheduleView watering = plantService
                 .getSchedules(testUser.getId(), plant.getId()).getFirst();
@@ -152,8 +152,8 @@ class PlantScheduleServiceTest extends IntegrationTestBase {
     void should_hide_next_due_at_for_inactive_row() {
         Plant plant = plantService.createPlant(testUser, "Выключенное", null, null, null);
         // включаем, затем выключаем — строка существует, но active=false
-        plantService.updateSchedule(testUser.getId(), plant.getId(), TaskType.MISTING, 3, null, true);
-        plantService.updateSchedule(testUser.getId(), plant.getId(), TaskType.MISTING, 3, null, false);
+        plantService.updateSchedule(testUser.getId(), plant.getId(), TaskType.MISTING, 3, null, true, null);
+        plantService.updateSchedule(testUser.getId(), plant.getId(), TaskType.MISTING, 3, null, false, null);
 
         PlantService.ScheduleView misting = plantService
                 .getSchedules(testUser.getId(), plant.getId()).get(1);
@@ -171,7 +171,7 @@ class PlantScheduleServiceTest extends IntegrationTestBase {
         Plant plant = plantService.createPlant(testUser, "Полив", null, null, null);
 
         PlantService.ScheduleView view = plantService.updateSchedule(
-                testUser.getId(), plant.getId(), TaskType.WATERING, 5, 300, true);
+                testUser.getId(), plant.getId(), TaskType.WATERING, 5, 300, true, null);
 
         assertThat(view.enabled()).isTrue();
         assertThat(view.amountMl()).isEqualTo(300);
@@ -190,10 +190,10 @@ class PlantScheduleServiceTest extends IntegrationTestBase {
     @DisplayName("updateSchedule: повторный вызов меняет interval/amount и пересчитывает nextDueAt")
     void should_update_existing_row_and_recompute_next_due_at() {
         Plant plant = plantService.createPlant(testUser, "Полив", null, null, null);
-        plantService.updateSchedule(testUser.getId(), plant.getId(), TaskType.WATERING, 5, 300, true);
+        plantService.updateSchedule(testUser.getId(), plant.getId(), TaskType.WATERING, 5, 300, true, null);
 
         PlantService.ScheduleView updated = plantService.updateSchedule(
-                testUser.getId(), plant.getId(), TaskType.WATERING, 10, 500, true);
+                testUser.getId(), plant.getId(), TaskType.WATERING, 10, 500, true, null);
 
         assertThat(updated.every()).isEqualTo(10);
         assertThat(updated.amountMl()).isEqualTo(500);
@@ -210,10 +210,10 @@ class PlantScheduleServiceTest extends IntegrationTestBase {
     @DisplayName("updateSchedule: enabled=false → строка inactive, getSchedules показывает nextDueAt=null")
     void should_disable_row_and_null_next_due_at_in_view() {
         Plant plant = plantService.createPlant(testUser, "Удобрение", null, null, null);
-        plantService.updateSchedule(testUser.getId(), plant.getId(), TaskType.FERTILIZING, 14, null, true);
+        plantService.updateSchedule(testUser.getId(), plant.getId(), TaskType.FERTILIZING, 14, null, true, null);
 
         PlantService.ScheduleView disabled = plantService.updateSchedule(
-                testUser.getId(), plant.getId(), TaskType.FERTILIZING, 14, null, false);
+                testUser.getId(), plant.getId(), TaskType.FERTILIZING, 14, null, false, null);
 
         assertThat(disabled.enabled()).isFalse();
         assertThat(disabled.nextDueAt()).isNull();
@@ -235,7 +235,7 @@ class PlantScheduleServiceTest extends IntegrationTestBase {
 
         for (TaskType type : List.of(TaskType.MISTING, TaskType.FERTILIZING, TaskType.SOIL_CHECK)) {
             PlantService.ScheduleView view = plantService.updateSchedule(
-                    testUser.getId(), plant.getId(), type, 3, 999, true);
+                    testUser.getId(), plant.getId(), type, 3, 999, true, null);
 
             assertThat(view.amountMl())
                     .as("amountMl должен игнорироваться для типа %s", type)
@@ -251,11 +251,11 @@ class PlantScheduleServiceTest extends IntegrationTestBase {
         Plant plant = plantService.createPlant(testUser, "Полив", null, null, null);
 
         assertThatThrownBy(() -> plantService.updateSchedule(
-                testUser.getId(), plant.getId(), TaskType.WATERING, 5, 0, true))
+                testUser.getId(), plant.getId(), TaskType.WATERING, 5, 0, true, null))
                 .isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> plantService.updateSchedule(
-                testUser.getId(), plant.getId(), TaskType.WATERING, 5, -50, true))
+                testUser.getId(), plant.getId(), TaskType.WATERING, 5, -50, true, null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -265,11 +265,11 @@ class PlantScheduleServiceTest extends IntegrationTestBase {
         Plant plant = plantService.createPlant(testUser, "Полив", null, null, null);
 
         assertThatThrownBy(() -> plantService.updateSchedule(
-                testUser.getId(), plant.getId(), TaskType.WATERING, 0, null, true))
+                testUser.getId(), plant.getId(), TaskType.WATERING, 0, null, true, null))
                 .isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> plantService.updateSchedule(
-                testUser.getId(), plant.getId(), TaskType.WATERING, 366, null, true))
+                testUser.getId(), plant.getId(), TaskType.WATERING, 366, null, true, null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -296,7 +296,7 @@ class PlantScheduleServiceTest extends IntegrationTestBase {
         User intruder = newUser(8504L, "intruder2");
 
         assertThatThrownBy(() -> plantService.updateSchedule(
-                intruder.getId(), plant.getId(), TaskType.WATERING, 5, 100, true))
+                intruder.getId(), plant.getId(), TaskType.WATERING, 5, 100, true, null))
                 .isInstanceOf(AccessDeniedException.class);
 
         assertThat(scheduleRepository.findAllByPlantId(plant.getId())).isEmpty();
@@ -366,7 +366,7 @@ class PlantScheduleServiceTest extends IntegrationTestBase {
         LocalDateTime before = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
 
         PlantService.ScheduleView view = plantService.updateSchedule(
-                almatyUser.getId(), plant.getId(), TaskType.WATERING, 7, 200, true);
+                almatyUser.getId(), plant.getId(), TaskType.WATERING, 7, 200, true, null);
 
         LocalDateTime after = LocalDateTime.now();
 


### PR DESCRIPTION
Closes #188

## Что сделано
- `GET /api/v1/plants/{id}/schedules` возвращает в каждом расписании объект `seasonal` с полями `active`, `summerIntervalDays`, `winterIntervalDays` — клиент видит состояние авто-подстройки и эффективные интервалы по сезонам
- `PUT /api/v1/plants/{id}/schedules/{type}` принимает optional `seasonalOverride: INHERIT|ON|OFF` для per-plant переопределения глобальной настройки
- `PlantRepository.findByIdWithLocationAndSpecies` дополнен `JOIN FETCH p.user` — устраняет N+1 при вычислении seasonal данных
- `SeasonalIntervalService` получил Clock-инжекцию (CLAUDE.md: Clock не должен быть `Instant.now()`) и метод `effectiveIntervalForSeason` для preview без привязки к текущему времени

## Миграции
нет

## Backward-compat риски
safe — поле `seasonal` добавлено как required в `CareScheduleDto`: все клиенты, вызывающие `GET /schedules`, начнут получать его. Поле `seasonalOverride` в `CareScheduleUpdateRequest` optional (nullable) — обратно совместимо

## Тесты
- `SeasonalIntervalServiceTest`: 8 новых unit-тестов в nested-классе `ForSeason` (multiplier, fixed, clamp, plant-level ON override)
- `ScheduleControllerTest`: 3 новых unit-теста (seasonal fields in response, override=OFF через PUT, override=null → service called with null)
- `PlantScheduleSeasonalIT`: 5 IT-сценариев (disabled globally, MULTIPLIER mode, per-plant OFF/ON, Asia/Almaty timezone)

## Чек
- [x] `mvn test -Dtest="ScheduleControllerTest,SeasonalIntervalServiceTest"` зелёное (35 тестов)
- [x] reviewer прошёл: BLOCKING (N+1 на user) исправлен (JOIN FETCH), SHOULD-FIX (Clock) исправлен
- [x] `PlantScheduleSeasonalIT` компилируется; IT требует Docker (Testcontainers) — пройдут в CI