### PR TITLE
feat: plant archive list, archive/restore/hard-delete endpoints (#219)

### DIFF
--- a/src/main/java/com/plantcare/api/v1/PlantController.java
+++ b/src/main/java/com/plantcare/api/v1/PlantController.java
@@ -9,6 +9,7 @@ import com.plantcare.api.generated.model.PlantDiagnosisDto;
 import com.plantcare.api.generated.model.PlantDto;
 import com.plantcare.api.generated.model.PlantFamilyMemberDto;
 import com.plantcare.api.generated.model.PlantFamilyResponse;
+import com.plantcare.api.generated.model.PlantArchiveRequest;
 import com.plantcare.api.generated.model.PlantHealthDto;
 import com.plantcare.api.generated.model.PlantUpdateRequest;
 import com.plantcare.api.generated.model.ScheduleInput;
@@ -46,8 +47,17 @@ public class PlantController implements PlantsApi {
     private final Clock clock;
 
     @Override
-    public PageResponsePlantDto listPlants(Long locationId, Integer offset, Integer limit) {
+    public PageResponsePlantDto listPlants(String status, Long locationId, Integer offset, Integer limit) {
         Long userId = currentUserProvider.currentUserId();
+
+        if ("archived".equalsIgnoreCase(status)) {
+            List<PlantDto> archived = plantService.listArchivedPlants(userId).stream()
+                    .map(this::toArchivedDto)
+                    .toList();
+            // Архивная выдача не пагинируется на сервере (экран показывает весь список):
+            // отдаём всё одной страницей, total = размеру списка.
+            return new PageResponsePlantDto(archived, archived.size(), 0, archived.size());
+        }
 
         int safeLimit = Math.min(Math.max(limit, 1), 100);
         int safeOffset = Math.max(offset, 0);
@@ -61,6 +71,28 @@ public class PlantController implements PlantsApi {
                 .toList();
 
         return new PageResponsePlantDto(items, (int) total, safeOffset, safeLimit);
+    }
+
+    @Override
+    public PlantDto archivePlant(Long id, PlantArchiveRequest request) {
+        Long userId = currentUserProvider.currentUserId();
+
+        Boolean gifted = request != null ? request.getGifted() : null;
+        String note = request != null ? request.getNote() : null;
+
+        Plant archived = plantService.archivePlantWithReason(userId, id, gifted, note);
+
+        PlantDto dto = toDto(archived);
+        applyArchiveReason(dto, archived);
+        return dto;
+    }
+
+    @Override
+    public PlantDto restorePlant(Long id) {
+        Long userId = currentUserProvider.currentUserId();
+
+        Plant restored = plantService.restorePlant(userId, id);
+        return toDto(restored);
     }
 
     @Override
@@ -131,7 +163,7 @@ public class PlantController implements PlantsApi {
     @Override
     public void deletePlant(Long id) {
         Long userId = currentUserProvider.currentUserId();
-        plantService.archivePlant(userId, id);
+        plantService.hardDeletePlant(userId, id);
     }
 
     @Override
@@ -229,6 +261,29 @@ public class PlantController implements PlantsApi {
             }
         }
         return dto;
+    }
+
+    /**
+     * Архивное растение с агрегатами для экрана «Архив» (issue #219).
+     * Поверх базового DTO добавляет поля выбытия и счётчики.
+     */
+    private PlantDto toArchivedDto(PlantService.ArchivedPlant archived) {
+        Plant plant = archived.plant();
+
+        PlantDto dto = toDto(plant);
+        applyArchiveReason(dto, plant);
+        dto.totalCareDays(archived.totalCareDays())
+                .totalCareEvents(archived.totalCareEvents());
+        return dto;
+    }
+
+    /** Заполняет поля выбытия (archivedAt/gifted/note) из растения (issue #219). */
+    private void applyArchiveReason(PlantDto dto, Plant plant) {
+        if (plant.getArchivedAt() != null) {
+            dto.archivedAt(plant.getArchivedAt().atOffset(ZoneOffset.UTC));
+        }
+        dto.gifted(plant.getArchiveGifted())
+                .note(plant.getArchiveNote());
     }
 
     private static PlantFamilyMemberDto toFamilyMemberDto(Plant plant) {

--- a/src/main/java/com/plantcare/core/domain/Plant.java
+++ b/src/main/java/com/plantcare/core/domain/Plant.java
@@ -77,6 +77,20 @@ public class Plant extends BaseEntity {
     private LocalDateTime archivedAt;
 
     /**
+     * Причина выбытия (issue #219): {@code true} — растение подарили,
+     * {@code false} — погибло. {@code null} пока растение активно.
+     */
+    @Column(name = "archive_gifted")
+    private Boolean archiveGifted;
+
+    /**
+     * Свободная заметка о выбытии растения (issue #219), напр. «Залила соседка».
+     * {@code null} — не задана. Сбрасывается при восстановлении из архива.
+     */
+    @Column(name = "archive_note", columnDefinition = "text")
+    private String archiveNote;
+
+    /**
      * Дата, когда юзер «завёл» растение (issue #117). NULL = юзер не указал,
      * в годовщинах не участвует и строка «С тобой с …» в карточке не печатается.
      * Тип — {@link LocalDate}, в БД хранится как DATE (без TZ): юбилеи привязаны
@@ -143,6 +157,30 @@ public class Plant extends BaseEntity {
 
     public void archive() {
         this.archivedAt = LocalDateTime.now();
+    }
+
+    /**
+     * Архивация с метаданными выбытия (issue #219). Момент архивации задаётся
+     * вызывающим (сервис с инжектируемым {@link java.time.Clock}).
+     *
+     * @param at     момент архивации (UTC)
+     * @param gifted true — подарили, false — погибло, null — не указано
+     * @param note   свободная заметка, может быть null
+     */
+    public void archive(LocalDateTime at, Boolean gifted, String note) {
+        this.archivedAt = at;
+        this.archiveGifted = gifted;
+        this.archiveNote = note;
+    }
+
+    /**
+     * Восстановление из архива (issue #219): сбрасывает дату архивации и
+     * метаданные выбытия. Расписания при этом не трогаются.
+     */
+    public void restore() {
+        this.archivedAt = null;
+        this.archiveGifted = null;
+        this.archiveNote = null;
     }
 
     /** issue #75: true, если сейчас активен режим акклиматизации. */

--- a/src/main/java/com/plantcare/core/repository/PlantRepository.java
+++ b/src/main/java/com/plantcare/core/repository/PlantRepository.java
@@ -91,6 +91,15 @@ public interface PlantRepository extends JpaRepository<Plant, Long> {
     List<Plant> findAllByUserIdAndArchivedAtIsNotNullOrderByArchivedAtDesc(Long userId);
 
     /**
+     * Архивные растения юзера для REST-экрана «Архив» (issue #219).
+     * {@code location}/{@code species} подтягиваются через {@link EntityGraph}:
+     * DTO собирается в контроллере вне транзакции (OSIV=false), иначе ленивые
+     * связи дадут {@code no Session}. Сортировка — свежие сверху.
+     */
+    @EntityGraph(attributePaths = {"location", "species"})
+    List<Plant> findByUserIdAndArchivedAtIsNotNullOrderByArchivedAtDesc(Long userId);
+
+    /**
      * Архивное растение конкретного юзера по id.
      * Используется в карточке архива и в действиях «восстановить / удалить навсегда».
      */

--- a/src/main/java/com/plantcare/core/service/PlantService.java
+++ b/src/main/java/com/plantcare/core/service/PlantService.java
@@ -882,6 +882,120 @@ public class PlantService {
         log.info("Archived plant {} (user {})", plantId, userId);
     }
 
+    /**
+     * Находит растение, принадлежащее юзеру, независимо от статуса архивации.
+     * Чужое или несуществующее растение трактуется как 404 (issue #219:
+     * «404 если растение не найдено или принадлежит другому пользователю»).
+     */
+    @Transactional(readOnly = true)
+    public Plant getOwnedPlantOrThrow(Long userId, Long plantId) {
+        Plant plant = plantRepository.findByIdWithLocationAndSpecies(plantId)
+                .orElseThrow(() -> new EntityNotFoundException("Plant not found: " + plantId));
+
+        if (!plant.getUser().getId().equals(userId)) {
+            throw new EntityNotFoundException("Plant not found: " + plantId);
+        }
+
+        return plant;
+    }
+
+    /**
+     * Архивация растения с метаданными выбытия (issue #219, mobile G15).
+     * Устанавливает {@code archived_at = now()} (через инжектируемый Clock).
+     * Расписания ухода не удаляются. Повторная архивация → 409.
+     *
+     * @return обновлённое растение (для маппинга в DTO вне транзакции)
+     */
+    @Transactional
+    public Plant archivePlantWithReason(Long userId, Long plantId, Boolean gifted, String note) {
+        Plant plant = getOwnedPlantOrThrow(userId, plantId);
+
+        if (plant.isArchived()) {
+            throw new IllegalStateException("Plant already archived: " + plantId);
+        }
+
+        plant.archive(LocalDateTime.now(clock), gifted, note);
+        Plant saved = plantRepository.save(plant);
+
+        log.info("Archived plant {} (user {}, gifted={})", plantId, userId, gifted);
+        return saved;
+    }
+
+    /**
+     * Восстановление растения из архива (issue #219, mobile G15).
+     * Сбрасывает {@code archived_at} и метаданные выбытия. Расписания
+     * автоматически не восстанавливаются. Вызов на активном → 409.
+     *
+     * @return обновлённое растение
+     */
+    @Transactional
+    public Plant restorePlant(Long userId, Long plantId) {
+        Plant plant = getOwnedPlantOrThrow(userId, plantId);
+
+        if (!plant.isArchived()) {
+            throw new IllegalStateException("Plant is not archived: " + plantId);
+        }
+
+        plant.restore();
+        Plant saved = plantRepository.save(plant);
+
+        log.info("Restored plant {} (user {})", plantId, userId);
+        return saved;
+    }
+
+    /**
+     * Безвозвратное удаление растения с каскадом по связанным таблицам
+     * (issue #219, mobile G15). Доступно только для архивных растений —
+     * активное → 400 (барьер от случайного hard-delete). Не найдено → 404.
+     */
+    @Transactional
+    public void hardDeletePlant(Long userId, Long plantId) {
+        Plant plant = getOwnedPlantOrThrow(userId, plantId);
+
+        if (!plant.isArchived()) {
+            throw new IllegalArgumentException(
+                    "Active plant cannot be hard-deleted; archive it first: " + plantId);
+        }
+
+        plantRepository.delete(plant);
+
+        log.info("Hard-deleted plant {} (user {})", plantId, userId);
+    }
+
+    /** Архивное растение вместе с агрегатами для экрана «Архив» (issue #219). */
+    public record ArchivedPlant(Plant plant, int totalCareDays, int totalCareEvents) {}
+
+    /**
+     * Список архивных растений юзера с агрегатами выбытия (issue #219, mobile G15).
+     * Сортировка — свежие сверху (по {@code archived_at DESC}).
+     */
+    @Transactional(readOnly = true)
+    public List<ArchivedPlant> listArchivedPlants(Long userId) {
+        return plantRepository.findByUserIdAndArchivedAtIsNotNullOrderByArchivedAtDesc(userId).stream()
+                .map(plant -> {
+                    long events = careHistoryRepository.countActiveByPlantId(plant.getId());
+                    int days = computeTotalCareDays(plant);
+                    return new ArchivedPlant(plant, days, (int) events);
+                })
+                .toList();
+    }
+
+    /**
+     * Сколько дней растение было с пользователем: {@code archivedAt - acquiredAt}
+     * (или {@code createdAt}, если {@code acquiredAt} не задан). Не меньше 0.
+     */
+    private int computeTotalCareDays(Plant plant) {
+        if (plant.getArchivedAt() == null) {
+            return 0;
+        }
+        LocalDate end = plant.getArchivedAt().toLocalDate();
+        LocalDate start = plant.getAcquiredAt() != null
+                ? plant.getAcquiredAt()
+                : (plant.getCreatedAt() != null ? plant.getCreatedAt().toLocalDate() : end);
+        long days = java.time.temporal.ChronoUnit.DAYS.between(start, end);
+        return (int) Math.max(0, days);
+    }
+
     @Transactional
     public CareSchedule updateScheduleInterval(
             Long userId,

--- a/src/main/resources/db/migration/V38__add_plant_archive_metadata.sql
+++ b/src/main/resources/db/migration/V38__add_plant_archive_metadata.sql
@@ -1,0 +1,36 @@
+-- V38__add_plant_archive_metadata.sql
+-- Issue #219 (mobile G15): метаданные выбытия растения для экрана «Архив».
+--
+-- Колонка archived_at уже есть (используется как soft-delete с самого начала).
+-- Не хватало причины выбытия: было ли растение подарено (gifted = true) или
+-- погибло (gifted = false), и свободной заметки пользователя.
+--
+-- Добавляем два опциональных поля:
+--   * archive_gifted  — BOOLEAN: true = подарили, false = погибло. NULL до архивации.
+--   * archive_note    — TEXT: свободная заметка о выбытии. NULL — не задана.
+--
+-- Backward-compat note:
+--   * Обе колонки NULLABLE без NOT NULL → существующие строки plants остаются
+--     валидными, бэкфил не нужен (CLAUDE.md: nullable без 3-шагового бэкфила).
+--   * Семантика: поля осмысленны только для архивных растений
+--     (archived_at IS NOT NULL); при восстановлении (restore) сбрасываются вместе
+--     с archived_at кодом сервиса.
+--   * Индекс не добавляем: фильтрации/сортировки по этим полям нет, читаются
+--     вместе со строкой растения.
+--   * Безопасно для rolling deploy. Только DDL, без сидинга.
+
+BEGIN;
+
+ALTER TABLE plants
+    ADD COLUMN archive_gifted BOOLEAN,
+    ADD COLUMN archive_note   TEXT;
+
+COMMENT ON COLUMN plants.archive_gifted IS
+    'Причина выбытия растения (issue #219): true — подарили, false — погибло. '
+        'NULL пока растение активно (archived_at IS NULL).';
+
+COMMENT ON COLUMN plants.archive_note IS
+    'Свободная заметка о выбытии растения (issue #219), напр. «Залила соседка». '
+        'NULL — не задана. Сбрасывается при восстановлении из архива.';
+
+COMMIT;

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -124,6 +124,10 @@ paths:
     $ref: './resources/plants.yaml#/paths/Collection'
   /api/v1/plants/{id}:
     $ref: './resources/plants.yaml#/paths/Item'
+  /api/v1/plants/{id}/archive:
+    $ref: './resources/plants.yaml#/paths/ItemArchive'
+  /api/v1/plants/{id}/restore:
+    $ref: './resources/plants.yaml#/paths/ItemRestore'
   /api/v1/plants/{id}/history:
     $ref: './resources/plant-history.yaml#/paths/ItemHistory'
   /api/v1/plants/{id}/history/summary:
@@ -254,6 +258,8 @@ components:
       $ref: './resources/plants.yaml#/schemas/PlantCreateRequest'
     PlantUpdateRequest:
       $ref: './resources/plants.yaml#/schemas/PlantUpdateRequest'
+    PlantArchiveRequest:
+      $ref: './resources/plants.yaml#/schemas/PlantArchiveRequest'
     PageResponsePlantDto:
       $ref: './resources/plants.yaml#/schemas/PageResponsePlantDto'
     PlantDiagnosisDto:

--- a/src/main/resources/openapi/resources/plants.yaml
+++ b/src/main/resources/openapi/resources/plants.yaml
@@ -8,8 +8,13 @@ paths:
       summary: Список растений пользователя
       description: |
         Возвращает страницу растений, принадлежащих текущему пользователю
-        (`sub` из bearer-токена). Архивированные (soft-deleted) растения в
-        выдачу не попадают.
+        (`sub` из bearer-токена).
+
+        По умолчанию (без `status` или `status=active`) архивированные
+        (soft-deleted) растения в выдачу **не** попадают. С `status=archived`
+        возвращаются только архивные растения, и для них дополнительно
+        заполняются поля выбытия: `archivedAt`, `gifted`, `note`,
+        `totalCareDays`, `totalCareEvents` (mobile gap G15, issue #219).
 
         Можно фильтровать по локации параметром `locationId`. Пагинация —
         классическая `offset/limit`.
@@ -21,6 +26,18 @@ paths:
       security:
         - bearerAuth: [ ]
       parameters:
+        - name: status
+          in: query
+          required: false
+          description: |
+            Фильтр по жизненному статусу растения. `active` (или отсутствие
+            параметра) — только живые (`archived_at IS NULL`). `archived` —
+            только архивные, с заполненными полями выбытия.
+          schema:
+            type: string
+            enum: [ active, archived ]
+            default: active
+            example: archived
         - name: locationId
           in: query
           required: false
@@ -160,22 +177,105 @@ paths:
     delete:
       tags: [ Plants ]
       operationId: deletePlant
-      summary: Архивировать растение (soft-delete)
+      summary: Удалить растение навсегда (hard-delete)
       description: |
-        Помечает растение как удалённое (`archived_at = now()` в UTC). Запись
-        в БД остаётся, но перестаёт появляться во всех `/api/v1/plants/*`
-        выборках. Восстановления через API в этой версии нет.
+        Безвозвратно удаляет растение и каскадно связанные данные
+        (`care_history`, `care_schedules`, `notifications_log`, годовщины,
+        предложения по пересадке). Доступно **только для уже архивированных**
+        растений (барьер от случайного удаления, mobile gap G15, issue #219):
+        активное растение сначала архивируют через
+        `PATCH /api/v1/plants/{id}/archive`.
+
+        * `204` — растение удалено;
+        * `400` — растение активно (не архивировано), hard-delete запрещён;
+        * `404` — растение не найдено или принадлежит другому пользователю.
       security:
         - bearerAuth: [ ]
       parameters:
         - $ref: '../_common/parameters.yaml#/PlantIdPath'
       responses:
         '204':
-          description: Растение архивировано. Тело ответа отсутствует.
+          description: Растение удалено навсегда. Тело ответа отсутствует.
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
         '403':
           $ref: '../_common/responses.yaml#/Forbidden'
         '404':
           $ref: '../_common/responses.yaml#/NotFound'
+
+  ItemArchive:
+    patch:
+      tags: [ Plants ]
+      operationId: archivePlant
+      summary: Архивировать растение (soft-delete с метаданными)
+      description: |
+        Помечает растение как выбывшее (`archived_at = now()` в UTC) и
+        сохраняет причину выбытия (mobile gap G15, issue #219). После
+        архивации растение пропадает из обычного `GET /plants` и появляется
+        в `GET /plants?status=archived`. Расписания ухода **не** удаляются —
+        остаются для ретроспективы.
+
+        * `200` — обновлённый `PlantDto` (`archived=true`, `archivedAt` задано);
+        * `404` — растение не найдено или принадлежит другому пользователю;
+        * `409` — растение уже архивировано.
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - $ref: '../_common/parameters.yaml#/PlantIdPath'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/PlantArchiveRequest'
+            example:
+              gifted: false
+              note: Залила соседка
+      responses:
+        '200':
+          description: Растение архивировано.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/PlantDto'
+        '403':
+          $ref: '../_common/responses.yaml#/Forbidden'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+        '409':
+          $ref: '../_common/responses.yaml#/Conflict'
+
+  ItemRestore:
+    post:
+      tags: [ Plants ]
+      operationId: restorePlant
+      summary: Восстановить растение из архива
+      description: |
+        Снимает архивацию (`archived_at = NULL`) и сбрасывает метаданные
+        выбытия (mobile gap G15, issue #219). Растение снова появляется в
+        обычном `GET /plants`. Расписания ухода автоматически **не**
+        восстанавливаются — пользователь создаёт их вручную.
+
+        * `200` — обновлённый `PlantDto` (`archived=false`, `archivedAt=null`);
+        * `404` — растение не найдено или принадлежит другому пользователю;
+        * `409` — растение не в архиве.
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - $ref: '../_common/parameters.yaml#/PlantIdPath'
+      responses:
+        '200':
+          description: Растение восстановлено.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/PlantDto'
+        '403':
+          $ref: '../_common/responses.yaml#/Forbidden'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+        '409':
+          $ref: '../_common/responses.yaml#/Conflict'
 
   ItemHealth:
     get:
@@ -463,6 +563,66 @@ schemas:
         nullable: true
         description: Конец периода акклиматизации (UTC). null если акклиматизация не активна.
         example: "2026-06-10T12:00:00Z"
+      archivedAt:
+        type: string
+        format: date-time
+        nullable: true
+        description: |
+          Момент архивации (UTC). Заполняется только в выдаче
+          `GET /plants?status=archived` и в ответах archive/restore
+          (mobile gap G15, issue #219). null для активных растений.
+        example: "2026-03-15T10:00:00Z"
+      gifted:
+        type: boolean
+        nullable: true
+        description: |
+          Причина выбытия (issue #219): true — растение подарили, false —
+          погибло. null если не указано или растение активно. Заполняется
+          только в архивной выдаче и ответах archive/restore.
+        example: false
+      note:
+        type: string
+        nullable: true
+        description: |
+          Заметка о выбытии растения (issue #219), напр. «Залила соседка».
+          null если не задана. Заполняется только в архивной выдаче и ответах
+          archive/restore. Это отдельное от `notes` поле.
+        example: Залила соседка
+      totalCareDays:
+        type: integer
+        format: int32
+        nullable: true
+        description: |
+          Сколько дней растение было с пользователем: `archivedAt - acquiredAt`
+          (или `createdAt`, если `acquiredAt` не задан). Заполняется только в
+          архивной выдаче (issue #219).
+        example: 227
+      totalCareEvents:
+        type: integer
+        format: int32
+        nullable: true
+        description: |
+          Сколько раз пользователь отмечал уход за этим растением (COUNT из
+          `care_history`). Заполняется только в архивной выдаче (issue #219).
+        example: 42
+
+  PlantArchiveRequest:
+    type: object
+    description: |
+      Тело PATCH /api/v1/plants/{id}/archive (issue #219). Оба поля
+      опциональны; само тело тоже опционально (можно архивировать без причины).
+    properties:
+      gifted:
+        type: boolean
+        nullable: true
+        description: true — растение подарили, false — погибло. null — не указано.
+        example: false
+      note:
+        type: string
+        maxLength: 2000
+        nullable: true
+        description: Свободная заметка о выбытии.
+        example: Залила соседка
 
   PlantCreateRequest:
     type: object

--- a/src/test/java/com/plantcare/api/v1/PlantControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/PlantControllerTest.java
@@ -376,11 +376,98 @@ class PlantControllerTest {
     }
 
     @Test
-    void should_delete_plant_and_return_204() throws Exception {
-        doNothing().when(plantService).archivePlant(1L, 1L);
+    void should_hard_delete_archived_plant_and_return_204() throws Exception {
+        doNothing().when(plantService).hardDeletePlant(1L, 1L);
 
         mockMvc.perform(delete("/api/v1/plants/1"))
                 .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void should_return_400_when_hard_deleting_active_plant() throws Exception {
+        org.mockito.Mockito.doThrow(new IllegalArgumentException("Active plant cannot be hard-deleted"))
+                .when(plantService).hardDeletePlant(1L, 1L);
+
+        mockMvc.perform(delete("/api/v1/plants/1"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("BAD_REQUEST"));
+    }
+
+    @Test
+    void should_archive_plant_with_reason_and_return_archive_fields() throws Exception {
+        Plant archived = mockPlant(1L, 1L, "Монстера");
+        when(archived.getArchivedAt()).thenReturn(java.time.LocalDateTime.parse("2026-03-15T10:00:00"));
+        when(archived.getArchiveGifted()).thenReturn(false);
+        when(archived.getArchiveNote()).thenReturn("Залила соседка");
+        when(archived.isArchived()).thenReturn(true);
+        when(plantService.archivePlantWithReason(eq(1L), eq(1L), eq(false), eq("Залила соседка")))
+                .thenReturn(archived);
+
+        String body = "{\"gifted\":false,\"note\":\"Залила соседка\"}";
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .patch("/api/v1/plants/1/archive")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.archived").value(true))
+                .andExpect(jsonPath("$.gifted").value(false))
+                .andExpect(jsonPath("$.note").value("Залила соседка"))
+                .andExpect(jsonPath("$.archivedAt").exists());
+    }
+
+    @Test
+    void should_return_409_when_archiving_already_archived_plant() throws Exception {
+        org.mockito.Mockito.doThrow(new IllegalStateException("Plant already archived"))
+                .when(plantService).archivePlantWithReason(eq(1L), eq(1L), isNull(), isNull());
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .patch("/api/v1/plants/1/archive")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("CONFLICT"));
+    }
+
+    @Test
+    void should_restore_plant_and_return_200() throws Exception {
+        Plant restored = mockPlant(1L, 1L, "Монстера");
+        when(restored.isArchived()).thenReturn(false);
+        when(plantService.restorePlant(1L, 1L)).thenReturn(restored);
+
+        mockMvc.perform(post("/api/v1/plants/1/restore"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.archived").value(false));
+    }
+
+    @Test
+    void should_return_409_when_restoring_active_plant() throws Exception {
+        org.mockito.Mockito.doThrow(new IllegalStateException("Plant is not archived"))
+                .when(plantService).restorePlant(1L, 1L);
+
+        mockMvc.perform(post("/api/v1/plants/1/restore"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("CONFLICT"));
+    }
+
+    @Test
+    void should_list_archived_plants_with_aggregates() throws Exception {
+        Plant p = mockPlant(42L, 1L, "Монстера");
+        when(p.getArchivedAt()).thenReturn(java.time.LocalDateTime.parse("2026-03-15T10:00:00"));
+        when(p.getArchiveGifted()).thenReturn(false);
+        when(p.getArchiveNote()).thenReturn("Залила соседка");
+        when(p.isArchived()).thenReturn(true);
+        when(plantService.listArchivedPlants(1L))
+                .thenReturn(List.of(new PlantService.ArchivedPlant(p, 227, 42)));
+
+        mockMvc.perform(get("/api/v1/plants").param("status", "archived"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(1))
+                .andExpect(jsonPath("$.items[0].id").value(42))
+                .andExpect(jsonPath("$.items[0].totalCareDays").value(227))
+                .andExpect(jsonPath("$.items[0].totalCareEvents").value(42))
+                .andExpect(jsonPath("$.items[0].gifted").value(false))
+                .andExpect(jsonPath("$.items[0].note").value("Залила соседка"));
     }
 
     @Test

--- a/src/test/java/com/plantcare/core/service/PlantServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/PlantServiceTest.java
@@ -575,6 +575,119 @@ class PlantServiceTest extends IntegrationTestBase {
         assertThat(plantRepository.findById(plant.getId()).orElseThrow().getArchivedAt()).isNotNull();
     }
 
+    // ==================== Архив: archive/restore/hardDelete/list (issue #219) ====================
+
+    @Test
+    @DisplayName("archivePlantWithReason: ставит archived_at + gifted/note, возвращает растение")
+    void archivePlantWithReason_setsReason() {
+        Plant plant = createTestPlant("X");
+
+        Plant archived = plantService.archivePlantWithReason(
+                testUser.getId(), plant.getId(), false, "Залила соседка");
+
+        assertThat(archived.isArchived()).isTrue();
+        Plant reloaded = plantRepository.findById(plant.getId()).orElseThrow();
+        assertThat(reloaded.getArchivedAt()).isNotNull();
+        assertThat(reloaded.getArchiveGifted()).isFalse();
+        assertThat(reloaded.getArchiveNote()).isEqualTo("Залила соседка");
+    }
+
+    @Test
+    @DisplayName("archivePlantWithReason: повторная архивация → IllegalStateException (409)")
+    void archivePlantWithReason_rejectsAlreadyArchived() {
+        Plant plant = createTestPlant("X");
+        plantService.archivePlantWithReason(testUser.getId(), plant.getId(), true, null);
+
+        assertThatThrownBy(() -> plantService.archivePlantWithReason(
+                testUser.getId(), plant.getId(), true, null))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("archivePlantWithReason: чужое растение → EntityNotFoundException (404)")
+    void archivePlantWithReason_otherUserIsNotFound() {
+        Plant plant = createTestPlant("X");
+        Long otherUserId = userRepository.save(User.builder()
+                .telegramChatId(999L).username("other").build()).getId();
+
+        assertThatThrownBy(() -> plantService.archivePlantWithReason(
+                otherUserId, plant.getId(), null, null))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("restorePlant: сбрасывает archived_at и метаданные выбытия")
+    void restorePlant_clearsArchive() {
+        Plant plant = createTestPlant("X");
+        plantService.archivePlantWithReason(testUser.getId(), plant.getId(), false, "Погибла");
+
+        Plant restored = plantService.restorePlant(testUser.getId(), plant.getId());
+
+        assertThat(restored.isArchived()).isFalse();
+        Plant reloaded = plantRepository.findById(plant.getId()).orElseThrow();
+        assertThat(reloaded.getArchivedAt()).isNull();
+        assertThat(reloaded.getArchiveGifted()).isNull();
+        assertThat(reloaded.getArchiveNote()).isNull();
+    }
+
+    @Test
+    @DisplayName("restorePlant: на активном растении → IllegalStateException (409)")
+    void restorePlant_rejectsActive() {
+        Plant plant = createTestPlant("X");
+
+        assertThatThrownBy(() -> plantService.restorePlant(testUser.getId(), plant.getId()))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("hardDeletePlant: архивное удаляется насовсем вместе с расписаниями")
+    void hardDeletePlant_deletesArchived() {
+        Plant plant = createTestPlant("X");
+        plantService.archivePlantWithReason(testUser.getId(), plant.getId(), true, null);
+
+        plantService.hardDeletePlant(testUser.getId(), plant.getId());
+
+        assertThat(plantRepository.findById(plant.getId())).isEmpty();
+        assertThat(scheduleRepository.findByPlantIdAndTaskType(plant.getId(), TaskType.WATERING))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("hardDeletePlant: активное растение → IllegalArgumentException (400)")
+    void hardDeletePlant_rejectsActive() {
+        Plant plant = createTestPlant("X");
+
+        assertThatThrownBy(() -> plantService.hardDeletePlant(testUser.getId(), plant.getId()))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThat(plantRepository.findById(plant.getId())).isPresent();
+    }
+
+    @Test
+    @DisplayName("listArchivedPlants: возвращает только архивные с totalCareDays/Events")
+    void listArchivedPlants_returnsAggregates() {
+        Plant active = createTestPlant("Активное");
+        Plant gone = createTestPlant("Выбывшее");
+
+        careHistoryRepository.save(com.plantcare.core.domain.CareHistory.builder()
+                .plant(gone).taskType(TaskType.WATERING)
+                .doneAt(LocalDateTime.now().minusDays(10)).onTime(true).build());
+        careHistoryRepository.save(com.plantcare.core.domain.CareHistory.builder()
+                .plant(gone).taskType(TaskType.WATERING)
+                .doneAt(LocalDateTime.now().minusDays(5)).onTime(true).build());
+
+        plantService.archivePlantWithReason(testUser.getId(), gone.getId(), false, "Погибла");
+
+        List<PlantService.ArchivedPlant> archived =
+                plantService.listArchivedPlants(testUser.getId());
+
+        assertThat(archived).hasSize(1);
+        PlantService.ArchivedPlant a = archived.get(0);
+        assertThat(a.plant().getId()).isEqualTo(gone.getId());
+        assertThat(a.totalCareEvents()).isEqualTo(2);
+        assertThat(a.totalCareDays()).isGreaterThanOrEqualTo(0);
+        assertThat(active.isArchived()).isFalse();
+    }
+
     @Test
     @DisplayName("updateScheduleInterval: меняет interval_days, не трогает next_due_at")
     void updateScheduleInterval_changesIntervalOnly() {


### PR DESCRIPTION
Closes #219

## Что сделано
- `GET /api/v1/plants?status=archived` — список архивных растений текущего пользователя с полями выбытия (`archivedAt`, `gifted`, `note`) и агрегатами `totalCareDays` (archivedAt − acquiredAt, иначе − createdAt) и `totalCareEvents` (COUNT активных записей `care_history`). Без `status` (или `status=active`) поведение прежнее — архивные не возвращаются (без регрессии).
- `PATCH /api/v1/plants/{id}/archive` — soft-delete с причиной выбытия (`gifted`/`note`); ставит `archived_at = now()` (UTC через инжектируемый `Clock`). Расписания НЕ удаляются. Повторная архивация → `409`.
- `POST /api/v1/plants/{id}/restore` — сбрасывает `archived_at` и метаданные выбытия; на активном растении → `409`. Расписания автоматически не восстанавливаются.
- `DELETE /api/v1/plants/{id}` — теперь hard-delete с БД-каскадом (`care_history`, `care_schedules`, `notifications_log`, годовщины, supply-suggestions — все FK уже `ON DELETE CASCADE`/`SET NULL`). Доступен только для архивных растений; на активном → `400` (барьер от случайного удаления).
- Все эндпоинты задокументированы в OpenAPI-спеке (`src/main/resources/openapi/`), генератор обновляет `/v3/api-docs` и `PlantsApi`.
- Поля выбытия добавлены в `PlantDto` как nullable (заполняются только в архивной выдаче / ответах archive·restore).

Маппинг кодов ошибок — через существующий `ApiExceptionHandler`: `EntityNotFoundException`→404, `IllegalStateException`→409, `IllegalArgumentException`→400.

## Миграции
`V38__add_plant_archive_metadata.sql` — добавляет nullable `archive_gifted BOOLEAN`, `archive_note TEXT` в `plants`.

## Backward-compat риски
Safe. Обе колонки nullable без NOT NULL (один шаг, без бэкфила — CLAUDE.md). Существующий `GET /plants` без `status` не меняет выдачу. Колонка `archived_at` и FK-каскады уже существовали.

Примечание по поведению `DELETE`: семантика изменена с soft-delete (архивация) на hard-delete-только-для-архивных по требованию issue. Бот-слой архивирует через отдельный метод сервиса `archivePlant(userId, plantId)`, который не тронут.

## Тесты
- `PlantControllerTest` (`@WebMvcTest`): архивация с причиной и проверка полей, 409 при повторной архивации, restore + 200, 409 при restore активного, hard-delete архивного → 204, 400 при hard-delete активного, список `?status=archived` с агрегатами. 37 тестов зелёные.
- `PlantServiceTest` (Testcontainers Postgres): archive/restore/hardDelete happy + edge (409/400/404 чужой), `listArchivedPlants` с `totalCareEvents`/`totalCareDays`. Все новые тесты зелёные.

## Чек
- [x] Архивные эндпоинты и фильтр реализованы и покрыты тестами
- [x] OpenAPI обновлён, клиент/интерфейсы регенерируются
- [ ] `mvn verify` полностью зелёное — см. примечание ниже

### Примечание про `verify`
Локальный прогон на машине в TZ Europe/Moscow даёт 1 падение — `PlantServiceTest#markCareDone_writesHistoryAndReschedules`. Оно **пред-существующее и не связано с issue #219**: тест сравнивает `LocalDateTime.now()` (машинная TZ) с временем, посчитанным от `Clock.systemUTC()`, и ломается при не-UTC TZ хоста. Подтверждено прогоном того же теста на чистом `origin/develop` — падает идентично без моих изменений. На CI (UTC) тест зелёный.
