### PR TITLE
feat: журнал событий растения GET/POST /plants/{id}/events (#220)

### DIFF
--- a/src/main/java/com/plantcare/api/ApiExceptionHandler.java
+++ b/src/main/java/com/plantcare/api/ApiExceptionHandler.java
@@ -10,6 +10,7 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -44,6 +45,31 @@ public class ApiExceptionHandler {
     public ResponseEntity<ApiErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ApiErrorResponse.of("BAD_REQUEST", "Invalid parameter value: " + e.getValue()));
+    }
+
+    /**
+     * Тело не читается. Если причина — недопустимое значение enum/семантически
+     * невалидное поле (Jackson оборачивает {@link IllegalArgumentException} из
+     * {@code @JsonCreator}), это 422 (issue #220: неизвестный {@code eventType}).
+     * Прочий синтаксический мусор остаётся 400.
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiErrorResponse> handleNotReadable(HttpMessageNotReadableException e) {
+        if (hasCause(e, IllegalArgumentException.class)) {
+            return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                    .body(ApiErrorResponse.of("VALIDATION_ERROR", "Validation failed"));
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiErrorResponse.of("BAD_REQUEST", "Malformed request body"));
+    }
+
+    private static boolean hasCause(Throwable t, Class<? extends Throwable> type) {
+        for (Throwable c = t; c != null; c = c.getCause()) {
+            if (type.isInstance(c)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @ExceptionHandler(EntityNotFoundException.class)

--- a/src/main/java/com/plantcare/api/v1/PlantEventController.java
+++ b/src/main/java/com/plantcare/api/v1/PlantEventController.java
@@ -1,0 +1,96 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.api.generated.PlantEventsApi;
+import com.plantcare.api.generated.model.PlantEventDto;
+import com.plantcare.api.generated.model.PlantEventPageResponse;
+import com.plantcare.api.generated.model.PlantEventRequest;
+import com.plantcare.core.domain.PlantEvent;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.PlantEventType;
+import com.plantcare.core.service.PlantEventService;
+import com.plantcare.core.service.PlantEventService.AddResult;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.ZoneOffset;
+import java.util.List;
+
+/**
+ * REST API журнала событий растения (issue #220): чтение и добавление редких
+ * разовых событий (пересадка, замена грунта, обрезка, обработка от вредителей).
+ *
+ * <p>Контроллер тонкий: вся логика (дедуп, проверка владельца, пагинация) —
+ * в {@link PlantEventService}. Документация и mapping живут в сгенерированном
+ * {@link PlantEventsApi} (см. openapi.yaml).
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class PlantEventController implements PlantEventsApi {
+
+    private final PlantEventService plantEventService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    public PlantEventPageResponse getPlantEvents(Long id, Integer limit, Integer offset) {
+        User user = currentUserProvider.currentUser();
+
+        // limit уже валидирован [1,100] на входе (@Min/@Max в сгенерированном API);
+        // offset нормализуем на всякий случай, как в остальных листингах.
+        int safeOffset = Math.max(0, offset);
+
+        log.info("GET /api/v1/plants/{}/events: userId={}, limit={}, offset={}",
+                id, user.getId(), limit, safeOffset);
+
+        Page<PlantEvent> page = plantEventService.getEventsPage(user, id, safeOffset, limit);
+
+        List<PlantEventDto> items = page.getContent().stream()
+                .map(PlantEventController::toDto)
+                .toList();
+
+        return new PlantEventPageResponse(items, page.getTotalElements(), limit, safeOffset);
+    }
+
+    @Override
+    public PlantEventDto createPlantEvent(Long id, PlantEventRequest request) {
+        User user = currentUserProvider.currentUser();
+
+        // eventType валиден по enum (неизвестное значение отсекается десериализацией → 422),
+        // здесь маппим API-enum в доменный по имени — наборы значений идентичны.
+        PlantEventType eventType = PlantEventType.valueOf(request.getEventType().getValue());
+
+        log.info("POST /api/v1/plants/{}/events: userId={}, eventType={}",
+                id, user.getId(), eventType);
+
+        AddResult result = plantEventService.addEvent(user, id, eventType);
+
+        if (result.wasNotFound()) {
+            throw new EntityNotFoundException(
+                    "Plant not found: id=" + id + " for userId=" + user.getId());
+        }
+        if (result.wasDuplicate()) {
+            // Повтор того же типа в окне дедупа (60 сек) — двойное нажатие.
+            throw new IllegalStateException(
+                    "Duplicate plant event: type=" + eventType + " within dedup window");
+        }
+
+        return toDto(result.event());
+    }
+
+    /**
+     * Доменное событие → API DTO. {@code eventDate} в БД хранится как UTC
+     * (см. CLAUDE.md), поэтому отдаём со смещением UTC. {@code comment} в v1
+     * всегда null — колонка зарезервирована под будущее.
+     */
+    private static PlantEventDto toDto(PlantEvent event) {
+        return new PlantEventDto(
+                event.getId(),
+                com.plantcare.api.generated.model.PlantEventType.fromValue(event.getEventType().name()),
+                event.getEventDate().atOffset(ZoneOffset.UTC)
+        ).comment(event.getComment());
+    }
+}

--- a/src/main/java/com/plantcare/core/service/PlantEventService.java
+++ b/src/main/java/com/plantcare/core/service/PlantEventService.java
@@ -4,13 +4,16 @@ import com.plantcare.core.domain.Plant;
 import com.plantcare.core.domain.PlantEvent;
 import com.plantcare.core.domain.User;
 import com.plantcare.core.domain.enums.PlantEventType;
+import com.plantcare.core.repository.OffsetLimitPageable;
 import com.plantcare.core.repository.PlantEventRepository;
 import com.plantcare.core.repository.PlantRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -95,6 +98,33 @@ public class PlantEventService {
 
         int safePage = Math.max(0, page);
         Pageable pageable = PageRequest.of(safePage, EVENTS_PAGE_SIZE);
+        return plantEventRepository.findByPlantIdOrderByEventDateDesc(plantId, pageable);
+    }
+
+    /**
+     * Возвращает страницу журнала по произвольному {@code offset/limit} — для
+     * REST API (issue #220). В отличие от {@link #getEvents(User, Long, int)},
+     * который для Telegram-бота отдаёт пустую страницу при недоступном растении,
+     * здесь недоступность — это {@link EntityNotFoundException} (контроллер
+     * мапит в 404): чужое/архивное/несуществующее растение неотличимо для клиента.
+     *
+     * <p>Сортировка фиксирована — {@code event_date DESC}. {@code offset/limit}
+     * предполагаются уже нормализованными вызывающим.
+     */
+    @Transactional(readOnly = true)
+    public Page<PlantEvent> getEventsPage(User user, Long plantId, int offset, int limit) {
+        boolean accessible = plantRepository
+                .findByUserIdAndIdAndArchivedAtIsNull(user.getId(), plantId)
+                .isPresent();
+
+        if (!accessible) {
+            throw new EntityNotFoundException(
+                    "Plant not found: id=" + plantId + " for userId=" + user.getId());
+        }
+
+        // Сортировка уже зашита в имя метода (OrderByEventDateDesc); во избежание
+        // дублирования ORDER BY передаём в Pageable unsorted.
+        Pageable pageable = OffsetLimitPageable.of(offset, limit, Sort.unsorted());
         return plantEventRepository.findByPlantIdOrderByEventDateDesc(plantId, pageable);
     }
 

--- a/src/main/resources/openapi/_common/responses.yaml
+++ b/src/main/resources/openapi/_common/responses.yaml
@@ -83,3 +83,16 @@ Conflict:
         error:
           code: CONFLICT
           message: Operation not allowed in the current state
+
+UnprocessableEntity:
+  description: |
+    Тело запроса синтаксически корректно, но семантически невалидно — например,
+    значение enum вне допустимого набора. Код `VALIDATION_ERROR`.
+  content:
+    application/json:
+      schema:
+        $ref: './errors.yaml#/schemas/ApiErrorResponse'
+      example:
+        error:
+          code: VALIDATION_ERROR
+          message: Validation failed

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -62,6 +62,10 @@ tags:
       soft-delete (флаг `archivedAt`), физически записи в БД остаются.
   - name: Plant History
     description: История событий ухода для конкретного растения с пагинацией.
+  - name: Plant Events
+    description: |
+      Журнал редких разовых событий растения (пересадка, замена грунта,
+      обрезка, обработка от вредителей) с пагинацией и дедупом повторных нажатий.
   - name: Locations
     description: |
       Локации (комнаты/места) пользователя, в которых стоят растения. Каждый
@@ -128,6 +132,8 @@ paths:
     $ref: './resources/plant-history.yaml#/paths/ItemHistory'
   /api/v1/plants/{id}/history/summary:
     $ref: './resources/plant-history.yaml#/paths/ItemHistorySummary'
+  /api/v1/plants/{id}/events:
+    $ref: './resources/plant-events.yaml#/paths/Collection'
   /api/v1/plants/{id}/health:
     $ref: './resources/plants.yaml#/paths/ItemHealth'
   /api/v1/plants/{id}/family:
@@ -224,6 +230,8 @@ components:
       $ref: './_common/responses.yaml#/NotFound'
     Conflict:
       $ref: './_common/responses.yaml#/Conflict'
+    UnprocessableEntity:
+      $ref: './_common/responses.yaml#/UnprocessableEntity'
 
   # Все доменные схемы регистрируются здесь, чтобы они появились в
   # /v3/api-docs и были генерированы openapi-generator'ом как Java-классы
@@ -269,6 +277,15 @@ components:
       $ref: './resources/plant-history.yaml#/schemas/PlantHistoryResponse'
     PlantHistorySummaryDto:
       $ref: './resources/plant-history.yaml#/schemas/PlantHistorySummaryDto'
+
+    PlantEventType:
+      $ref: './resources/plant-events.yaml#/schemas/PlantEventType'
+    PlantEventDto:
+      $ref: './resources/plant-events.yaml#/schemas/PlantEventDto'
+    PlantEventRequest:
+      $ref: './resources/plant-events.yaml#/schemas/PlantEventRequest'
+    PlantEventPageResponse:
+      $ref: './resources/plant-events.yaml#/schemas/PlantEventPageResponse'
 
     LocationDto:
       $ref: './resources/locations.yaml#/schemas/LocationDto'

--- a/src/main/resources/openapi/resources/plant-events.yaml
+++ b/src/main/resources/openapi/resources/plant-events.yaml
@@ -1,0 +1,158 @@
+# Журнал событий растения (issue #220): редкие разовые события — пересадка,
+# замена грунта, обрезка, обработка от вредителей. В отличие от истории ухода
+# (plant-history.yaml) — без расписаний и рекомендаций, просто факты на шкале.
+
+paths:
+  Collection:
+    get:
+      tags: [Plant Events]
+      operationId: getPlantEvents
+      summary: Журнал событий растения
+      description: |
+        Возвращает страницу журнала событий растения, принадлежащего текущему
+        пользователю (`sub` из bearer-токена). Сортировка — по дате события
+        (`eventDate`) по убыванию (свежие сверху).
+
+        Доступ только к неархивированному растению текущего пользователя.
+        Если растение не найдено, архивировано или принадлежит другому
+        пользователю — 404.
+
+        Пагинация — `limit/offset`. `limit` нормализуется в диапазон [1, 100]
+        (по умолчанию 5 — совпадает с размером страницы журнала). `offset` < 0
+        нормализуется в 0.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '../_common/parameters.yaml#/PlantIdPath'
+        - name: limit
+          in: query
+          required: false
+          description: Размер страницы. Нормализуется в [1, 100]. По умолчанию 5.
+          schema:
+            type: integer
+            format: int32
+            default: 5
+            minimum: 1
+            maximum: 100
+        - name: offset
+          in: query
+          required: false
+          description: Сдвиг от начала журнала. Значения < 0 нормализуются в 0.
+          schema:
+            type: integer
+            format: int32
+            default: 0
+            minimum: 0
+      responses:
+        '200':
+          description: Страница журнала событий.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/PlantEventPageResponse'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+    post:
+      tags: [Plant Events]
+      operationId: createPlantEvent
+      summary: Добавить событие в журнал растения
+      description: |
+        Создаёт событие журнала текущей датой (UTC) для растения текущего
+        пользователя. Одно нажатие = одно событие; `comment` в v1 не принимается.
+
+        ## Дедуп
+
+        Повторный запрос того же `eventType` для того же растения в окне 60
+        секунд считается двойным нажатием и возвращает 409 без повторной вставки.
+
+        Доступ только к неархивированному растению текущего пользователя —
+        иначе 404. Неизвестный `eventType` — 422.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '../_common/parameters.yaml#/PlantIdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/PlantEventRequest'
+            example:
+              eventType: TRANSPLANT
+      responses:
+        '201':
+          description: Событие создано.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/PlantEventDto'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+        '409':
+          $ref: '../_common/responses.yaml#/Conflict'
+        '422':
+          $ref: '../_common/responses.yaml#/UnprocessableEntity'
+
+schemas:
+  PlantEventType:
+    type: string
+    description: |
+      Тип события в журнале растения. Редкие разовые события (не регулярный
+      уход): пересадка, замена грунта, обрезка, обработка от вредителей.
+    enum: [TRANSPLANT, SOIL_CHANGE, PRUNING, PEST_TREATMENT]
+    example: TRANSPLANT
+
+  PlantEventDto:
+    type: object
+    description: Запись журнала событий растения.
+    required: [id, eventType, eventDate]
+    properties:
+      id:
+        type: integer
+        format: int64
+        example: 7
+      eventType:
+        $ref: '#/schemas/PlantEventType'
+      eventDate:
+        type: string
+        format: date-time
+        description: Момент события в UTC.
+        example: 2026-05-10T14:30:00Z
+      comment:
+        type: string
+        nullable: true
+        description: Необязательный комментарий. В v1 всегда null.
+
+  PlantEventRequest:
+    type: object
+    description: Тело POST /api/v1/plants/{id}/events.
+    required: [eventType]
+    properties:
+      eventType:
+        $ref: '#/schemas/PlantEventType'
+
+  PlantEventPageResponse:
+    type: object
+    description: Страница журнала событий растения с метаданными пагинации.
+    required: [items, total, limit, offset]
+    properties:
+      items:
+        type: array
+        items:
+          $ref: '#/schemas/PlantEventDto'
+      total:
+        type: integer
+        format: int64
+        description: Общее количество событий растения.
+        example: 5
+      limit:
+        type: integer
+        format: int32
+        example: 5
+      offset:
+        type: integer
+        format: int32
+        example: 0

--- a/src/test/java/com/plantcare/api/v1/PlantEventControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/PlantEventControllerTest.java
@@ -1,0 +1,215 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.core.domain.PlantEvent;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.PlantEventType;
+import com.plantcare.core.service.PlantEventService;
+import com.plantcare.core.service.PlantEventService.AddResult;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * WebMvcTest для {@link PlantEventController} — issue #220.
+ *
+ * <p>Покрывает HTTP-контракт GET/POST /api/v1/plants/{id}/events: пагинацию,
+ * 201 на создание, 404 для чужого/архивного растения, 409 на дедуп и 422 на
+ * неизвестный {@code eventType}.
+ */
+@WebMvcTest(PlantEventController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PlantEventControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PlantEventService plantEventService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    private static final long USER_ID = 1L;
+    private static final long PLANT_ID = 42L;
+
+    @BeforeEach
+    void stubCurrentUser() {
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(USER_ID);
+        when(currentUserProvider.currentUser()).thenReturn(user);
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /api/v1/plants/{id}/events
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_return_paged_events_with_defaults_when_no_query_params() throws Exception {
+        // arrange
+        PlantEvent e1 = event(7L, PlantEventType.TRANSPLANT,
+                LocalDateTime.of(2026, 5, 10, 14, 30));
+        PlantEvent e2 = event(3L, PlantEventType.PRUNING,
+                LocalDateTime.of(2026, 3, 1, 10, 0));
+        Page<PlantEvent> page = new PageImpl<>(List.of(e1, e2), PageRequest.of(0, 5), 5);
+        when(plantEventService.getEventsPage(any(User.class), eq(PLANT_ID), eq(0), eq(5)))
+                .thenReturn(page);
+
+        // act & assert
+        mockMvc.perform(get("/api/v1/plants/{id}/events", PLANT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(5))
+                .andExpect(jsonPath("$.limit").value(5))
+                .andExpect(jsonPath("$.offset").value(0))
+                .andExpect(jsonPath("$.items").isArray())
+                .andExpect(jsonPath("$.items[0].id").value(7))
+                .andExpect(jsonPath("$.items[0].eventType").value("TRANSPLANT"))
+                .andExpect(jsonPath("$.items[0].eventDate").value("2026-05-10T14:30:00Z"))
+                .andExpect(jsonPath("$.items[0].comment").doesNotExist())
+                .andExpect(jsonPath("$.items[1].eventType").value("PRUNING"));
+
+        verify(plantEventService).getEventsPage(any(User.class), eq(PLANT_ID), eq(0), eq(5));
+    }
+
+    @Test
+    void should_pass_explicit_limit_and_offset_to_service() throws Exception {
+        // arrange
+        Page<PlantEvent> page = new PageImpl<>(List.of(), PageRequest.of(0, 2), 0);
+        when(plantEventService.getEventsPage(any(User.class), eq(PLANT_ID), eq(4), eq(2)))
+                .thenReturn(page);
+
+        // act & assert
+        mockMvc.perform(get("/api/v1/plants/{id}/events", PLANT_ID)
+                        .queryParam("limit", "2")
+                        .queryParam("offset", "4"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.limit").value(2))
+                .andExpect(jsonPath("$.offset").value(4));
+
+        verify(plantEventService).getEventsPage(any(User.class), eq(PLANT_ID), eq(4), eq(2));
+    }
+
+    @Test
+    void should_return_400_when_limit_out_of_range() throws Exception {
+        // act & assert — @Min/@Max в сгенерированном API отсекают до контроллера
+        mockMvc.perform(get("/api/v1/plants/{id}/events", PLANT_ID)
+                        .queryParam("limit", "0"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void should_return_404_for_get_when_plant_not_owned() throws Exception {
+        // arrange
+        when(plantEventService.getEventsPage(any(User.class), eq(999L), eq(0), eq(5)))
+                .thenThrow(new EntityNotFoundException("Plant not found"));
+
+        // act & assert
+        mockMvc.perform(get("/api/v1/plants/{id}/events", 999L))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/v1/plants/{id}/events
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_create_event_and_return_201() throws Exception {
+        // arrange
+        PlantEvent created = event(8L, PlantEventType.TRANSPLANT,
+                LocalDateTime.of(2026, 6, 3, 12, 0));
+        when(plantEventService.addEvent(any(User.class), eq(PLANT_ID), eq(PlantEventType.TRANSPLANT)))
+                .thenReturn(AddResult.created(created));
+
+        // act & assert
+        mockMvc.perform(post("/api/v1/plants/{id}/events", PLANT_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"eventType\":\"TRANSPLANT\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(8))
+                .andExpect(jsonPath("$.eventType").value("TRANSPLANT"))
+                .andExpect(jsonPath("$.eventDate").value("2026-06-03T12:00:00Z"))
+                .andExpect(jsonPath("$.comment").doesNotExist());
+
+        verify(plantEventService).addEvent(any(User.class), eq(PLANT_ID), eq(PlantEventType.TRANSPLANT));
+    }
+
+    @Test
+    void should_return_409_when_duplicate_within_dedup_window() throws Exception {
+        // arrange
+        PlantEvent last = event(8L, PlantEventType.TRANSPLANT,
+                LocalDateTime.of(2026, 6, 3, 12, 0));
+        when(plantEventService.addEvent(any(User.class), eq(PLANT_ID), eq(PlantEventType.TRANSPLANT)))
+                .thenReturn(AddResult.duplicate(last));
+
+        // act & assert
+        mockMvc.perform(post("/api/v1/plants/{id}/events", PLANT_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"eventType\":\"TRANSPLANT\"}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("CONFLICT"));
+    }
+
+    @Test
+    void should_return_404_for_post_when_plant_not_owned() throws Exception {
+        // arrange
+        when(plantEventService.addEvent(any(User.class), eq(999L), eq(PlantEventType.PRUNING)))
+                .thenReturn(AddResult.notFound());
+
+        // act & assert
+        mockMvc.perform(post("/api/v1/plants/{id}/events", 999L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"eventType\":\"PRUNING\"}"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void should_return_422_when_unknown_event_type() throws Exception {
+        // act & assert — недопустимое значение enum отсекается десериализацией
+        mockMvc.perform(post("/api/v1/plants/{id}/events", PLANT_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"eventType\":\"FLYING\"}"))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private static PlantEvent event(Long id, PlantEventType type, LocalDateTime date) {
+        PlantEvent e = PlantEvent.builder()
+                .eventType(type)
+                .eventDate(date)
+                .build();
+        ReflectionTestUtils.setField(e, "id", id);
+        return e;
+    }
+}


### PR DESCRIPTION
Closes #220

REST API журнала событий растения (PlantEventType).

- `GET /api/v1/plants/{id}/events` — пагинация limit/offset (дефолт 5), сортировка event_date DESC, 404 для чужого/архивного растения
- `POST /api/v1/plants/{id}/events` — 201, дедуп → 409, чужое → 404, неизвестный eventType → 422
- `PlantEventService.getEventsPage(offset/limit)`, маппинг 422 для unreadable-enum в `ApiExceptionHandler`
- OpenAPI: `plant-events.yaml` + регистрация
- Тесты: `PlantEventControllerTest` 8/8, `PlantEventServiceTest` 8/8, `ApiExceptionHandlerTest` 4/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)