### PR TITLE
feat: совместный уход — GET /sharing, POST /sharing/invites (#191)

### DIFF
--- a/src/main/java/com/plantcare/api/v1/SharingController.java
+++ b/src/main/java/com/plantcare/api/v1/SharingController.java
@@ -1,0 +1,63 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.api.generated.SharingApi;
+import com.plantcare.api.generated.model.SharingInviteCreateRequest;
+import com.plantcare.api.generated.model.SharingMemberDto;
+import com.plantcare.api.generated.model.SharingMembersResponse;
+import com.plantcare.api.generated.model.SharingStatus;
+import com.plantcare.core.domain.SharingInvite;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.service.SharingService;
+import com.plantcare.core.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * REST API совместного ухода (issue #191, mobile G22, экран 26).
+ *
+ * <p>Документация и mapping живут в сгенерированном {@link SharingApi}
+ * (см. openapi/resources/sharing.yaml).
+ */
+@RestController
+@RequiredArgsConstructor
+public class SharingController implements SharingApi {
+
+    private final SharingService sharingService;
+    private final UserService userService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    public SharingMembersResponse listSharingMembers() {
+        Long userId = currentUserProvider.currentUserId();
+        return new SharingMembersResponse(
+                sharingService.listMembers(userId).stream()
+                        .map(SharingController::toDto)
+                        .toList()
+        );
+    }
+
+    @Override
+    public SharingMemberDto createSharingInvite(SharingInviteCreateRequest request) {
+        User user = userService.getByIdOrThrow(currentUserProvider.currentUserId());
+        boolean canLogCare = Boolean.TRUE.equals(request.getCanLogCare());
+        SharingInvite invite = sharingService.createInvite(
+                user, request.getPlantIds(), request.getInviteeContact(), canLogCare);
+        return toDto(invite);
+    }
+
+    private static SharingMemberDto toDto(SharingInvite invite) {
+        List<Long> plantIds = new ArrayList<>(invite.getPlantIds());
+        plantIds.sort(Long::compareTo);
+        return new SharingMemberDto(
+                invite.getId(),
+                invite.getInviteeContact(),
+                SharingStatus.fromValue(invite.getStatus().name()),
+                invite.isCanLogCare(),
+                plantIds
+        );
+    }
+}

--- a/src/main/java/com/plantcare/core/domain/SharingInvite.java
+++ b/src/main/java/com/plantcare/core/domain/SharingInvite.java
@@ -1,0 +1,71 @@
+package com.plantcare.core.domain;
+
+import com.plantcare.core.domain.base.BaseEntity;
+import com.plantcare.core.domain.enums.SharingStatus;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Приглашение соухаживающего (issue #191, экран 26 «Совместный уход»).
+ *
+ * <p>Владелец ({@code inviter}) выпускает приглашение на набор растений
+ * ({@code plantIds}) для контакта {@code inviteeContact} (@username / телефон).
+ * Контакт хранится свободной строкой, потому что у приглашённого может ещё не
+ * быть аккаунта на момент инвайта. Статус стартует с {@link SharingStatus#PENDING}.
+ *
+ * <p>id и created_at наследуются из {@link BaseEntity}.
+ */
+@Entity
+@Table(name = "sharing_invites")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SharingInvite extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "inviter_user_id", nullable = false)
+    private User inviter;
+
+    @Column(name = "invitee_contact", nullable = false, length = 255)
+    private String inviteeContact;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private SharingStatus status = SharingStatus.PENDING;
+
+    @Column(name = "can_log_care", nullable = false)
+    private boolean canLogCare = false;
+
+    /**
+     * Идентификаторы растений, на которые распространяется приглашение.
+     * Принадлежность растений владельцу проверяется на сервисном слое до записи.
+     */
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(
+            name = "sharing_invite_plants",
+            joinColumns = @JoinColumn(name = "invite_id")
+    )
+    @Column(name = "plant_id", nullable = false)
+    private Set<Long> plantIds = new LinkedHashSet<>();
+
+    public SharingInvite(User inviter, String inviteeContact, boolean canLogCare, Set<Long> plantIds) {
+        this.inviter = inviter;
+        this.inviteeContact = inviteeContact;
+        this.canLogCare = canLogCare;
+        this.status = SharingStatus.PENDING;
+        this.plantIds = new LinkedHashSet<>(plantIds);
+    }
+}

--- a/src/main/java/com/plantcare/core/domain/enums/SharingStatus.java
+++ b/src/main/java/com/plantcare/core/domain/enums/SharingStatus.java
@@ -1,0 +1,14 @@
+package com.plantcare.core.domain.enums;
+
+/**
+ * Статус приглашения соухаживающего (issue #191).
+ *
+ * <ul>
+ *   <li>{@link #PENDING} — приглашение выпущено владельцем, ещё не принято.</li>
+ *   <li>{@link #ACCEPTED} — приглашение принято приглашённым.</li>
+ * </ul>
+ */
+public enum SharingStatus {
+    PENDING,
+    ACCEPTED
+}

--- a/src/main/java/com/plantcare/core/repository/PlantRepository.java
+++ b/src/main/java/com/plantcare/core/repository/PlantRepository.java
@@ -37,6 +37,14 @@ public interface PlantRepository extends JpaRepository<Plant, Long> {
     Optional<Plant> findByUserIdAndIdAndArchivedAtIsNull(Long userId, Long plantId);
 
     /**
+     * Сколько из переданных {@code ids} — активные (не архивированные) растения
+     * данного пользователя. Используется для проверки, что весь набор растений
+     * принадлежит владельцу перед выдачей доступа (issue #191): если число
+     * меньше размера набора — какой-то id чужой/архивный/несуществующий.
+     */
+    long countByUserIdAndArchivedAtIsNullAndIdIn(Long userId, Collection<Long> ids);
+
+    /**
      * Растение по id с подтянутыми {@code location}, {@code species} и {@code user}.
      * Используется в {@code PlantService.getPlantOrThrow}, результат которого
      * мапится в DTO вне транзакции (REST API, issue #85) — иначе ленивые

--- a/src/main/java/com/plantcare/core/repository/SharingInviteRepository.java
+++ b/src/main/java/com/plantcare/core/repository/SharingInviteRepository.java
@@ -1,0 +1,26 @@
+package com.plantcare.core.repository;
+
+import com.plantcare.core.domain.SharingInvite;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SharingInviteRepository extends JpaRepository<SharingInvite, Long> {
+
+    /**
+     * Приглашения, выпущенные владельцем, с подтянутым набором {@code plantIds},
+     * чтобы маппинг в DTO вне транзакции не упирался в {@code no Session}.
+     * {@code DISTINCT} — из-за JOIN на коллекцию растений.
+     */
+    @Query("""
+            SELECT DISTINCT i FROM SharingInvite i
+            LEFT JOIN FETCH i.plantIds
+            WHERE i.inviter.id = :userId
+            ORDER BY i.id ASC
+            """)
+    List<SharingInvite> findAllByInviterIdWithPlants(@Param("userId") Long userId);
+}

--- a/src/main/java/com/plantcare/core/service/SharingService.java
+++ b/src/main/java/com/plantcare/core/service/SharingService.java
@@ -1,0 +1,77 @@
+package com.plantcare.core.service;
+
+import com.plantcare.core.domain.SharingInvite;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.SharingInviteRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Совместный уход (issue #191, mobile G22, экран 26).
+ *
+ * <p>Владелец приглашает соухаживающего по контакту, выбирает набор своих
+ * растений и решает, может ли приглашённый отмечать уход. Приглашение стартует
+ * в статусе {@code PENDING}; приём приглашения — отдельная задача.
+ *
+ * <p>Модель доступа: растения в приглашении обязаны принадлежать владельцу
+ * (активные, не архивные) — иначе нельзя выдать доступ к чужому/несуществующему
+ * растению (404).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SharingService {
+
+    public static final String PLANTS_NOT_FOUND =
+            "Некоторые растения не найдены или не принадлежат пользователю";
+
+    private final SharingInviteRepository sharingInviteRepository;
+    private final PlantRepository plantRepository;
+
+    /** Приглашения, выпущенные владельцем, с набором растений каждого. */
+    @Transactional(readOnly = true)
+    public List<SharingInvite> listMembers(Long inviterUserId) {
+        return sharingInviteRepository.findAllByInviterIdWithPlants(inviterUserId);
+    }
+
+    /**
+     * Создаёт приглашение на набор растений с правом {@code canLogCare}.
+     * Контакт нормализуется (trim); пустой контакт или пустой набор растений —
+     * {@link IllegalArgumentException} (400). Если хотя бы одно растение чужое
+     * или не существует — {@link EntityNotFoundException} (404).
+     */
+    @Transactional
+    public SharingInvite createInvite(User inviter, List<Long> plantIds, String rawContact, boolean canLogCare) {
+        String contact = rawContact == null ? "" : rawContact.trim();
+        if (contact.isBlank()) {
+            throw new IllegalArgumentException("Контакт приглашённого не может быть пустым");
+        }
+        if (plantIds == null || plantIds.isEmpty()) {
+            throw new IllegalArgumentException("Нужно выбрать хотя бы одно растение");
+        }
+
+        Set<Long> uniquePlantIds = new LinkedHashSet<>(plantIds);
+
+        long owned = plantRepository.countByUserIdAndArchivedAtIsNullAndIdIn(
+                inviter.getId(), uniquePlantIds);
+        if (owned != uniquePlantIds.size()) {
+            throw new EntityNotFoundException(PLANTS_NOT_FOUND);
+        }
+
+        SharingInvite saved = sharingInviteRepository.save(
+                new SharingInvite(inviter, contact, canLogCare, uniquePlantIds));
+
+        log.info("Created sharing invite {} for contact {} by user {} on {} plants (canLogCare={})",
+                saved.getId(), contact, inviter.getId(), uniquePlantIds.size(), canLogCare);
+
+        return saved;
+    }
+}

--- a/src/main/resources/db/migration/V38__create_sharing_invites.sql
+++ b/src/main/resources/db/migration/V38__create_sharing_invites.sql
@@ -1,0 +1,71 @@
+-- V38__create_sharing_invites.sql
+-- Issue #191 (mobile G22, экран 26 «Совместный уход»): пользователь приглашает
+-- соухаживающего по контакту (@username / телефон), выбирает набор растений и
+-- решает, может ли приглашённый отмечать уход (canLogCare).
+--
+-- Модель доступа:
+--   * sharing_invites — приглашение, выпущенное владельцем (inviter_user_id).
+--     contact приглашённого хранится свободной строкой (@username или телефон),
+--     потому что у приглашённого может ещё не быть аккаунта на момент инвайта.
+--   * status: PENDING (выпущено, ещё не принято) / ACCEPTED (принято).
+--     ACCEPTED-состояние и связывание с реальным user приглашённого — отдельная
+--     задача (приём инвайта); здесь создаём приглашение и читаем список.
+--   * can_log_care — право приглашённого отмечать уход за выбранными растениями.
+--   * sharing_invite_plants — набор растений, на которые распространяется инвайт.
+--
+-- Backward-compat note:
+--   * Две новые таблицы — для старого кода невидимы (аддитивно, один релиз).
+--   * id маппится JPA как GenerationType.IDENTITY → BIGSERIAL.
+--   * created_at маппится @CreationTimestamp → TIMESTAMPTZ (UTC), как везде.
+--   * ON DELETE CASCADE на inviter_user_id и plant_id: удаление пользователя или
+--     растения убирает связанные инвайты/связи. id не переиспользуется.
+--   * Только DDL, без сидинга. Безопасно для rolling deploy.
+
+BEGIN;
+
+CREATE TABLE sharing_invites (
+    id              BIGSERIAL    PRIMARY KEY,
+    inviter_user_id BIGINT       NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    invitee_contact VARCHAR(255) NOT NULL,
+    status          VARCHAR(16)  NOT NULL DEFAULT 'PENDING',
+    can_log_care    BOOLEAN      NOT NULL DEFAULT false,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT chk_sharing_invites_status CHECK (status IN ('PENDING', 'ACCEPTED'))
+);
+
+COMMENT ON TABLE sharing_invites IS
+    'Приглашение соухаживающего (issue #191): по строке на приглашение от владельца.';
+
+COMMENT ON COLUMN sharing_invites.inviter_user_id IS
+    'Владелец растений, выпустивший приглашение.';
+
+COMMENT ON COLUMN sharing_invites.invitee_contact IS
+    'Контакт приглашённого: @username или телефон. Свободная строка — аккаунта может ещё не быть.';
+
+COMMENT ON COLUMN sharing_invites.status IS
+    'Статус приглашения: PENDING (ещё не принято) или ACCEPTED (принято).';
+
+COMMENT ON COLUMN sharing_invites.can_log_care IS
+    'Право приглашённого отмечать уход за растениями из набора.';
+
+COMMENT ON COLUMN sharing_invites.created_at IS
+    'Момент создания приглашения в UTC (TIMESTAMPTZ).';
+
+-- Основной запрос: список приглашений, выпущенных владельцем. Покрывает FK.
+CREATE INDEX idx_sharing_invites_inviter
+    ON sharing_invites (inviter_user_id, created_at);
+
+CREATE TABLE sharing_invite_plants (
+    invite_id BIGINT NOT NULL REFERENCES sharing_invites(id) ON DELETE CASCADE,
+    plant_id  BIGINT NOT NULL REFERENCES plants(id) ON DELETE CASCADE,
+    PRIMARY KEY (invite_id, plant_id)
+);
+
+COMMENT ON TABLE sharing_invite_plants IS
+    'Набор растений, на которые распространяется приглашение (issue #191).';
+
+-- Обратный поиск инвайтов по растению + покрытие FK plant_id.
+CREATE INDEX idx_sharing_invite_plants_plant
+    ON sharing_invite_plants (plant_id);
+
+COMMIT;

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -100,6 +100,11 @@ tags:
     description: |
       Персистентный inbox уведомлений пользователя для мобильного приложения
       (gap G17): лента со счётчиком непрочитанных и идемпотентная отметка прочтения.
+  - name: Sharing
+    description: |
+      Совместный уход (gap G22, экран 26): владелец приглашает соухаживающего
+      по контакту (@username / телефон), выбирает растения и даёт право
+      отмечать уход.
 
 paths:
   /api/v1/auth/apple:
@@ -191,6 +196,11 @@ paths:
 
   /api/v1/me:
     $ref: './resources/me.yaml#/paths/Me'
+
+  /api/v1/sharing:
+    $ref: './resources/sharing.yaml#/paths/Collection'
+  /api/v1/sharing/invites:
+    $ref: './resources/sharing.yaml#/paths/Invites'
 
 components:
   securitySchemes:
@@ -345,6 +355,15 @@ components:
       $ref: './resources/notifications.yaml#/schemas/NotificationDto'
     NotificationsResponse:
       $ref: './resources/notifications.yaml#/schemas/NotificationsResponse'
+
+    SharingStatus:
+      $ref: './resources/sharing.yaml#/schemas/SharingStatus'
+    SharingMemberDto:
+      $ref: './resources/sharing.yaml#/schemas/SharingMemberDto'
+    SharingMembersResponse:
+      $ref: './resources/sharing.yaml#/schemas/SharingMembersResponse'
+    SharingInviteCreateRequest:
+      $ref: './resources/sharing.yaml#/schemas/SharingInviteCreateRequest'
 
     ApiErrorResponse:
       $ref: './_common/errors.yaml#/schemas/ApiErrorResponse'

--- a/src/main/resources/openapi/resources/sharing.yaml
+++ b/src/main/resources/openapi/resources/sharing.yaml
@@ -1,0 +1,132 @@
+# Совместный уход (issue #191, mobile G22, экран 26).
+#
+# Владелец растений приглашает соухаживающего по контакту (@username / телефон),
+# выбирает набор растений и решает, может ли приглашённый отмечать уход.
+# GET /sharing — текущие соухаживающие со статусом; POST /sharing/invites —
+# создать приглашение. Все эндпоинты в scope текущего пользователя (bearer.sub).
+
+paths:
+  Collection:
+    get:
+      tags: [Sharing]
+      operationId: listSharingMembers
+      summary: Соухаживающие текущего пользователя
+      description: |
+        Возвращает приглашения, выпущенные текущим пользователем
+        (`sub` из bearer-токена), со статусом (`PENDING`/`ACCEPTED`),
+        правом `canLogCare` и набором растений каждого приглашения.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Список соухаживающих.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/SharingMembersResponse'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+
+  Invites:
+    post:
+      tags: [Sharing]
+      operationId: createSharingInvite
+      summary: Пригласить соухаживающего
+      description: |
+        Создаёт приглашение на набор растений с правом `canLogCare`.
+        Растения должны принадлежать текущему пользователю — иначе 404.
+        Пустой набор растений или пустой контакт — 400.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/SharingInviteCreateRequest'
+            example:
+              plantIds: [23, 24]
+              inviteeContact: '@anna'
+              canLogCare: true
+      responses:
+        '201':
+          description: Приглашение создано.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/SharingMemberDto'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+schemas:
+  SharingStatus:
+    type: string
+    description: Статус приглашения соухаживающего.
+    enum: [PENDING, ACCEPTED]
+    example: PENDING
+
+  SharingMemberDto:
+    type: object
+    description: Соухаживающий — приглашение, выпущенное владельцем.
+    required: [id, contact, status, canLogCare, plantIds]
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Идентификатор приглашения (membership).
+        example: 5
+      contact:
+        type: string
+        description: Контакт приглашённого (@username или телефон).
+        example: '@anna'
+      status:
+        $ref: '#/schemas/SharingStatus'
+      canLogCare:
+        type: boolean
+        description: Может ли приглашённый отмечать уход за растениями набора.
+        example: true
+      plantIds:
+        type: array
+        description: Растения, на которые распространяется приглашение.
+        items:
+          type: integer
+          format: int64
+        example: [23, 24]
+
+  SharingMembersResponse:
+    type: object
+    description: Обёртка над списком соухаживающих.
+    required: [members]
+    properties:
+      members:
+        type: array
+        items:
+          $ref: '#/schemas/SharingMemberDto'
+
+  SharingInviteCreateRequest:
+    type: object
+    required: [plantIds, inviteeContact]
+    properties:
+      plantIds:
+        type: array
+        description: Растения, на которые выдаётся доступ. Минимум одно.
+        minItems: 1
+        items:
+          type: integer
+          format: int64
+        example: [23, 24]
+      inviteeContact:
+        type: string
+        description: Контакт приглашённого — @username или телефон.
+        minLength: 1
+        maxLength: 255
+        example: '@anna'
+      canLogCare:
+        type: boolean
+        description: Дать ли приглашённому право отмечать уход. По умолчанию false.
+        default: false
+        example: true

--- a/src/test/java/com/plantcare/api/v1/SharingControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/SharingControllerTest.java
@@ -1,0 +1,215 @@
+package com.plantcare.api.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.core.domain.SharingInvite;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.SharingStatus;
+import com.plantcare.core.service.SharingService;
+import com.plantcare.core.service.UserService;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * {@code @WebMvcTest} для {@link SharingController} — list/create, валидация (400),
+ * cross-user/неизвестное растение (404) для API совместного ухода (issue #191).
+ *
+ * <p>Фильтры выключены, {@link ApiExceptionHandler} импортируется,
+ * {@link CurrentUserProvider} застаблен на user id = 1.
+ */
+@WebMvcTest(SharingController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class SharingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private SharingService sharingService;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    @BeforeEach
+    void stubCurrentUser() {
+        when(currentUserProvider.currentUserId()).thenReturn(1L);
+    }
+
+    private SharingInvite mockInvite(long id, String contact, SharingStatus status,
+                                     boolean canLogCare, Set<Long> plantIds) {
+        SharingInvite invite = mock(SharingInvite.class);
+        when(invite.getId()).thenReturn(id);
+        when(invite.getInviteeContact()).thenReturn(contact);
+        when(invite.getStatus()).thenReturn(status);
+        when(invite.isCanLogCare()).thenReturn(canLogCare);
+        when(invite.getPlantIds()).thenReturn(plantIds);
+        return invite;
+    }
+
+    // ------------------------------------------------------------------ GET list
+
+    @Test
+    void should_return_members_wrapped_under_members_when_listing() throws Exception {
+        SharingInvite anna = mockInvite(5L, "@anna", SharingStatus.PENDING, true, Set.of(23L, 24L));
+        SharingInvite bob = mockInvite(6L, "@bob", SharingStatus.ACCEPTED, false, Set.of(23L));
+
+        when(sharingService.listMembers(1L)).thenReturn(List.of(anna, bob));
+
+        mockMvc.perform(get("/api/v1/sharing"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.members").isArray())
+                .andExpect(jsonPath("$.members.length()").value(2))
+                .andExpect(jsonPath("$.members[0].id").value(5))
+                .andExpect(jsonPath("$.members[0].contact").value("@anna"))
+                .andExpect(jsonPath("$.members[0].status").value("PENDING"))
+                .andExpect(jsonPath("$.members[0].canLogCare").value(true))
+                .andExpect(jsonPath("$.members[0].plantIds").isArray())
+                .andExpect(jsonPath("$.members[0].plantIds.length()").value(2))
+                .andExpect(jsonPath("$.members[1].id").value(6))
+                .andExpect(jsonPath("$.members[1].status").value("ACCEPTED"))
+                .andExpect(jsonPath("$.members[1].canLogCare").value(false));
+    }
+
+    @Test
+    void should_return_empty_members_array_when_user_has_no_invites() throws Exception {
+        when(sharingService.listMembers(1L)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/sharing"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.members").isArray())
+                .andExpect(jsonPath("$.members.length()").value(0));
+    }
+
+    // ------------------------------------------------------------------ POST invite
+
+    @Test
+    void should_create_invite_and_return_201_when_request_valid() throws Exception {
+        User user = User.builder().telegramChatId(1L).build();
+        SharingInvite created = mockInvite(5L, "@anna", SharingStatus.PENDING, true, Set.of(23L, 24L));
+
+        when(userService.getByIdOrThrow(1L)).thenReturn(user);
+        when(sharingService.createInvite(eq(user), eq(List.of(23L, 24L)), eq("@anna"), eq(true)))
+                .thenReturn(created);
+
+        String body = """
+                {"plantIds": [23, 24], "inviteeContact": "@anna", "canLogCare": true}
+                """;
+
+        mockMvc.perform(post("/api/v1/sharing/invites")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(5))
+                .andExpect(jsonPath("$.contact").value("@anna"))
+                .andExpect(jsonPath("$.status").value("PENDING"))
+                .andExpect(jsonPath("$.canLogCare").value(true))
+                .andExpect(jsonPath("$.plantIds.length()").value(2));
+    }
+
+    @Test
+    void should_default_can_log_care_false_when_flag_omitted() throws Exception {
+        User user = User.builder().telegramChatId(1L).build();
+        SharingInvite created = mockInvite(7L, "@anna", SharingStatus.PENDING, false, Set.of(23L));
+
+        when(userService.getByIdOrThrow(1L)).thenReturn(user);
+        when(sharingService.createInvite(eq(user), eq(List.of(23L)), eq("@anna"), eq(false)))
+                .thenReturn(created);
+
+        String body = """
+                {"plantIds": [23], "inviteeContact": "@anna"}
+                """;
+
+        mockMvc.perform(post("/api/v1/sharing/invites")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.canLogCare").value(false));
+    }
+
+    @Test
+    void should_return_400_when_plant_ids_empty() throws Exception {
+        String body = """
+                {"plantIds": [], "inviteeContact": "@anna", "canLogCare": true}
+                """;
+
+        mockMvc.perform(post("/api/v1/sharing/invites")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void should_return_400_when_contact_blank() throws Exception {
+        String body = """
+                {"plantIds": [23], "inviteeContact": "", "canLogCare": true}
+                """;
+
+        mockMvc.perform(post("/api/v1/sharing/invites")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void should_return_400_when_contact_missing() throws Exception {
+        String body = """
+                {"plantIds": [23]}
+                """;
+
+        mockMvc.perform(post("/api/v1/sharing/invites")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void should_return_404_when_a_plant_is_not_owned_or_missing() throws Exception {
+        User user = User.builder().telegramChatId(1L).build();
+        when(userService.getByIdOrThrow(1L)).thenReturn(user);
+        when(sharingService.createInvite(any(), any(), anyString(), anyBoolean()))
+                .thenThrow(new EntityNotFoundException(SharingService.PLANTS_NOT_FOUND));
+
+        String body = """
+                {"plantIds": [23, 999], "inviteeContact": "@anna", "canLogCare": true}
+                """;
+
+        mockMvc.perform(post("/api/v1/sharing/invites")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+}

--- a/src/test/java/com/plantcare/core/service/SharingServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/SharingServiceTest.java
@@ -1,0 +1,229 @@
+package com.plantcare.core.service;
+
+import com.plantcare.bot.support.IntegrationTestBase;
+import com.plantcare.core.domain.Location;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.SharingInvite;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.SharingStatus;
+import com.plantcare.core.repository.LocationRepository;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.SharingInviteRepository;
+import com.plantcare.core.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Интеграционные тесты {@link SharingService} на реальном Postgres (Testcontainers, issue #191).
+ *
+ * <p>Репозиторий не мокается — проверяем персистентность приглашения, скоупинг растений
+ * по владельцу (чужое/архивное/несуществующее растение → 404), статус PENDING,
+ * нормализацию контакта и валидацию пустого ввода (400).
+ */
+class SharingServiceTest extends IntegrationTestBase {
+
+    @Autowired private SharingService sharingService;
+    @Autowired private SharingInviteRepository sharingInviteRepository;
+    @Autowired private PlantRepository plantRepository;
+    @Autowired private LocationRepository locationRepository;
+    @Autowired private UserRepository userRepository;
+
+    private User owner;
+    private User other;
+    private Plant plant1;
+    private Plant plant2;
+
+    @BeforeEach
+    void setUp() {
+        owner = savedUser(9101L);
+        other = savedUser(9102L);
+        plant1 = savedPlant(owner, "Фикус");
+        plant2 = savedPlant(owner, "Монстера");
+    }
+
+    @AfterEach
+    void cleanup() {
+        sharingInviteRepository.deleteAll();
+        plantRepository.deleteAll();
+        locationRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // --- AC: create invite happy path ---
+
+    @Test
+    void should_create_pending_invite_with_plants_and_can_log_care() {
+        SharingInvite invite = sharingService.createInvite(
+                owner, List.of(plant1.getId(), plant2.getId()), "@anna", true);
+
+        assertThat(invite.getId()).isNotNull();
+
+        // plantIds — LAZY-коллекция; читаем через fetch-запрос сервиса (как делает контроллер),
+        // а не у detached-сущности, чтобы не упереться в no-Session.
+        SharingInvite reloaded = sharingService.listMembers(owner.getId()).get(0);
+        assertThat(reloaded.getInviter().getId()).isEqualTo(owner.getId());
+        assertThat(reloaded.getInviteeContact()).isEqualTo("@anna");
+        assertThat(reloaded.getStatus()).isEqualTo(SharingStatus.PENDING);
+        assertThat(reloaded.isCanLogCare()).isTrue();
+        assertThat(reloaded.getPlantIds()).containsExactlyInAnyOrder(plant1.getId(), plant2.getId());
+    }
+
+    @Test
+    void should_default_can_log_care_false_when_not_granted() {
+        SharingInvite invite = sharingService.createInvite(
+                owner, List.of(plant1.getId()), "+79991234567", false);
+
+        assertThat(sharingInviteRepository.findById(invite.getId()).orElseThrow().isCanLogCare())
+                .isFalse();
+    }
+
+    @Test
+    void should_trim_surrounding_whitespace_in_contact() {
+        SharingInvite invite = sharingService.createInvite(
+                owner, List.of(plant1.getId()), "   @anna   ", true);
+
+        assertThat(sharingInviteRepository.findById(invite.getId()).orElseThrow().getInviteeContact())
+                .isEqualTo("@anna");
+    }
+
+    @Test
+    void should_deduplicate_repeated_plant_ids() {
+        sharingService.createInvite(
+                owner, List.of(plant1.getId(), plant1.getId()), "@anna", true);
+
+        assertThat(sharingService.listMembers(owner.getId()).get(0).getPlantIds())
+                .containsExactly(plant1.getId());
+    }
+
+    // --- AC: validation (400-path) ---
+
+    @Test
+    void should_reject_blank_contact() {
+        assertThatThrownBy(() -> sharingService.createInvite(owner, List.of(plant1.getId()), "   ", true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Контакт");
+
+        assertThat(sharingInviteRepository.count()).isZero();
+    }
+
+    @Test
+    void should_reject_null_contact() {
+        assertThatThrownBy(() -> sharingService.createInvite(owner, List.of(plant1.getId()), null, true))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_reject_empty_plant_set() {
+        assertThatThrownBy(() -> sharingService.createInvite(owner, List.of(), "@anna", true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("хотя бы одно растение");
+
+        assertThat(sharingInviteRepository.count()).isZero();
+    }
+
+    // --- AC: access model — plants must belong to the owner (404-path) ---
+
+    @Test
+    void should_reject_when_a_plant_belongs_to_another_user() {
+        Plant otherPlant = savedPlant(other, "Чужой кактус");
+
+        assertThatThrownBy(() -> sharingService.createInvite(
+                owner, List.of(plant1.getId(), otherPlant.getId()), "@anna", true))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage(SharingService.PLANTS_NOT_FOUND);
+
+        assertThat(sharingInviteRepository.count()).isZero();
+    }
+
+    @Test
+    void should_reject_when_a_plant_does_not_exist() {
+        assertThatThrownBy(() -> sharingService.createInvite(
+                owner, List.of(plant1.getId(), 999_999L), "@anna", true))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage(SharingService.PLANTS_NOT_FOUND);
+    }
+
+    @Test
+    void should_reject_when_a_plant_is_archived() {
+        plant2.setArchivedAt(LocalDateTime.now().truncatedTo(ChronoUnit.MICROS));
+        plantRepository.save(plant2);
+
+        assertThatThrownBy(() -> sharingService.createInvite(
+                owner, List.of(plant1.getId(), plant2.getId()), "@anna", true))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage(SharingService.PLANTS_NOT_FOUND);
+    }
+
+    // --- AC: list members ---
+
+    @Test
+    void should_list_invites_of_owner_with_their_plants() {
+        sharingService.createInvite(owner, List.of(plant1.getId(), plant2.getId()), "@anna", true);
+        sharingService.createInvite(owner, List.of(plant1.getId()), "@bob", false);
+
+        List<SharingInvite> members = sharingService.listMembers(owner.getId());
+
+        assertThat(members).hasSize(2);
+        assertThat(members).extracting(SharingInvite::getInviteeContact)
+                .containsExactlyInAnyOrder("@anna", "@bob");
+        assertThat(members).allSatisfy(m ->
+                assertThat(m.getStatus()).isEqualTo(SharingStatus.PENDING));
+    }
+
+    @Test
+    void should_not_return_invites_of_other_users() {
+        Plant otherPlant = savedPlant(other, "Чужой кактус");
+        sharingService.createInvite(owner, List.of(plant1.getId()), "@anna", true);
+        sharingService.createInvite(other, List.of(otherPlant.getId()), "@carol", true);
+
+        List<SharingInvite> members = sharingService.listMembers(owner.getId());
+
+        assertThat(members).hasSize(1);
+        assertThat(members.get(0).getInviteeContact()).isEqualTo("@anna");
+    }
+
+    @Test
+    void should_return_empty_list_when_owner_has_no_invites() {
+        assertThat(sharingService.listMembers(owner.getId())).isEmpty();
+    }
+
+    // --- helpers ---
+
+    private User savedUser(Long chatId) {
+        return userRepository.save(User.builder()
+                .telegramChatId(chatId)
+                .timezone("UTC")
+                .blocked(false)
+                .build());
+    }
+
+    private Location savedDefaultLocation(User user) {
+        return locationRepository.findByUserIdAndDefaultLocationTrue(user.getId())
+                .orElseGet(() -> locationRepository.save(Location.builder()
+                        .user(user)
+                        .name(Location.DEFAULT_NAME)
+                        .emoji(Location.DEFAULT_EMOJI)
+                        .defaultLocation(true)
+                        .build()));
+    }
+
+    private Plant savedPlant(User user, String name) {
+        return plantRepository.save(Plant.builder()
+                .user(user)
+                .location(savedDefaultLocation(user))
+                .name(name)
+                .acquiredAt(LocalDate.of(2024, 1, 1))
+                .build());
+    }
+}


### PR DESCRIPTION
Closes #191

Совместный уход (mobile G22). Spec-first.

- `GET /api/v1/sharing`, `POST /api/v1/sharing/invites`
- OpenAPI: `openapi/resources/sharing.yaml` + регистрация в `openapi.yaml`
- Слои: `SharingInvite` + `SharingStatus`, `SharingInviteRepository`, `SharingService` (валидация принадлежности растений → 404, пустой ввод → 400), `SharingController`
- Миграция `V38__create_sharing_invites.sql`
- Тесты: `SharingServiceTest` (Testcontainers) + `SharingControllerTest` (@WebMvcTest) — 21 зелёный

🤖 Generated with [Claude Code](https://claude.com/claude-code)