### PR TITLE
feat: diseases catalog REST API GET /diseases (#225)

### DIFF
--- a/src/main/java/com/plantcare/api/config/ApiSecurityConfig.java
+++ b/src/main/java/com/plantcare/api/config/ApiSecurityConfig.java
@@ -20,7 +20,7 @@ import org.springframework.security.web.SecurityFilterChain;
  * верификаторы в сервисах). STATELESS, без CSRF (мобильный клиент, bearer-токены).
  *
  * <p>Публичны только {@code /api/v1/auth/**}, справочники ({@code species},
- * {@code care-types}) и {@code /api/v1/health}; остальное требует аутентификации.
+ * {@code care-types}, {@code diseases}) и {@code /api/v1/health}; остальное требует аутентификации.
  *
  * <p>{@code @Order(0)} — выше дефолтной цепочки ({@code AdminSecurityConfig},
  * @Order 3), чтобы перехватывать {@code /api/v1/**} раньше permitAll-цепочки.
@@ -47,7 +47,7 @@ public class ApiSecurityConfig {
                         .requestMatchers(HttpMethod.POST,
                                 "/api/v1/auth/logout", "/api/v1/auth/logout-all").authenticated()
                         .requestMatchers("/api/v1/auth/**").permitAll()
-                        .requestMatchers("/api/v1/species/**", "/api/v1/care-types/**").permitAll()
+                        .requestMatchers("/api/v1/species/**", "/api/v1/care-types/**", "/api/v1/diseases/**").permitAll()
                         .requestMatchers("/api/v1/health").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/plantcare/api/web/DiseasesController.java
+++ b/src/main/java/com/plantcare/api/web/DiseasesController.java
@@ -1,0 +1,54 @@
+package com.plantcare.api.web;
+
+import com.plantcare.api.generated.DiseasesApi;
+import com.plantcare.api.generated.model.DiseaseDto;
+import com.plantcare.core.service.DiseaseCard;
+import com.plantcare.core.service.DiseaseService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Публичный REST API справочника болезней и вредителей комнатных растений (issue #225).
+ *
+ * <p>Документация и mapping живут в сгенерированном {@link DiseasesApi}.
+ * Аутентификация не требуется — справочник общедоступен.
+ * Вся бизнес-логика делегируется {@link DiseaseService}.
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class DiseasesController implements DiseasesApi {
+
+    private static final int SEARCH_MAX_RESULTS = 20;
+
+    private final DiseaseService diseaseService;
+
+    @Override
+    public List<DiseaseDto> listDiseases(String q) {
+        if (q == null || q.isBlank()) {
+            log.debug("Diseases list request: all");
+            return diseaseService.getAll().stream()
+                    .map(DiseasesController::toDto)
+                    .toList();
+        }
+
+        log.debug("Diseases search request. q='{}'", q);
+        return diseaseService.search(q, SEARCH_MAX_RESULTS).stream()
+                .map(DiseasesController::toDto)
+                .toList();
+    }
+
+    @Override
+    public DiseaseDto getDiseaseById(Long id) {
+        log.debug("Disease detail request. id={}", id);
+        return toDto(diseaseService.getById(id));
+    }
+
+    private static DiseaseDto toDto(DiseaseCard card) {
+        return new DiseaseDto(card.id(), card.name(), card.symptoms(), card.treatment(), card.prevention())
+                .latinName(card.latinName());
+    }
+}

--- a/src/main/java/com/plantcare/api/web/exception/WebApiExceptionHandler.java
+++ b/src/main/java/com/plantcare/api/web/exception/WebApiExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.plantcare.api.web.exception;
 
+import com.plantcare.core.service.DiseaseNotFoundException;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
@@ -32,6 +33,13 @@ public class WebApiExceptionHandler {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ApiError handleNotFound(EntityNotFoundException e) {
         log.warn("Entity not found: {}", e.getMessage());
+        return new ApiError("NOT_FOUND", e.getMessage());
+    }
+
+    @ExceptionHandler(DiseaseNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ApiError handleDiseaseNotFound(DiseaseNotFoundException e) {
+        log.warn("Disease not found: {}", e.getMessage());
         return new ApiError("NOT_FOUND", e.getMessage());
     }
 

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -84,6 +84,8 @@ tags:
     description: Публичный справочник видов растений. Без авторизации.
   - name: Care Types
     description: Публичный справочник типов ухода (полив, опрыскивание, и т.п.). Без авторизации.
+  - name: Diseases
+    description: Публичный справочник болезней и вредителей комнатных растений. Без авторизации.
   - name: Weather
     description: Текущий снимок погоды для рекомендаций по уходу.
   - name: Schedules
@@ -171,6 +173,11 @@ paths:
 
   /api/v1/care-types:
     $ref: './resources/care-types.yaml#/paths/Collection'
+
+  /api/v1/diseases:
+    $ref: './resources/diseases.yaml#/paths/Collection'
+  /api/v1/diseases/{id}:
+    $ref: './resources/diseases.yaml#/paths/Item'
 
   /api/v1/shopping:
     $ref: './resources/shopping.yaml#/paths/Collection'
@@ -308,6 +315,9 @@ components:
 
     CareTypeDto:
       $ref: './resources/care-types.yaml#/schemas/CareTypeDto'
+
+    DiseaseDto:
+      $ref: './resources/diseases.yaml#/schemas/DiseaseDto'
 
     CareScheduleDto:
       $ref: './resources/schedules.yaml#/schemas/CareScheduleDto'

--- a/src/main/resources/openapi/resources/diseases.yaml
+++ b/src/main/resources/openapi/resources/diseases.yaml
@@ -1,0 +1,83 @@
+# Публичный справочник болезней и вредителей. Без авторизации.
+
+paths:
+  Collection:
+    get:
+      tags: [Diseases]
+      operationId: listDiseases
+      summary: Список болезней / полнотекстовый поиск
+      description: |
+        Публичный справочник болезней и вредителей комнатных растений.
+        Без авторизации.
+
+        Без параметра `q` — полный список в алфавитном порядке.
+        С параметром `q` — полнотекстовый поиск (делегирует `DiseaseService.search(q, 20)`).
+      parameters:
+        - name: q
+          in: query
+          required: false
+          description: Поисковая строка. Если пустая — возвращаются все болезни.
+          schema:
+            type: string
+            default: ""
+            example: клещ
+      responses:
+        '200':
+          description: Список болезней.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/schemas/DiseaseDto'
+
+  Item:
+    get:
+      tags: [Diseases]
+      operationId: getDiseaseById
+      summary: Карточка болезни по id
+      description: Полная карточка болезни/вредителя. 404 если не найдена.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Идентификатор болезни.
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: Болезнь найдена.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/DiseaseDto'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+schemas:
+  DiseaseDto:
+    type: object
+    description: Карточка болезни/вредителя комнатных растений.
+    required: [id, name, symptoms, treatment, prevention]
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+        example: Паутинный клещ
+      latinName:
+        type: string
+        nullable: true
+        example: Tetranychus urticae
+      symptoms:
+        type: string
+        example: Мелкая белёсая крапчатость на листьях…
+      treatment:
+        type: string
+        example: Промыть тёплым душем, обработать акарицидом…
+      prevention:
+        type: string
+        example: Поддерживать влажность воздуха…

--- a/src/test/java/com/plantcare/api/web/DiseasesControllerTest.java
+++ b/src/test/java/com/plantcare/api/web/DiseasesControllerTest.java
@@ -1,0 +1,137 @@
+package com.plantcare.api.web;
+
+import com.plantcare.api.web.exception.WebApiExceptionHandler;
+import com.plantcare.core.service.DiseaseCard;
+import com.plantcare.core.service.DiseaseNotFoundException;
+import com.plantcare.core.service.DiseaseService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {DiseasesController.class, WebApiExceptionHandler.class})
+@AutoConfigureMockMvc(addFilters = false)
+class DiseasesControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private DiseaseService diseaseService;
+
+    // ------------------------------------------------------------------ GET /diseases
+
+    @Test
+    void should_return_all_diseases_when_no_query() throws Exception {
+        // arrange
+        var card = new DiseaseCard(1L, "Паутинный клещ", "Tetranychus urticae",
+                "Крапчатость на листьях", "Обработать акарицидом", "Поддерживать влажность");
+        when(diseaseService.getAll()).thenReturn(List.of(card));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/diseases"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].name").value("Паутинный клещ"))
+                .andExpect(jsonPath("$[0].latinName").value("Tetranychus urticae"))
+                .andExpect(jsonPath("$[0].symptoms").value("Крапчатость на листьях"))
+                .andExpect(jsonPath("$[0].treatment").value("Обработать акарицидом"))
+                .andExpect(jsonPath("$[0].prevention").value("Поддерживать влажность"));
+
+        verify(diseaseService).getAll();
+    }
+
+    @Test
+    void should_return_empty_array_when_no_diseases_exist() throws Exception {
+        // arrange
+        when(diseaseService.getAll()).thenReturn(List.of());
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/diseases"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    void should_delegate_to_search_when_q_is_provided() throws Exception {
+        // arrange
+        var card = new DiseaseCard(2L, "Мучнистая роса", null,
+                "Белый налёт на листьях", "Фунгицид", "Проветривание");
+        when(diseaseService.search("роса", 20)).thenReturn(List.of(card));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/diseases").param("q", "роса"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("Мучнистая роса"))
+                .andExpect(jsonPath("$[0].latinName").isEmpty());
+
+        verify(diseaseService).search("роса", 20);
+    }
+
+    @Test
+    void should_return_all_when_q_is_blank() throws Exception {
+        // arrange
+        when(diseaseService.getAll()).thenReturn(List.of());
+
+        // act + assert — пустая строка q = как без q
+        mockMvc.perform(get("/api/v1/diseases").param("q", "  "))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+
+        verify(diseaseService).getAll();
+    }
+
+    // ------------------------------------------------------------------ GET /diseases/{id}
+
+    @Test
+    void should_return_disease_card_when_id_exists() throws Exception {
+        // arrange
+        var card = new DiseaseCard(5L, "Серая гниль", "Botrytis cinerea",
+                "Серый пушистый налёт", "Удалить поражённые части", "Не переливать");
+        when(diseaseService.getById(5L)).thenReturn(card);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/diseases/5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(5))
+                .andExpect(jsonPath("$.name").value("Серая гниль"))
+                .andExpect(jsonPath("$.latinName").value("Botrytis cinerea"));
+    }
+
+    @Test
+    void should_return_404_when_disease_not_found() throws Exception {
+        // arrange
+        when(diseaseService.getById(999L)).thenThrow(new DiseaseNotFoundException(999L));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/diseases/999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("Disease not found: 999"));
+    }
+
+    @Test
+    void should_serialize_null_latin_name_when_not_present() throws Exception {
+        // arrange — latinName nullable для неинфекционных проблем
+        var card = new DiseaseCard(3L, "Хлороз", null,
+                "Пожелтение листьев", "Внести железо", "Контролировать pH");
+        when(diseaseService.getById(3L)).thenReturn(card);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/diseases/3"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.latinName").isEmpty());
+    }
+}


### PR DESCRIPTION
Closes #225

## Что сделано
- `GET /api/v1/diseases` — полный список болезней в алфавитном порядке
- `GET /api/v1/diseases?q=клещ` — делегирует `DiseaseService.search(q, 20)`
- `GET /api/v1/diseases/{id}` — карточка болезни; несуществующий id → 404
- `DiseasesController` в пакете `com.plantcare.api.web` реализует сгенерированный `DiseasesApi`
- `WebApiExceptionHandler` расширен: `DiseaseNotFoundException` → 404
- `ApiSecurityConfig`: `/api/v1/diseases/**` добавлен в публичный whitelist
- OpenAPI-спека: `src/main/resources/openapi/resources/diseases.yaml` + регистрация в `openapi.yaml`

## Миграции
Нет — таблица `diseases` уже существует (V24/V25).

## Backward-compat риски
Safe. Только добавление новых эндпоинтов, ничего не меняется в существующем API.

## Тесты
`DiseasesControllerTest` (7 тестов):
- список без `q` → `getAll()`
- пустой список
- поиск с `?q=` → `search(q, 20)`
- пробельный `q` → `getAll()`
- карточка по id
- 404 при несуществующем id
- nullable `latinName`

## Чек
- [x] mvn verify зелёное (unit + WebMvcTest; Testcontainers-тесты падают без Docker — pre-existing)
- [x] self-review пройден