### PR TITLE
feat: add speciesId to PlantUpdateRequest (#228)

### DIFF
--- a/src/main/java/com/plantcare/api/v1/PlantController.java
+++ b/src/main/java/com/plantcare/api/v1/PlantController.java
@@ -107,7 +107,9 @@ public class PlantController implements PlantsApi {
                 id,
                 request.getName(),
                 request.getNotes(),
-                request.getLocationId()
+                request.getLocationId(),
+                request.getSpeciesId(),
+                request.getClearSpecies()
         );
 
         return toDto(updated);

--- a/src/main/java/com/plantcare/core/service/PlantService.java
+++ b/src/main/java/com/plantcare/core/service/PlantService.java
@@ -508,6 +508,19 @@ public class PlantService {
 
     @Transactional
     public Plant updatePlant(Long userId, Long plantId, String name, String notes, Long locationId) {
+        return updatePlant(userId, plantId, name, notes, locationId, null, null);
+    }
+
+    @Transactional
+    public Plant updatePlant(
+            Long userId,
+            Long plantId,
+            String name,
+            String notes,
+            Long locationId,
+            Long speciesId,
+            Boolean clearSpecies
+    ) {
         Plant plant = getPlantOrThrow(userId, plantId);
 
         if (name != null) {
@@ -523,9 +536,23 @@ public class PlantService {
             plant.setLocation(location);
         }
 
+        if (speciesId != null) {
+            Species species = speciesRepository.findById(speciesId)
+                    .orElseThrow(() -> new EntityNotFoundException("Species not found: " + speciesId));
+            plant.setSpecies(species);
+        } else if (Boolean.TRUE.equals(clearSpecies)) {
+            plant.setSpecies(null);
+        }
+
         Plant saved = plantRepository.save(plant);
 
-        log.info("Updated plant {} via REST API (user {})", plantId, userId);
+        log.info(
+                "Updated plant {} via REST API (user {}, speciesId={}, clearSpecies={})",
+                plantId,
+                userId,
+                speciesId,
+                clearSpecies
+        );
 
         return saved;
     }

--- a/src/main/resources/openapi/resources/plants.yaml
+++ b/src/main/resources/openapi/resources/plants.yaml
@@ -512,6 +512,20 @@ schemas:
         type: integer
         format: int64
         nullable: true
+      speciesId:
+        type: integer
+        format: int64
+        nullable: true
+        description: |
+          Новый вид растения. Если не передан — вид не изменяется.
+          Для снятия привязки используй clearSpecies: true.
+          Если вид не найден — 404.
+      clearSpecies:
+        type: boolean
+        nullable: true
+        description: |
+          true — убрать привязку к виду (plant.species = null).
+          Игнорируется, если speciesId задан.
 
   PageResponsePlantDto:
     type: object

--- a/src/test/java/com/plantcare/api/v1/PlantControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/PlantControllerTest.java
@@ -287,7 +287,7 @@ class PlantControllerTest {
     void should_update_plant() throws Exception {
         Plant updated = mockPlant(1L, 1L, "Updated");
 
-        when(plantService.updatePlant(eq(1L), eq(1L), eq("Updated"), isNull(), isNull()))
+        when(plantService.updatePlant(eq(1L), eq(1L), eq("Updated"), isNull(), isNull(), isNull(), isNull()))
                 .thenReturn(updated);
 
         String body = """
@@ -299,6 +299,66 @@ class PlantControllerTest {
                         .content(body))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("Updated"));
+    }
+
+    @Test
+    void should_update_plant_species_when_speciesId_provided() throws Exception {
+        Plant updated = mockPlant(1L, 1L, "Ficus");
+
+        Species species = mock(Species.class);
+        when(species.getId()).thenReturn(7L);
+        when(species.getName()).thenReturn("Ficus benjamina");
+        when(updated.getSpecies()).thenReturn(species);
+
+        when(plantService.updatePlant(eq(1L), eq(1L), isNull(), isNull(), isNull(), eq(7L), isNull()))
+                .thenReturn(updated);
+
+        String body = """
+                {"speciesId": 7}
+                """;
+
+        mockMvc.perform(put("/api/v1/plants/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.speciesId").value(7))
+                .andExpect(jsonPath("$.speciesName").value("Ficus benjamina"));
+    }
+
+    @Test
+    void should_clear_species_when_clearSpecies_true() throws Exception {
+        Plant updated = mockPlant(1L, 1L, "Ficus");
+        // species is null after clearing
+        when(updated.getSpecies()).thenReturn(null);
+
+        when(plantService.updatePlant(eq(1L), eq(1L), isNull(), isNull(), isNull(), isNull(), eq(true)))
+                .thenReturn(updated);
+
+        String body = """
+                {"clearSpecies": true}
+                """;
+
+        mockMvc.perform(put("/api/v1/plants/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.speciesId").doesNotExist());
+    }
+
+    @Test
+    void should_return_404_when_species_not_found_on_update() throws Exception {
+        when(plantService.updatePlant(eq(1L), eq(1L), isNull(), isNull(), isNull(), eq(999L), isNull()))
+                .thenThrow(new EntityNotFoundException("Species not found: 999"));
+
+        String body = """
+                {"speciesId": 999}
+                """;
+
+        mockMvc.perform(put("/api/v1/plants/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
     }
 
     @Test


### PR DESCRIPTION
Closes #228

## Что сделано
- Добавлено поле `speciesId` (Long, nullable) в `PlantUpdateRequest` в OpenAPI-спеке
- Добавлено поле `clearSpecies` (boolean, nullable) для явного снятия привязки к виду
- `PlantService.updatePlant` расширен новой сигнатурой с `speciesId` и `clearSpecies`; старая 5-параметровая сигнатура делегирует в неё (backward compat)
- `PlantController.updatePlant` передаёт оба новых поля в сервис
- Несуществующий `speciesId` бросает `EntityNotFoundException` → 404

## Почему clearSpecies вместо null=убрать
`openApiNullable=false` в pom.xml — Jackson не различает "поле не передано" и "передано null". Явный флаг `clearSpecies: true` — единственный способ без изменения конфига генератора.

## Миграции
Нет — схема БД не изменялась (связь plants→species уже существует).

## Тесты
- `should_update_plant_species_when_speciesId_provided` — happy path: смена вида
- `should_clear_species_when_clearSpecies_true` — снятие привязки через clearSpecies
- `should_return_404_when_species_not_found_on_update` — несуществующий вид → 404
- Обновлён `should_update_plant` — мок теперь покрывает 7-параметровую сигнатуру

## Чек
- [x] mvn test (PlantControllerTest) 31/31 зелёный
- [x] Нет @Autowired полей
- [x] Нет голых RuntimeException
- [x] @Transactional только на сервисном слое
- [x] self-review пройден