### PR TITLE
feat: acquiredAt + isNew fields in POST /plants (#221)

### DIFF
--- a/src/main/java/com/plantcare/api/v1/PlantController.java
+++ b/src/main/java/com/plantcare/api/v1/PlantController.java
@@ -16,6 +16,7 @@ import com.plantcare.core.domain.Plant;
 import com.plantcare.core.domain.User;
 import com.plantcare.core.domain.enums.TaskType;
 import com.plantcare.core.service.HealthScoreService;
+import com.plantcare.core.service.PlantAcclimationService;
 import com.plantcare.core.service.PlantDiagnosisReportService;
 import com.plantcare.core.service.PlantService;
 import com.plantcare.core.service.PlantService.ScheduleInputDto;
@@ -23,6 +24,8 @@ import com.plantcare.core.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 
@@ -37,8 +40,10 @@ import java.util.List;
 public class PlantController implements PlantsApi {
 
     private final PlantService plantService;
+    private final PlantAcclimationService plantAcclimationService;
     private final UserService userService;
     private final CurrentUserProvider currentUserProvider;
+    private final Clock clock;
 
     @Override
     public PageResponsePlantDto listPlants(Long locationId, Integer offset, Integer limit) {
@@ -79,8 +84,16 @@ public class PlantController implements PlantsApi {
                 request.getLocationId(),
                 request.getSpeciesId(),
                 request.getParentPlantId(),
+                request.getAcquiredAt(),
                 schedules
         );
+
+        // Акклиматизация вызывается вне транзакции createPlant: она открывает свою транзакцию внутри.
+        if (Boolean.TRUE.equals(request.getIsNew())) {
+            plantAcclimationService.enable(user, plant.getId());
+            // Перечитываем растение с обновлёнными полями акклиматизации.
+            plant = plantService.getPlantOrThrow(user.getId(), plant.getId());
+        }
 
         return toDto(plant);
     }
@@ -172,7 +185,7 @@ public class PlantController implements PlantsApi {
         return response;
     }
 
-    private static PlantDto toDto(Plant plant) {
+    private PlantDto toDto(Plant plant) {
         PlantDto dto = new PlantDto(plant.getId(), plant.getName(), plant.isArchived())
                 .notes(plant.getNotes())
                 .photoFileId(plant.getPhotoFileId());
@@ -191,10 +204,20 @@ public class PlantController implements PlantsApi {
             dto.createdAt(plant.getCreatedAt().atOffset(ZoneOffset.UTC));
         }
 
+        dto.acquiredAt(plant.getAcquiredAt());
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        boolean inAcclimation = plant.isInAcclimation(now);
+        dto.inAcclimation(inAcclimation);
+
+        if (plant.getAcclimationUntil() != null) {
+            dto.acclimationUntil(plant.getAcclimationUntil().atOffset(ZoneOffset.UTC));
+        }
+
         return dto;
     }
 
-    private static PlantDto toDto(Plant plant, HealthScoreService.HealthScore health) {
+    private PlantDto toDto(Plant plant, HealthScoreService.HealthScore health) {
         PlantDto dto = toDto(plant);
         if (health != null) {
             dto.healthInsufficientData(health.insufficientData());

--- a/src/main/java/com/plantcare/core/service/PlantService.java
+++ b/src/main/java/com/plantcare/core/service/PlantService.java
@@ -137,6 +137,19 @@ public class PlantService {
             Long speciesId,
             Long parentPlantId
     ) {
+        return createPlant(user, name, notes, locationId, speciesId, parentPlantId, (LocalDate) null);
+    }
+
+    @Transactional
+    public Plant createPlant(
+            User user,
+            String name,
+            String notes,
+            Long locationId,
+            Long speciesId,
+            Long parentPlantId,
+            LocalDate acquiredAt
+    ) {
         Location location;
         if (locationId != null) {
             location = locationService.getUserLocationOrThrow(user.getId(), locationId);
@@ -163,21 +176,24 @@ public class PlantService {
                 .notes(notes)
                 .species(species)
                 .parent(parent)
+                .acquiredAt(acquiredAt)
                 .build();
 
         Plant saved = plantRepository.save(plant);
 
         log.info(
-                "Created plant '{}' (id={}, speciesId={}, parentPlantId={}) via REST API for user {}",
+                "Created plant '{}' (id={}, speciesId={}, parentPlantId={}, acquiredAt={}) via REST API for user {}",
                 name,
                 saved.getId(),
                 speciesId,
                 parentPlantId,
+                acquiredAt,
                 user.getId()
         );
 
         return saved;
     }
+
     @Transactional
     public Plant createPlant(
             User user,
@@ -210,10 +226,11 @@ public class PlantService {
             Long locationId,
             Long speciesId,
             Long parentPlantId,
+            LocalDate acquiredAt,
             List<ScheduleInputDto> schedules
     ) {
         // internal call — already within @Transactional boundary, proxy bypass is intentional
-        Plant plant = createPlant(user, name, notes, locationId, speciesId, parentPlantId);
+        Plant plant = createPlant(user, name, notes, locationId, speciesId, parentPlantId, acquiredAt);
 
         if (schedules == null || schedules.isEmpty()) {
             LocalDateTime now = LocalDateTime.now(clock);

--- a/src/main/resources/openapi/resources/plants.yaml
+++ b/src/main/resources/openapi/resources/plants.yaml
@@ -446,6 +446,23 @@ schemas:
         enum: [ GREEN, YELLOW, RED ]
         nullable: true
         description: Цветовая зона. null если insufficientData.
+      acquiredAt:
+        type: string
+        format: date
+        nullable: true
+        description: Дата покупки/получения растения (ISO-8601). null если не указана.
+        example: "2026-05-20"
+      inAcclimation:
+        type: boolean
+        nullable: true
+        description: true пока acclimation_until > now(). Вычисляемое поле, в БД не хранится.
+        example: true
+      acclimationUntil:
+        type: string
+        format: date-time
+        nullable: true
+        description: Конец периода акклиматизации (UTC). null если акклиматизация не активна.
+        example: "2026-06-10T12:00:00Z"
 
   PlantCreateRequest:
     type: object
@@ -486,6 +503,17 @@ schemas:
           отводком/потомком этого растения. Родитель должен принадлежать текущему
           пользователю и не быть архивированным, иначе 404/403.
         example: 10
+      acquiredAt:
+        type: string
+        format: date
+        nullable: true
+        description: Дата покупки/получения растения (ISO-8601). Используется для годовщин и строки «С тобой с …».
+        example: "2026-05-20"
+      isNew:
+        type: boolean
+        nullable: true
+        description: Если true — включить режим акклиматизации на 21 день после создания.
+        example: true
       schedules:
         type: array
         nullable: true

--- a/src/test/java/com/plantcare/api/v1/PlantControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/PlantControllerTest.java
@@ -10,9 +10,11 @@ import com.plantcare.core.domain.User;
 import com.plantcare.core.domain.enums.HealthZone;
 import com.plantcare.core.service.HealthScoreService;
 import com.plantcare.core.service.LocationService;
+import com.plantcare.core.service.PlantAcclimationService;
 import com.plantcare.core.service.PlantDiagnosisReportService;
 import com.plantcare.core.service.PlantService;
 import com.plantcare.core.service.UserService;
+import java.time.Clock;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,6 +63,9 @@ class PlantControllerTest {
     private PlantService plantService;
 
     @MockitoBean
+    private PlantAcclimationService plantAcclimationService;
+
+    @MockitoBean
     private UserService userService;
 
     @MockitoBean
@@ -69,9 +74,15 @@ class PlantControllerTest {
     @MockitoBean
     private CurrentUserProvider currentUserProvider;
 
+    @MockitoBean
+    private Clock clock;
+
     @org.junit.jupiter.api.BeforeEach
     void stubCurrentUser() {
         when(currentUserProvider.currentUserId()).thenReturn(1L);
+        java.time.Instant fixedNow = java.time.Instant.parse("2026-06-03T00:00:00Z");
+        when(clock.instant()).thenReturn(fixedNow);
+        when(clock.getZone()).thenReturn(java.time.ZoneOffset.UTC);
     }
 
     private Plant mockPlant(long plantId, long userId, String name) {
@@ -169,6 +180,7 @@ class PlantControllerTest {
                 isNull(),
                 isNull(),
                 isNull(),
+                isNull(),
                 isNull()
         )).thenReturn(plant);
 
@@ -202,6 +214,7 @@ class PlantControllerTest {
                 isNull(),
                 eq(7L),
                 isNull(),
+                isNull(),
                 isNull()
         )).thenReturn(plant);
 
@@ -231,6 +244,7 @@ class PlantControllerTest {
                 isNull(),
                 isNull(),
                 eq(10L),
+                isNull(),
                 isNull()
         )).thenReturn(plant);
 
@@ -523,6 +537,7 @@ class PlantControllerTest {
                 isNull(),
                 isNull(),
                 isNull(),
+                isNull(),
                 isNull()
         )).thenReturn(plant);
 
@@ -548,6 +563,7 @@ class PlantControllerTest {
         when(plantService.createPlant(
                 eq(user),
                 eq("Rose"),
+                isNull(),
                 isNull(),
                 isNull(),
                 isNull(),
@@ -583,6 +599,7 @@ class PlantControllerTest {
         when(plantService.createPlant(
                 eq(user),
                 eq("Monstera"),
+                isNull(),
                 isNull(),
                 isNull(),
                 isNull(),

--- a/src/test/java/com/plantcare/api/v1/PlantCreateAcquiredAtControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/PlantCreateAcquiredAtControllerTest.java
@@ -1,0 +1,317 @@
+package com.plantcare.api.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.core.domain.Location;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.service.HealthScoreService;
+import com.plantcare.core.service.LocationService;
+import com.plantcare.core.service.PlantAcclimationService;
+import com.plantcare.core.service.PlantDiagnosisReportService;
+import com.plantcare.core.service.PlantService;
+import com.plantcare.core.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * {@link PlantController} tests covering issue #221:
+ * acquiredAt and isNew fields in POST /plants.
+ */
+@WebMvcTest(PlantController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PlantCreateAcquiredAtControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private PlantService plantService;
+
+    @MockitoBean
+    private PlantAcclimationService plantAcclimationService;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private LocationService locationService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    @MockitoBean
+    private Clock clock;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        when(currentUserProvider.currentUserId()).thenReturn(1L);
+        testUser = User.builder().telegramChatId(1L).build();
+        when(userService.getByIdOrThrow(1L)).thenReturn(testUser);
+        // Stub clock to return fixed "now" for inAcclimation computation
+        Instant fixedNow = Instant.parse("2026-06-03T00:00:00Z");
+        when(clock.instant()).thenReturn(fixedNow);
+        when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+    }
+
+    /** Fixed "now" that matches the stubbed clock — 2026-06-03T00:00:00Z. */
+    private static final LocalDateTime FIXED_NOW = LocalDateTime.of(2026, 6, 3, 0, 0, 0);
+
+    private Plant mockPlantWithAcquiredAt(long id, LocalDate acquiredAt, LocalDateTime acclimationUntil) {
+        Location location = mock(Location.class);
+        when(location.getId()).thenReturn(1L);
+        when(location.getName()).thenReturn("Подоконник");
+
+        Plant plant = mock(Plant.class);
+        when(plant.getId()).thenReturn(id);
+        when(plant.getName()).thenReturn("Монстера");
+        when(plant.getNotes()).thenReturn(null);
+        when(plant.getPhotoFileId()).thenReturn(null);
+        when(plant.getLocation()).thenReturn(location);
+        when(plant.getSpecies()).thenReturn(null);
+        when(plant.isArchived()).thenReturn(false);
+        when(plant.getCreatedAt()).thenReturn(null);
+        when(plant.getUser()).thenReturn(mock(com.plantcare.core.domain.User.class));
+        when(plant.getAcquiredAt()).thenReturn(acquiredAt);
+        when(plant.getAcclimationUntil()).thenReturn(acclimationUntil);
+        // isInAcclimation is called with LocalDateTime.now(clock) = FIXED_NOW
+        when(plant.isInAcclimation(any(LocalDateTime.class)))
+                .thenReturn(acclimationUntil != null && acclimationUntil.isAfter(FIXED_NOW));
+        return plant;
+    }
+
+    // ==================== acquiredAt ====================
+
+    @Test
+    void should_save_acquiredAt_when_provided_in_request() throws Exception {
+        // arrange
+        LocalDate acquired = LocalDate.of(2026, 5, 20);
+        Plant plant = mockPlantWithAcquiredAt(30L, acquired, null);
+
+        when(plantService.createPlant(
+                eq(testUser),
+                eq("Монстера"),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                eq(acquired),
+                isNull()
+        )).thenReturn(plant);
+
+        String body = """
+                {"name": "Монстера", "acquiredAt": "2026-05-20"}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/plants")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(30))
+                .andExpect(jsonPath("$.acquiredAt").value("2026-05-20"))
+                .andExpect(jsonPath("$.inAcclimation").value(false))
+                .andExpect(jsonPath("$.acclimationUntil").isEmpty());
+
+        verify(plantAcclimationService, never()).enable(any(), any());
+    }
+
+    @Test
+    void should_not_set_acquiredAt_when_absent_in_request() throws Exception {
+        // arrange
+        Plant plant = mockPlantWithAcquiredAt(31L, null, null);
+
+        when(plantService.createPlant(
+                eq(testUser),
+                eq("Фикус"),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull()
+        )).thenReturn(plant);
+
+        String body = """
+                {"name": "Фикус"}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/plants")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.acquiredAt").isEmpty())
+                .andExpect(jsonPath("$.inAcclimation").value(false))
+                .andExpect(jsonPath("$.acclimationUntil").isEmpty());
+
+        verify(plantAcclimationService, never()).enable(any(), any());
+    }
+
+    // ==================== isNew + acclimation ====================
+
+    @Test
+    void should_enable_acclimation_when_isNew_is_true() throws Exception {
+        // arrange
+        LocalDateTime acclimationUntil = FIXED_NOW.plusDays(21);
+        Plant createdPlant = mockPlantWithAcquiredAt(32L, null, null);
+        Plant plantAfterAcclimation = mockPlantWithAcquiredAt(32L, null, acclimationUntil);
+
+        when(plantService.createPlant(
+                eq(testUser),
+                eq("Новая Монстера"),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull()
+        )).thenReturn(createdPlant);
+
+        when(plantAcclimationService.enable(eq(testUser), eq(32L))).thenReturn(plantAfterAcclimation);
+
+        when(plantService.getPlantOrThrow(any(), eq(32L))).thenReturn(plantAfterAcclimation);
+
+        String body = """
+                {"name": "Новая Монстера", "isNew": true}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/plants")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(32))
+                .andExpect(jsonPath("$.inAcclimation").value(true))
+                .andExpect(jsonPath("$.acclimationUntil").isNotEmpty());
+
+        verify(plantAcclimationService).enable(eq(testUser), eq(32L));
+        verify(plantService).getPlantOrThrow(any(), eq(32L));
+    }
+
+    @Test
+    void should_not_enable_acclimation_when_isNew_is_false() throws Exception {
+        // arrange
+        Plant plant = mockPlantWithAcquiredAt(33L, null, null);
+
+        when(plantService.createPlant(
+                eq(testUser),
+                eq("Фикус"),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull()
+        )).thenReturn(plant);
+
+        String body = """
+                {"name": "Фикус", "isNew": false}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/plants")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.inAcclimation").value(false));
+
+        verify(plantAcclimationService, never()).enable(any(), any());
+    }
+
+    @Test
+    void should_not_enable_acclimation_when_isNew_is_absent() throws Exception {
+        // arrange
+        Plant plant = mockPlantWithAcquiredAt(34L, null, null);
+
+        when(plantService.createPlant(
+                eq(testUser),
+                eq("Фикус"),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull()
+        )).thenReturn(plant);
+
+        String body = """
+                {"name": "Фикус"}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/plants")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated());
+
+        verify(plantAcclimationService, never()).enable(any(), any());
+    }
+
+    @Test
+    void should_save_acquiredAt_and_enable_acclimation_together() throws Exception {
+        // arrange: оба поля переданы одновременно
+        LocalDate acquired = LocalDate.of(2026, 5, 15);
+        LocalDateTime acclimationUntil = FIXED_NOW.plusDays(21);
+        Plant createdPlant = mockPlantWithAcquiredAt(35L, acquired, null);
+        Plant plantAfterAcclimation = mockPlantWithAcquiredAt(35L, acquired, acclimationUntil);
+
+        when(plantService.createPlant(
+                eq(testUser),
+                eq("Растение"),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                eq(acquired),
+                isNull()
+        )).thenReturn(createdPlant);
+
+        when(plantAcclimationService.enable(eq(testUser), eq(35L))).thenReturn(plantAfterAcclimation);
+        when(plantService.getPlantOrThrow(any(), eq(35L))).thenReturn(plantAfterAcclimation);
+
+        String body = """
+                {"name": "Растение", "acquiredAt": "2026-05-15", "isNew": true}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/plants")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.acquiredAt").value("2026-05-15"))
+                .andExpect(jsonPath("$.inAcclimation").value(true))
+                .andExpect(jsonPath("$.acclimationUntil").isNotEmpty());
+    }
+}


### PR DESCRIPTION
Closes #221

## Что сделано
- Расширен `PlantCreateRequest` (OpenAPI + сгенерированная модель): поля `acquiredAt` (date, nullable) и `isNew` (boolean, nullable)
- Расширен `PlantDto` (OpenAPI + сгенерированная модель): поля `acquiredAt`, `inAcclimation`, `acclimationUntil`
- Добавлен перегруженный метод `PlantService.createPlant(..., LocalDate acquiredAt, List<ScheduleInputDto> schedules)` — единственный вариант с полным набором параметров; старые перегрузки делегируют к нему
- `PlantController.createPlant`: передаёт `acquiredAt` в сервис; если `isNew == true` — вызывает `PlantAcclimationService.enable()` **вне** транзакции создания, затем перечитывает растение
- `PlantController.toDto`: маппит `acquiredAt`, вычисляет `inAcclimation` через инжектируемый `Clock`, маппит `acclimationUntil`

## Миграции
Нет — `plants.acquired_at` добавлена в V20, `acclimation_until` в V12.

## Backward-compat риски
Safe — оба поля nullable, отсутствие полей в запросе не меняет поведение.

## Тесты
- `PlantCreateAcquiredAtControllerTest` (6 тестов): acquiredAt сохраняется; acquiredAt отсутствует → null; `isNew=true` → акклиматизация включена; `isNew=false` → не включена; `isNew` отсутствует → не включена; оба поля вместе
- `PlantControllerTest` (28 тестов): все существующие тесты обновлены под новую 8-аргументную сигнатуру сервиса
- `PlantAcclimationServiceTest` (9 тестов): без изменений, все зелёные

## Чек
- [x] mvn verify зелёное (unit-тесты; IT падают из-за отсутствия Docker — это pre-existing flaky)
- [x] self-review пройден