### PR TITLE
feat: history summary + type filter для GET /plants/{id}/history (#206)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ echo 'testcontainers.reuse.enable=true' >> ~/.testcontainers.properties
 |---|---|---|---|
 | `/api/v1/care-events` | `POST` | 201 | Регистрация ухода (WATER/SPRAY/FERTILIZE). Поле `clientId` обеспечивает идемпотентность: повторный запрос с тем же `clientId` возвращает существующую запись без дублирования |
 | `/api/v1/care-events/{id}` | `DELETE` | 204 | Отмена события через compensation pattern: запись не удаляется физически, создаётся компенсирующая запись |
-| `/api/v1/plants/{id}/history` | `GET` | 200 | История ухода за растением с offset-пагинацией. Query params: `limit` [1–100], default 20; `offset`, default 0. Проверяет ownership растения |
+| `/api/v1/plants/{id}/history` | `GET` | 200 | История ухода за растением с offset-пагинацией. Query params: `limit` [1–100], default 20; `offset`, default 0; `type` (`WATER`/`SPRAY`/`FERTILIZE`) — фильтр по типу, если не задан — все типы. Невалидное значение `type` → 400. Проверяет ownership растения |
+| `/api/v1/plants/{id}/history/summary` | `GET` | 200 | Агрегат по всей истории: `total`, `onTimeCount`, `onTimePercent`, `byType` (разбивка по типам, ключи `WATER`/`SPRAY`/`FERTILIZE`, только типы с count > 0; `SOIL_CHECK` исключён). Учитываются только не отменённые записи. Проверяет ownership растения |
 | `/api/v1/today` | `GET` | 200 | Задачи ухода на сегодня в таймзоне пользователя |
 | `/api/v1/calendar` | `GET` | 200 | Расписание за произвольный период. Query params: `from`, `to` (ISO date). Диапазон не более 60 дней. Дни без задач в ответ не включаются |
 | `/api/v1/calendar/progress` | `GET` | 200 | Прогресс выполнения по дням за период: карта `{ "YYYY-MM-DD": { "planned", "done" } }`, где `planned` — запланированные occurrence'ы расписаний, `done` — выполненные (не отменённые) записи ухода за этот локальный день в таймзоне пользователя. Query params: `from`, `to` (ISO date), диапазон не более 60 дней. Дни без планов и без выполнений не включаются |

--- a/src/main/java/com/plantcare/api/ApiExceptionHandler.java
+++ b/src/main/java/com/plantcare/api/ApiExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 /**
  * Глобальный обработчик ошибок REST API ({@code /api/**}).
@@ -37,6 +38,12 @@ public class ApiExceptionHandler {
     public ResponseEntity<ApiErrorResponse> handleMethodValidation(Exception e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ApiErrorResponse.of("VALIDATION_ERROR", "Validation failed"));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiErrorResponse.of("BAD_REQUEST", "Invalid parameter value: " + e.getValue()));
     }
 
     @ExceptionHandler(EntityNotFoundException.class)

--- a/src/main/java/com/plantcare/api/v1/PlantHistoryController.java
+++ b/src/main/java/com/plantcare/api/v1/PlantHistoryController.java
@@ -2,7 +2,9 @@ package com.plantcare.api.v1;
 
 import com.plantcare.api.generated.PlantHistoryApi;
 import com.plantcare.api.generated.model.CareEventResponse;
+import com.plantcare.api.generated.model.CareEventType;
 import com.plantcare.api.generated.model.PlantHistoryResponse;
+import com.plantcare.api.generated.model.PlantHistorySummaryDto;
 import com.plantcare.api.CurrentUserProvider;
 import com.plantcare.core.domain.CareHistory;
 import com.plantcare.core.domain.Plant;
@@ -16,9 +18,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
- * REST API для получения истории ухода за растением (issue #86).
+ * REST API для получения истории ухода за растением (issue #86, #206).
  *
  * <p>Документация и mapping живут в сгенерированном {@link PlantHistoryApi}.
  */
@@ -32,21 +36,22 @@ public class PlantHistoryController implements PlantHistoryApi {
     private final CurrentUserProvider currentUserProvider;
 
     @Override
-    public PlantHistoryResponse getPlantHistory(Long id, Integer limit, Integer offset) {
+    public PlantHistoryResponse getPlantHistory(Long id, Integer limit, Integer offset, CareEventType type) {
         User user = currentUserProvider.currentUser();
 
         Plant plant = plantRepository.findByUserIdAndIdAndArchivedAtIsNull(user.getId(), id)
                 .orElseThrow(() -> new EntityNotFoundException(
                         "Plant not found: id=" + id + " for userId=" + user.getId()));
 
-        log.info("GET /api/v1/plants/{}/history: userId={}, limit={}, offset={}",
-                id, user.getId(), limit, offset);
+        log.info("GET /api/v1/plants/{}/history: userId={}, limit={}, offset={}, type={}",
+                id, user.getId(), limit, offset, type);
 
         int safeOffset = Math.max(0, offset);
+        TaskType taskType = toTaskType(type);
 
         List<CareHistory> items = careHistoryService.getHistoryPageWithLimit(
-                plant.getId(), safeOffset, limit);
-        long total = careHistoryService.countHistory(plant.getId());
+                plant.getId(), safeOffset, limit, taskType);
+        long total = careHistoryService.countHistory(plant.getId(), taskType);
 
         // Все записи принадлежат одному загруженному выше растению; мапим из него,
         // а не из ленивого history.getPlant() — нативный листинг истории plant не
@@ -57,5 +62,60 @@ public class PlantHistoryController implements PlantHistoryApi {
                 .toList();
 
         return new PlantHistoryResponse(responseItems, total, limit, safeOffset);
+    }
+
+    @Override
+    public PlantHistorySummaryDto getPlantHistorySummary(Long id) {
+        User user = currentUserProvider.currentUser();
+
+        Plant plant = plantRepository.findByUserIdAndIdAndArchivedAtIsNull(user.getId(), id)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Plant not found: id=" + id + " for userId=" + user.getId()));
+
+        log.info("GET /api/v1/plants/{}/history/summary: userId={}", id, user.getId());
+
+        CareHistoryService.HistorySummary summary = careHistoryService.getHistorySummary(plant.getId());
+
+        // Преобразуем Map<TaskType, Long> → Map<String, Long> с ключами CareEventType
+        // (SOIL_CHECK уже отфильтрован в сервисе, поэтому fromTaskType всегда даёт результат).
+        Map<String, Long> byType = summary.byType().entrySet().stream()
+                .collect(Collectors.toMap(
+                        e -> fromTaskType(e.getKey()).getValue(),
+                        Map.Entry::getValue
+                ));
+
+        return new PlantHistorySummaryDto(
+                summary.total(),
+                summary.onTimeCount(),
+                summary.onTimePercent(),
+                byType
+        );
+    }
+
+    /**
+     * Конвертирует API {@link CareEventType} в доменный {@link TaskType}.
+     * {@code null} → {@code null} (нет фильтра).
+     */
+    private static TaskType toTaskType(CareEventType type) {
+        if (type == null) return null;
+        return switch (type) {
+            case WATER -> TaskType.WATERING;
+            case SPRAY -> TaskType.MISTING;
+            case FERTILIZE -> TaskType.FERTILIZING;
+        };
+    }
+
+    /**
+     * Конвертирует доменный {@link TaskType} в API {@link CareEventType}.
+     * SOIL_CHECK не должен сюда попасть — фильтрация в сервисе.
+     */
+    private static CareEventType fromTaskType(TaskType type) {
+        return switch (type) {
+            case WATERING -> CareEventType.WATER;
+            case MISTING -> CareEventType.SPRAY;
+            case FERTILIZING -> CareEventType.FERTILIZE;
+            case SOIL_CHECK -> throw new IllegalStateException(
+                    "SOIL_CHECK cannot be represented as CareEventType, filter before mapping");
+        };
     }
 }

--- a/src/main/java/com/plantcare/core/repository/CareHistoryRepository.java
+++ b/src/main/java/com/plantcare/core/repository/CareHistoryRepository.java
@@ -154,6 +154,65 @@ public interface CareHistoryRepository extends JpaRepository<CareHistory, Long> 
             @Param("offset") int offset
     );
 
+    /**
+     * Постраничный листинг истории с реальным offset и фильтром по типу ухода.
+     *
+     * <p>Используется REST API GET /api/v1/plants/{id}/history?type=WATERING&limit=N&offset=M.
+     * Нативный запрос аналогичен {@link #findActiveByPlantIdWithRealOffset}, но добавляет
+     * опциональный фильтр по типу: если {@code taskType} передан как {@code null} —
+     * условие игнорируется и возвращаются все типы.
+     *
+     * @param plantId  id растения
+     * @param limit    количество записей
+     * @param offset   смещение от начала (0-based)
+     * @param taskType {@code TaskType.name()} для фильтра, или {@code null} — все типы
+     * @return срез истории
+     */
+    @Query(value = "SELECT * FROM care_history h " +
+            "WHERE h.plant_id = :plantId AND h.cancelled_by IS NULL " +
+            "AND (:taskType IS NULL OR h.task_type = :taskType) " +
+            "ORDER BY h.done_at DESC " +
+            "LIMIT :limit OFFSET :offset", nativeQuery = true)
+    List<CareHistory> findActiveByPlantIdWithRealOffsetAndType(
+            @Param("plantId") Long plantId,
+            @Param("limit") int limit,
+            @Param("offset") int offset,
+            @Param("taskType") String taskType
+    );
+
+    /**
+     * Кол-во активных (не-cancelled) записей с опциональным фильтром по типу ухода.
+     *
+     * <p>Если {@code taskType} передан как {@code null} — возвращает общее число,
+     * аналогично {@link #countActiveByPlantId}.
+     */
+    @Query(value = "SELECT COUNT(*) FROM care_history h " +
+            "WHERE h.plant_id = :plantId AND h.cancelled_by IS NULL " +
+            "AND (:taskType IS NULL OR h.task_type = :taskType)", nativeQuery = true)
+    long countActiveByPlantIdAndType(
+            @Param("plantId") Long plantId,
+            @Param("taskType") String taskType
+    );
+
+    /**
+     * Кол-во активных (не-cancelled) on-time записей по растению за всё время.
+     * Числитель для {@code onTimePercent} в сводке истории (issue #206).
+     */
+    @Query("SELECT COUNT(h) FROM CareHistory h " +
+            "WHERE h.plant.id = :plantId AND h.cancelledBy IS NULL " +
+            "AND h.onTime = true")
+    long countActiveOnTimeByPlantId(@Param("plantId") Long plantId);
+
+    /**
+     * Разбивка активных (не-cancelled) записей по типам ухода за всё время.
+     * Только типы с count ≥ 1 попадают в результат (GROUP BY без HAVING — фильтрация в сервисе).
+     * Используется для {@code byType} в сводке истории (issue #206).
+     */
+    @Query("SELECT h.taskType AS taskType, COUNT(h) AS count FROM CareHistory h " +
+            "WHERE h.plant.id = :plantId AND h.cancelledBy IS NULL " +
+            "GROUP BY h.taskType")
+    List<TaskTypeCount> countActiveByPlantIdGroupedByType(@Param("plantId") Long plantId);
+
     // ===== Месячный отчёт (issue #137) =====
 
     /**

--- a/src/main/java/com/plantcare/core/service/CareHistoryService.java
+++ b/src/main/java/com/plantcare/core/service/CareHistoryService.java
@@ -2,6 +2,7 @@ package com.plantcare.core.service;
 
 import com.plantcare.core.domain.CareHistory;
 import com.plantcare.core.domain.CareSchedule;
+import com.plantcare.core.domain.enums.TaskType;
 import com.plantcare.core.repository.CareHistoryRepository;
 import com.plantcare.core.repository.CareScheduleRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,14 +12,18 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 /**
  * Сервис для экрана «📜 История» в карточке растения и стриков (issue #51).
@@ -74,6 +79,7 @@ public class CareHistoryService {
 
     private final CareHistoryRepository careHistoryRepository;
     private final CareScheduleRepository careScheduleRepository;
+    private final Clock clock;
 
     /**
      * Одна страница истории растения в обратном хронологическом порядке.
@@ -93,14 +99,57 @@ public class CareHistoryService {
      * <p>Использует нативный SQL с LIMIT/OFFSET вместо page-based пагинации,
      * чтобы offset=5, limit=20 возвращал записи 5-24, а не 0-19.
      *
+     * @param plantId  id растения
+     * @param offset   смещение от начала (0-based)
+     * @param limit    количество записей [1, 100]
+     * @param taskType опциональный фильтр по типу ухода; {@code null} — все типы
+     */
+    @Transactional(readOnly = true)
+    public List<CareHistory> getHistoryPageWithLimit(Long plantId, int offset, int limit, TaskType taskType) {
+        int safeOffset = Math.max(0, offset);
+        String typeStr = taskType != null ? taskType.name() : null;
+        return careHistoryRepository.findActiveByPlantIdWithRealOffsetAndType(plantId, limit, safeOffset, typeStr);
+    }
+
+    /**
+     * Срез истории с реальным offset без фильтра по типу — делегирует к основному методу.
+     *
      * @param plantId id растения
      * @param offset  смещение от начала (0-based)
      * @param limit   количество записей [1, 100]
      */
     @Transactional(readOnly = true)
     public List<CareHistory> getHistoryPageWithLimit(Long plantId, int offset, int limit) {
-        int safeOffset = Math.max(0, offset);
-        return careHistoryRepository.findActiveByPlantIdWithRealOffset(plantId, limit, safeOffset);
+        return getHistoryPageWithLimit(plantId, offset, limit, null);
+    }
+
+    /**
+     * Сводная статистика по всей истории растения (issue #206).
+     *
+     * <p>Возвращает: общее число активных записей, число on-time, процент on-time,
+     * разбивку по типам ухода (без SOIL_CHECK, только типы с count > 0).
+     *
+     * @param plantId id растения
+     * @return сводка
+     */
+    @Transactional(readOnly = true)
+    public HistorySummary getHistorySummary(Long plantId) {
+        long total = countHistory(plantId);
+        long onTimeCount = careHistoryRepository.countActiveOnTimeByPlantId(plantId);
+        int onTimePercent = total == 0 ? 0 : (int) Math.round(100.0 * onTimeCount / total);
+
+        Map<TaskType, Long> byType = careHistoryRepository.countActiveByPlantIdGroupedByType(plantId)
+                .stream()
+                .filter(r -> r.getTaskType() != TaskType.SOIL_CHECK)
+                .filter(r -> r.getCount() > 0)
+                .collect(Collectors.toMap(
+                        CareHistoryRepository.TaskTypeCount::getTaskType,
+                        CareHistoryRepository.TaskTypeCount::getCount,
+                        Long::sum,
+                        () -> new EnumMap<>(TaskType.class)
+                ));
+
+        return new HistorySummary(total, onTimeCount, onTimePercent, byType);
     }
 
     /**
@@ -110,6 +159,19 @@ public class CareHistoryService {
     @Transactional(readOnly = true)
     public long countHistory(Long plantId) {
         return careHistoryRepository.countActiveByPlantId(plantId);
+    }
+
+    /**
+     * Сколько активных записей у растения с опциональным фильтром по типу ухода.
+     * При {@code taskType == null} возвращает общее число — аналогично {@link #countHistory(Long)}.
+     *
+     * @param plantId  id растения
+     * @param taskType тип ухода для фильтрации, или {@code null} — все типы
+     */
+    @Transactional(readOnly = true)
+    public long countHistory(Long plantId, TaskType taskType) {
+        String typeStr = taskType != null ? taskType.name() : null;
+        return careHistoryRepository.countActiveByPlantIdAndType(plantId, typeStr);
     }
 
     /**
@@ -124,7 +186,7 @@ public class CareHistoryService {
             return new PlantStats(0, 0, 0);
         }
 
-        LocalDateTime since = LocalDateTime.now().minusDays(ON_TIME_WINDOW_DAYS);
+        LocalDateTime since = LocalDateTime.now(clock).minusDays(ON_TIME_WINDOW_DAYS);
         long actionsInWindow = careHistoryRepository.countActiveByPlantIdSince(plantId, since);
         long onTimeInWindow = careHistoryRepository.countActiveOnTimeByPlantIdSince(plantId, since);
 
@@ -144,7 +206,7 @@ public class CareHistoryService {
     @Transactional(readOnly = true)
     public int computePlantStreak(Long plantId) {
         // 1) Просроченные расписания (без своего done) сразу обнуляют стрик.
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now(clock);
         List<CareSchedule> schedules = careScheduleRepository.findAllByPlantId(plantId);
         for (CareSchedule s : schedules) {
             if (!s.isActive() || s.getNextDueAt() == null) continue;
@@ -195,7 +257,7 @@ public class CareHistoryService {
             }
         }
 
-        LocalDate today = LocalDate.now(tz);
+        LocalDate today = LocalDate.now(clock.withZone(tz));
         LocalDate latest = uniqueDays.last();
 
         // Если последняя активность раньше «вчера» — стрик сломан.
@@ -239,4 +301,14 @@ public class CareHistoryService {
             return total >= MIN_ACTIONS_FOR_STATS;
         }
     }
+
+    /**
+     * Агрегированная статистика по всей истории растения (issue #206).
+     *
+     * @param total          всего активных (не-cancelled) записей
+     * @param onTimeCount    из них on-time
+     * @param onTimePercent  процент on-time; 0 если total = 0
+     * @param byType         разбивка по типам (без SOIL_CHECK, только count > 0)
+     */
+    public record HistorySummary(long total, long onTimeCount, int onTimePercent, Map<TaskType, Long> byType) {}
 }

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -122,6 +122,8 @@ paths:
     $ref: './resources/plants.yaml#/paths/Item'
   /api/v1/plants/{id}/history:
     $ref: './resources/plant-history.yaml#/paths/ItemHistory'
+  /api/v1/plants/{id}/history/summary:
+    $ref: './resources/plant-history.yaml#/paths/ItemHistorySummary'
   /api/v1/plants/{id}/health:
     $ref: './resources/plants.yaml#/paths/ItemHealth'
   /api/v1/plants/{id}/family:
@@ -256,6 +258,8 @@ components:
 
     PlantHistoryResponse:
       $ref: './resources/plant-history.yaml#/schemas/PlantHistoryResponse'
+    PlantHistorySummaryDto:
+      $ref: './resources/plant-history.yaml#/schemas/PlantHistorySummaryDto'
 
     LocationDto:
       $ref: './resources/locations.yaml#/schemas/LocationDto'

--- a/src/main/resources/openapi/resources/plant-history.yaml
+++ b/src/main/resources/openapi/resources/plant-history.yaml
@@ -17,6 +17,10 @@ paths:
         Пагинация — `limit/offset`. `limit` строго в диапазоне [1, 100]
         (значения вне диапазона отдаются как 400). `offset` < 0 нормализуется
         в 0.
+
+        Опциональный параметр `type` позволяет фильтровать историю по типу
+        ухода. Допустимые значения: `WATER`, `SPRAY`, `FERTILIZE`.
+        Если не задан — возвращаются все типы.
       security:
         - bearerAuth: []
       parameters:
@@ -40,6 +44,14 @@ paths:
             format: int32
             default: 0
             minimum: 0
+        - name: type
+          in: query
+          required: false
+          description: |
+            Фильтр по типу ухода. Допустимые значения: `WATER`, `SPRAY`, `FERTILIZE`.
+            Если не задан — возвращаются все типы.
+          schema:
+            $ref: './care-events.yaml#/schemas/CareEventType'
       responses:
         '200':
           description: Страница истории.
@@ -49,6 +61,33 @@ paths:
                 $ref: '#/schemas/PlantHistoryResponse'
         '400':
           $ref: '../_common/responses.yaml#/BadRequest'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+  ItemHistorySummary:
+    get:
+      tags: [Plant History]
+      operationId: getPlantHistorySummary
+      summary: Сводная статистика по всей истории растения
+      description: |
+        Возвращает агрегированную статистику по **всей** истории ухода за
+        растением (не по странице). Учитываются только активные (не отменённые)
+        записи. Тип `SOIL_CHECK` из выдачи исключён.
+
+        Доступ только к неархивированному растению текущего пользователя
+        (`sub` из bearer-токена). Если растение не найдено или принадлежит
+        другому пользователю — 404.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '../_common/parameters.yaml#/PlantIdPath'
+      responses:
+        '200':
+          description: Сводная статистика посчитана.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/PlantHistorySummaryDto'
         '404':
           $ref: '../_common/responses.yaml#/NotFound'
 
@@ -75,3 +114,36 @@ schemas:
         type: integer
         format: int32
         example: 0
+
+  PlantHistorySummaryDto:
+    type: object
+    description: Агрегированная статистика по всей истории ухода за растением.
+    required: [total, onTimeCount, onTimePercent, byType]
+    properties:
+      total:
+        type: integer
+        format: int64
+        description: Всего активных (не отменённых) записей истории.
+        example: 47
+      onTimeCount:
+        type: integer
+        format: int64
+        description: Из них выполненных вовремя (`was_on_time = true`).
+        example: 38
+      onTimePercent:
+        type: integer
+        format: int32
+        description: Процент вовремя выполненных. 0 если `total = 0`.
+        example: 81
+      byType:
+        type: object
+        description: |
+          Разбивка по типам ухода. Только типы с `count > 0`, `SOIL_CHECK` исключён.
+          Ключи — значения `CareEventType` (`WATER`, `SPRAY`, `FERTILIZE`).
+        additionalProperties:
+          type: integer
+          format: int64
+        example:
+          WATER: 20
+          SPRAY: 15
+          FERTILIZE: 12

--- a/src/test/java/com/plantcare/api/v1/PlantHistoryControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/PlantHistoryControllerTest.java
@@ -1,0 +1,203 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.core.domain.CareHistory;
+import com.plantcare.core.domain.Location;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.service.CareHistoryService;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * WebMvcTest для {@link PlantHistoryController} — issue #206.
+ *
+ * <p>Покрывает HTTP-контракт эндпоинтов GET /history и GET /history/summary:
+ * роутинг, маппинг query-параметра type, валидацию и JSON-форму ответа.
+ */
+@WebMvcTest(PlantHistoryController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PlantHistoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CareHistoryService careHistoryService;
+
+    @MockitoBean
+    private PlantRepository plantRepository;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    private static final long USER_ID = 1L;
+    private static final long PLANT_ID = 42L;
+
+    @BeforeEach
+    void stubCurrentUser() {
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(USER_ID);
+        when(currentUserProvider.currentUser()).thenReturn(user);
+    }
+
+    private Plant stubPlant() {
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(USER_ID);
+
+        Location location = mock(Location.class);
+        when(location.getId()).thenReturn(1L);
+        when(location.getName()).thenReturn("Windowsill");
+
+        Plant plant = mock(Plant.class);
+        when(plant.getId()).thenReturn(PLANT_ID);
+        when(plant.getName()).thenReturn("Monstera");
+        when(plant.getNotes()).thenReturn(null);
+        when(plant.getPhotoFileId()).thenReturn(null);
+        when(plant.getLocation()).thenReturn(location);
+        when(plant.getSpecies()).thenReturn(null);
+        when(plant.isArchived()).thenReturn(false);
+        when(plant.getArchivedAt()).thenReturn(null);
+        when(plant.getCreatedAt()).thenReturn(null);
+        when(plant.getUser()).thenReturn(user);
+
+        when(plantRepository.findByUserIdAndIdAndArchivedAtIsNull(USER_ID, PLANT_ID))
+                .thenReturn(Optional.of(plant));
+
+        return plant;
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /api/v1/plants/{id}/history — type-фильтр
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_return_history_page_without_filter_when_type_param_absent() throws Exception {
+        // arrange
+        Plant plant = stubPlant();
+        CareHistory item = careHistoryEntry(plant, TaskType.WATERING);
+        when(careHistoryService.getHistoryPageWithLimit(eq(PLANT_ID), eq(0), eq(20), isNull()))
+                .thenReturn(List.of(item));
+        when(careHistoryService.countHistory(eq(PLANT_ID), isNull())).thenReturn(1L);
+
+        // act
+        mockMvc.perform(get("/api/v1/plants/{id}/history", PLANT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(1))
+                .andExpect(jsonPath("$.items").isArray());
+
+        // assert — сервис вызван без фильтра по типу (null)
+        verify(careHistoryService).getHistoryPageWithLimit(eq(PLANT_ID), eq(0), eq(20), isNull());
+    }
+
+    @Test
+    void should_return_filtered_history_when_type_param_provided() throws Exception {
+        // arrange
+        Plant plant = stubPlant();
+        CareHistory item = careHistoryEntry(plant, TaskType.WATERING);
+        when(careHistoryService.getHistoryPageWithLimit(eq(PLANT_ID), eq(0), eq(20), eq(TaskType.WATERING)))
+                .thenReturn(List.of(item));
+        when(careHistoryService.countHistory(eq(PLANT_ID), eq(TaskType.WATERING))).thenReturn(1L);
+
+        // act
+        mockMvc.perform(get("/api/v1/plants/{id}/history", PLANT_ID)
+                        .queryParam("type", "WATER"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items").isArray());
+
+        // assert — сервис вызван с TaskType.WATERING
+        verify(careHistoryService).getHistoryPageWithLimit(eq(PLANT_ID), eq(0), eq(20), eq(TaskType.WATERING));
+    }
+
+    @Test
+    void should_return_400_when_unknown_type_param() throws Exception {
+        // arrange — plant stub не нужен, Spring отклонит до входа в контроллер
+        stubPlant();
+
+        // act & assert
+        mockMvc.perform(get("/api/v1/plants/{id}/history", PLANT_ID)
+                        .queryParam("type", "INVALID"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /api/v1/plants/{id}/history/summary
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_return_history_summary_with_all_fields() throws Exception {
+        // arrange
+        stubPlant();
+
+        Map<TaskType, Long> byTypeDomain = new EnumMap<>(TaskType.class);
+        byTypeDomain.put(TaskType.WATERING, 5L);
+        byTypeDomain.put(TaskType.MISTING, 3L);
+        byTypeDomain.put(TaskType.FERTILIZING, 2L);
+
+        CareHistoryService.HistorySummary summary =
+                new CareHistoryService.HistorySummary(10L, 8L, 80, byTypeDomain);
+
+        when(careHistoryService.getHistorySummary(PLANT_ID)).thenReturn(summary);
+
+        // act & assert
+        mockMvc.perform(get("/api/v1/plants/{id}/history/summary", PLANT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(10))
+                .andExpect(jsonPath("$.onTimeCount").value(8))
+                .andExpect(jsonPath("$.onTimePercent").value(80))
+                .andExpect(jsonPath("$.byType.WATER").value(5))
+                .andExpect(jsonPath("$.byType.SPRAY").value(3))
+                .andExpect(jsonPath("$.byType.FERTILIZE").value(2));
+    }
+
+    @Test
+    void should_return_404_for_summary_when_plant_not_found() throws Exception {
+        // arrange
+        when(plantRepository.findByUserIdAndIdAndArchivedAtIsNull(USER_ID, 999L))
+                .thenReturn(Optional.empty());
+
+        // act & assert
+        mockMvc.perform(get("/api/v1/plants/{id}/history/summary", 999L))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private CareHistory careHistoryEntry(Plant plant, TaskType type) {
+        CareHistory h = new CareHistory();
+        h.setPlant(plant);
+        h.setTaskType(type);
+        h.setDoneAt(LocalDateTime.of(2026, 6, 1, 10, 0));
+        h.setOnTime(true);
+        return h;
+    }
+}

--- a/src/test/java/com/plantcare/api/v1/PlantHistorySummaryIT.java
+++ b/src/test/java/com/plantcare/api/v1/PlantHistorySummaryIT.java
@@ -1,0 +1,236 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.bot.support.IntegrationTestBase;
+import com.plantcare.core.domain.CareHistory;
+import com.plantcare.core.domain.Location;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.repository.CareHistoryRepository;
+import com.plantcare.core.repository.LocationRepository;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Интеграционные тесты для GET /api/v1/plants/{id}/history/summary
+ * и GET /api/v1/plants/{id}/history?type=... (issue #206).
+ *
+ * <p>Полный стек: controller → service → repository → реальный Postgres 16.
+ * Проверяет агрегацию на реальных данных: total, onTimeCount, onTimePercent, byType,
+ * фильтрацию по типу, исключение SOIL_CHECK из byType.
+ */
+@AutoConfigureMockMvc
+class PlantHistorySummaryIT extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @Autowired
+    private PlantRepository plantRepository;
+
+    @Autowired
+    private CareHistoryRepository careHistoryRepository;
+
+    @AfterEach
+    void cleanup() {
+        careHistoryRepository.deleteAll();
+        plantRepository.deleteAll();
+        locationRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /history/summary — happy path
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_return_correct_summary_when_plant_has_mixed_history() throws Exception {
+        // arrange — 3 WATERING + 2 MISTING; 4 из 5 записей on-time
+        User user = saveUser(8_200_001L);
+        Plant plant = savePlant(user, "Monstera");
+
+        saveHistory(plant, TaskType.WATERING, true);
+        saveHistory(plant, TaskType.WATERING, true);
+        saveHistory(plant, TaskType.WATERING, true);
+        saveHistory(plant, TaskType.MISTING, true);
+        saveHistory(plant, TaskType.MISTING, false);   // опоздание
+
+        // act & assert
+        mockMvc.perform(get("/api/v1/plants/{id}/history/summary", plant.getId())
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(5))
+                .andExpect(jsonPath("$.onTimeCount").value(4))
+                .andExpect(jsonPath("$.onTimePercent").value(80))
+                .andExpect(jsonPath("$.byType.WATER").value(3))
+                .andExpect(jsonPath("$.byType.SPRAY").value(2))
+                .andExpect(jsonPath("$.byType.FERTILIZE").doesNotExist());
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /history/summary — edge: пустая история
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_return_zeros_and_empty_byType_when_history_is_empty() throws Exception {
+        // arrange — растение без единой записи
+        User user = saveUser(8_200_002L);
+        Plant plant = savePlant(user, "Ficus");
+
+        // act & assert
+        mockMvc.perform(get("/api/v1/plants/{id}/history/summary", plant.getId())
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(0))
+                .andExpect(jsonPath("$.onTimeCount").value(0))
+                .andExpect(jsonPath("$.onTimePercent").value(0))
+                .andExpect(jsonPath("$.byType").isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /history?type=WATER — фильтр возвращает только указанный тип
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_return_only_watering_records_when_type_filter_applied() throws Exception {
+        // arrange — 3 WATERING + 2 MISTING
+        User user = saveUser(8_200_003L);
+        Plant plant = savePlant(user, "Cactus");
+
+        saveHistory(plant, TaskType.WATERING, true);
+        saveHistory(plant, TaskType.WATERING, true);
+        saveHistory(plant, TaskType.WATERING, false);
+        saveHistory(plant, TaskType.MISTING, true);
+        saveHistory(plant, TaskType.MISTING, true);
+
+        // act & assert — ?type=WATER → только 3 записи полива в items
+        mockMvc.perform(get("/api/v1/plants/{id}/history", plant.getId())
+                        .queryParam("type", "WATER")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(3))
+                .andExpect(jsonPath("$.items[0].type").value("WATER"))
+                .andExpect(jsonPath("$.items[1].type").value("WATER"))
+                .andExpect(jsonPath("$.items[2].type").value("WATER"));
+    }
+
+    @Test
+    void should_return_all_records_when_no_type_filter() throws Exception {
+        // arrange — 3 WATERING + 2 MISTING
+        User user = saveUser(8_200_004L);
+        Plant plant = savePlant(user, "Aloe");
+
+        saveHistory(plant, TaskType.WATERING, true);
+        saveHistory(plant, TaskType.WATERING, true);
+        saveHistory(plant, TaskType.WATERING, true);
+        saveHistory(plant, TaskType.MISTING, true);
+        saveHistory(plant, TaskType.MISTING, true);
+
+        // act & assert — без фильтра → все 5 записей (SOIL_CHECK контроллер фильтрует из items,
+        // здесь SOIL_CHECK нет, поэтому items.length == 5)
+        mockMvc.perform(get("/api/v1/plants/{id}/history", plant.getId())
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(5));
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /history/summary — SOIL_CHECK скрыт из byType (total включает его)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_exclude_soil_check_from_byType_but_include_in_total() throws Exception {
+        // arrange — 2 WATERING + 1 SOIL_CHECK
+        // Поведение сервиса: total = countActiveByPlantId (все типы, включая SOIL_CHECK),
+        // byType = группировка с фильтрацией SOIL_CHECK в сервисе.
+        User user = saveUser(8_200_005L);
+        Plant plant = savePlant(user, "ZZ Plant");
+
+        saveHistory(plant, TaskType.WATERING, true);
+        saveHistory(plant, TaskType.WATERING, true);
+        saveHistory(plant, TaskType.SOIL_CHECK, true);
+
+        // act & assert
+        mockMvc.perform(get("/api/v1/plants/{id}/history/summary", plant.getId())
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk())
+                // total включает SOIL_CHECK (сырой счётчик всех активных записей)
+                .andExpect(jsonPath("$.total").value(3))
+                .andExpect(jsonPath("$.byType.WATER").value(2))
+                // SOIL_CHECK не должен появляться в byType
+                .andExpect(jsonPath("$.byType.SOIL_CHECK").doesNotExist());
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /history/summary — 404 при обращении к чужому растению
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_return_404_when_plant_belongs_to_another_user() throws Exception {
+        // arrange
+        User owner = saveUser(8_200_006L);
+        User stranger = saveUser(8_200_007L);
+        Plant ownerPlant = savePlant(owner, "Monstera");
+
+        // act — stranger запрашивает растение owner'а → 404
+        mockMvc.perform(get("/api/v1/plants/{id}/history/summary", ownerPlant.getId())
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(stranger.getId())))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private User saveUser(long chatId) {
+        return userRepository.save(User.builder()
+                .telegramChatId(chatId)
+                .timezone("UTC")
+                .blocked(false)
+                .build());
+    }
+
+    private Plant savePlant(User user, String name) {
+        Location location = locationRepository.findByUserIdAndDefaultLocationTrue(user.getId())
+                .orElseGet(() -> locationRepository.save(Location.builder()
+                        .user(user)
+                        .name(Location.DEFAULT_NAME)
+                        .emoji(Location.DEFAULT_EMOJI)
+                        .defaultLocation(true)
+                        .build()));
+        return plantRepository.save(Plant.builder()
+                .user(user)
+                .location(location)
+                .name(name)
+                .build());
+    }
+
+    private void saveHistory(Plant plant, TaskType type, boolean onTime) {
+        careHistoryRepository.save(CareHistory.builder()
+                .plant(plant)
+                .taskType(type)
+                .doneAt(LocalDateTime.now().truncatedTo(ChronoUnit.MICROS))
+                .onTime(onTime)
+                .build());
+    }
+}

--- a/src/test/java/com/plantcare/core/service/CareHistoryServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/CareHistoryServiceTest.java
@@ -5,6 +5,7 @@ import com.plantcare.core.domain.CareSchedule;
 import com.plantcare.core.domain.enums.TaskType;
 import com.plantcare.core.repository.CareHistoryRepository;
 import com.plantcare.core.repository.CareScheduleRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Limit;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -34,9 +37,21 @@ class CareHistoryServiceTest {
 
     @Mock private CareHistoryRepository historyRepository;
     @Mock private CareScheduleRepository scheduleRepository;
+    @Mock private Clock clock;
 
     @InjectMocks
     private CareHistoryService service;
+
+    @BeforeEach
+    void stubClock() {
+        Instant now = Instant.now();
+        lenient().when(clock.instant()).thenReturn(now);
+        lenient().when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+        lenient().when(clock.withZone(any(ZoneId.class))).thenAnswer(inv -> {
+            ZoneId zone = inv.getArgument(0);
+            return Clock.fixed(now, zone);
+        });
+    }
 
     @Nested
     @DisplayName("computePlantStreak")


### PR DESCRIPTION
Closes #206

## Что сделано
- Новый `GET /api/v1/plants/{id}/history/summary` → `{ total, onTimeCount, onTimePercent, byType }`. `SOIL_CHECK` исключён из `byType`; расчёт по всей истории, не по странице
- Query-параметр `?type=WATERING|MISTING|FERTILIZING` у `GET /plants/{id}/history` — фильтрация на уровне репозитория (нативный SQL), `total` в пагинаторе учитывает фильтр
- `ApiExceptionHandler` — добавлен `MethodArgumentTypeMismatchException` → 400 (невалидный `type` не даёт 500)
- `CareHistoryService` — `Clock` инжектируется, убраны `LocalDateTime.now()` россыпью

## Миграции
нет

## Backward-compat риски
safe — новый эндпоинт, параметр `type` опциональный, существующие клиенты без него работают как прежде

## Тесты
- `PlantHistoryControllerTest` (5 unit, `@WebMvcTest`): без фильтра, с фильтром WATERING, невалидный тип → 400, summary с полями, 404 при чужом растении
- `PlantHistorySummaryIT` (6 IT, Testcontainers Postgres): happy path summary, пустая история, фильтр по типу, SOIL_CHECK скрыт в byType, 404 при чужом растении
- `CareHistoryServiceTest` — расширен для работы с инжектируемым `Clock`

## Чек
- [x] `mvn test -Dtest=PlantHistoryControllerTest,CareHistoryServiceTest,LayeredArchitectureTest` — 29/29 зелёных
- [x] IT-тесты компилируются (Docker недоступен на машине — pre-existing)
- [x] reviewer Approved (1 итерация: 3 BLOCKING → исправлены)