### PR TITLE
feat: add totalCareEvents to GET /me (#226)

### DIFF
--- a/src/main/java/com/plantcare/api/v1/MeController.java
+++ b/src/main/java/com/plantcare/api/v1/MeController.java
@@ -65,6 +65,7 @@ public class MeController implements MeApi {
                 profile.name(),
                 profile.plantsTotal(),
                 profile.tasksToday(),
+                profile.totalCareEvents(),
                 profile.notificationsUnread(),
                 profile.quietHoursStart().format(HH_MM),
                 profile.quietHoursEnd().format(HH_MM),

--- a/src/main/java/com/plantcare/core/repository/CareHistoryRepository.java
+++ b/src/main/java/com/plantcare/core/repository/CareHistoryRepository.java
@@ -54,6 +54,14 @@ public interface CareHistoryRepository extends JpaRepository<CareHistory, Long> 
                                          @Param("after") LocalDateTime after);
 
     /**
+     * Суммарное число активных (не-cancelled) записей ухода по всем растениям пользователя
+     * за всё время, включая архивированные растения (issue #226).
+     */
+    @Query("SELECT COUNT(h) FROM CareHistory h " +
+            "WHERE h.plant.user.id = :userId AND h.cancelledBy IS NULL")
+    long countAllByUserId(@Param("userId") Long userId);
+
+    /**
      * Все done_at для всех растений юзера (для расчёта user-streak по дням).
      * Активные записи (не-cancelled). Сортировка по убыванию.
      */

--- a/src/main/java/com/plantcare/core/service/CareHistoryService.java
+++ b/src/main/java/com/plantcare/core/service/CareHistoryService.java
@@ -124,6 +124,18 @@ public class CareHistoryService {
     }
 
     /**
+     * Суммарное число активных (не-cancelled) записей ухода по всем растениям
+     * пользователя за всё время, включая архивированные растения (issue #226).
+     *
+     * @param userId id пользователя
+     * @return общее число уходов
+     */
+    @Transactional(readOnly = true)
+    public long countAllByUser(Long userId) {
+        return careHistoryRepository.countAllByUserId(userId);
+    }
+
+    /**
      * Сводная статистика по всей истории растения (issue #206).
      *
      * <p>Возвращает: общее число активных записей, число on-time, процент on-time,

--- a/src/main/java/com/plantcare/core/service/UserProfileService.java
+++ b/src/main/java/com/plantcare/core/service/UserProfileService.java
@@ -38,6 +38,7 @@ public class UserProfileService {
     private final PlantRepository plantRepository;
     private final TodayApiService todayApiService;
     private final UserSettingsService userSettingsService;
+    private final CareHistoryService careHistoryService;
 
     /**
      * Собранный профиль пользователя для {@code GET /api/v1/me}.
@@ -55,6 +56,7 @@ public class UserProfileService {
             String avatar,
             int plantsTotal,
             int tasksToday,
+            long totalCareEvents,
             int notificationsUnread,
             LocalTime quietHoursStart,
             LocalTime quietHoursEnd,
@@ -101,6 +103,8 @@ public class UserProfileService {
                 .filter(t -> t.doneAt() == null)
                 .count();
 
+        long totalCareEvents = careHistoryService.countAllByUser(user.getId());
+
         // notificationsUnread — плейсхолдер: фид уведомлений (issue #183) ещё не влит.
         int notificationsUnread = 0;
 
@@ -118,6 +122,7 @@ public class UserProfileService {
                 null, // avatar — плейсхолдер, колонки в схеме нет.
                 plantsTotal,
                 tasksToday,
+                totalCareEvents,
                 notificationsUnread,
                 user.getQuietHoursStart(),
                 user.getQuietHoursEnd(),

--- a/src/main/resources/openapi/resources/me.yaml
+++ b/src/main/resources/openapi/resources/me.yaml
@@ -73,6 +73,7 @@ schemas:
       - name
       - plantsTotal
       - tasksToday
+      - totalCareEvents
       - notificationsUnread
       - quietHoursStart
       - quietHoursEnd
@@ -132,6 +133,14 @@ schemas:
           пользователя: дедлайн до конца сегодняшнего дня, отметка «сделано»
           ещё не проставлена. Это pending-подмножество `GET /api/v1/today`.
         example: 3
+      totalCareEvents:
+        type: integer
+        format: int64
+        minimum: 0
+        description: |
+          Суммарное число уходов за всё время пользователя (включая архивированные
+          растения). Компенсирующие (отменённые) записи не учитываются.
+        example: 348
       notificationsUnread:
         type: integer
         format: int32

--- a/src/test/java/com/plantcare/api/v1/MeControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/MeControllerTest.java
@@ -81,7 +81,7 @@ class MeControllerTest {
         // seasonalMode-строка, featureFlags-map и linkage booleans
         Profile profile = new Profile(
                 42L, "user@example.com", true, CREATED_AT,
-                "Антон", null, 12, 3, 0,
+                "Антон", null, 12, 3, 348L, 0,
                 LocalTime.of(22, 0), LocalTime.of(8, 0),
                 "Europe/Moscow", "ru",
                 true, SeasonalMode.FIXED, true,
@@ -100,6 +100,7 @@ class MeControllerTest {
                 .andExpect(jsonPath("$.avatar").value(org.hamcrest.Matchers.nullValue()))
                 .andExpect(jsonPath("$.plantsTotal").value(12))
                 .andExpect(jsonPath("$.tasksToday").value(3))
+                .andExpect(jsonPath("$.totalCareEvents").value(348))
                 .andExpect(jsonPath("$.notificationsUnread").value(0))
                 .andExpect(jsonPath("$.quietHoursStart").value("22:00"))
                 .andExpect(jsonPath("$.quietHoursEnd").value("08:00"))
@@ -123,7 +124,7 @@ class MeControllerTest {
         // assert на отсутствие JSON-путей ловит регрессию, если кто-то добавит их в MeResponse.
         Profile profile = new Profile(
                 42L, "user@example.com", true, CREATED_AT,
-                "Антон", null, 1, 0, 0,
+                "Антон", null, 1, 0, 0L, 0,
                 LocalTime.of(22, 0), LocalTime.of(8, 0),
                 "Europe/Moscow", "ru",
                 false, SeasonalMode.MULTIPLIER, false,
@@ -151,7 +152,7 @@ class MeControllerTest {
         // arrange — edge: чисто Telegram-юзер, email == null, emailLinked == false
         Profile profile = new Profile(
                 42L, null, false, CREATED_AT,
-                "Аноним", null, 0, 0, 0,
+                "Аноним", null, 0, 0, 0L, 0,
                 LocalTime.of(22, 0), LocalTime.of(9, 0),
                 "UTC", "ru",
                 false, SeasonalMode.MULTIPLIER, false,
@@ -238,7 +239,7 @@ class MeControllerTest {
         // остальные поля апдейта остаются null (partial semantics)
         Profile updated = new Profile(
                 42L, "user@example.com", true, CREATED_AT,
-                "Антон", null, 1, 0, 0,
+                "Антон", null, 1, 0, 0L, 0,
                 LocalTime.of(22, 0), LocalTime.of(8, 0),
                 "Europe/Moscow", "ru",
                 true, SeasonalMode.FIXED, true,
@@ -300,7 +301,7 @@ class MeControllerTest {
         // arrange — AC: валидный IANA tz прокидывается в сервис и возвращается в ответе
         Profile updated = new Profile(
                 42L, "user@example.com", true, CREATED_AT,
-                "Антон", null, 1, 0, 0,
+                "Антон", null, 1, 0, 0L, 0,
                 LocalTime.of(22, 0), LocalTime.of(9, 0),
                 "Asia/Almaty", "ru",
                 false, SeasonalMode.MULTIPLIER, false,
@@ -458,7 +459,7 @@ class MeControllerTest {
     private static Profile sampleProfile() {
         return new Profile(
                 42L, "user@example.com", true, CREATED_AT,
-                "Антон", null, 0, 0, 0,
+                "Антон", null, 0, 0, 0L, 0,
                 LocalTime.of(22, 0), LocalTime.of(9, 0),
                 "Europe/Moscow", "ru",
                 false, SeasonalMode.MULTIPLIER, false,

--- a/src/test/java/com/plantcare/core/service/CareHistoryServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/CareHistoryServiceTest.java
@@ -359,6 +359,27 @@ class CareHistoryServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("countAllByUser")
+    class CountAllByUserTests {
+
+        @Test
+        @DisplayName("should_return_zero_when_user_has_no_care_history")
+        void should_return_zero_when_user_has_no_care_history() {
+            when(historyRepository.countAllByUserId(42L)).thenReturn(0L);
+
+            assertThat(service.countAllByUser(42L)).isZero();
+        }
+
+        @Test
+        @DisplayName("should_return_correct_count_when_user_has_care_events")
+        void should_return_correct_count_when_user_has_care_events() {
+            when(historyRepository.countAllByUserId(42L)).thenReturn(348L);
+
+            assertThat(service.countAllByUser(42L)).isEqualTo(348L);
+        }
+    }
+
     // ===== helpers =====
 
     /** Создаёт мок-CareHistory с указанными флагами on_time / cancelled. */


### PR DESCRIPTION
Closes #226

## Что сделано
- Добавлен метод `CareHistoryRepository.countAllByUserId(Long userId)` — JPQL-запрос считает активные (не-cancelled) записи по всем растениям пользователя, включая архивированные
- Добавлен метод `CareHistoryService.countAllByUser(Long userId)` с `@Transactional(readOnly = true)`
- Добавлено поле `totalCareEvents: long` в `UserProfileService.Profile` record
- `UserProfileService.getProfile` вызывает `careHistoryService.countAllByUser` и передаёт результат в `Profile`
- `MeController.toResponse` прокидывает `profile.totalCareEvents()` в сгенерированный `MeResponse`
- OpenAPI-спека `me.yaml`: поле `totalCareEvents` добавлено в `required` и в `properties` (`int64`, `minimum: 0`)

## Миграции
Нет — только код, схема БД не меняется.

## Backward-compat риски
safe — новое поле добавляется в ответ, клиенты не знающие о нём его проигнорируют.

## Тесты
- `CareHistoryServiceTest` — новый `@Nested` класс `CountAllByUserTests`: happy (348 уходов) + edge (0 уходов, пользователь без истории)
- `MeControllerTest` — `should_return_full_extended_profile_shape_with_linkage_booleans_when_getting_me` расширен проверкой `$.totalCareEvents == 348`; все `Profile`-конструкторы обновлены под новую сигнатуру record

## Чек
- [x] mvn test (CareHistoryServiceTest 23/23, MeControllerTest 16/16) зелёное
- [x] Нет @Autowired полей (только конструкторная инъекция через @RequiredArgsConstructor)
- [x] Нет голых RuntimeException
- [x] @Transactional только на сервисном слое
- [x] self-review пройден