### PR TITLE
feat: Universal Links / App Links для magic-link диплинков (#215)

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,72 @@ quiet hours), бот шлёт мягкую нотификацию с кнопк�
 `supplies` (по умолчанию «Грунт», «Дренаж») и `message-template` задаются списком/строкой
 в `application.yml`, env-override для них не предусмотрен.
 
+## Universal Links (iOS) / App Links (Android) — magic-link диплинки (issue #215)
+
+Magic-link письма теперь используют `https://`-ссылки вместо кастомной схемы `plantcare://`.
+Это позволяет почтовым клиентам (Gmail, Apple Mail) делать ссылки кликабельными и открывать
+мобильное приложение напрямую через Universal Links (iOS) / App Links (Android).
+
+### Как это работает
+
+1. Бэкенд отдаёт `.well-known`-файлы, которые ОС запрашивает при установке приложения.
+2. При клике на `https://<домен>/auth/verify?token=...` ОС открывает приложение напрямую.
+3. Если приложение не установлено — браузер показывает фоллбэк-страницу с инструкцией.
+
+### Env-переменные
+
+#### Magic-link URL (уже существующая переменная)
+
+| Переменная | Дефолт | Описание |
+|---|---|---|
+| `AUTH_MAGIC_LINK_BASE_URL` | `https://plants-care.up.railway.app/auth/verify` | Базовый URL magic-link в письме |
+
+Для дев-стенда: `https://plants-care-development.up.railway.app/auth/verify`
+
+#### iOS Universal Links (AASA)
+
+Требуется от app-команды: Team ID и bundle ID приложения.
+
+| Переменная | Пример | Описание |
+|---|---|---|
+| `DEEP_LINK_IOS_APP_IDS` | `TEAMID1234.com.example.plantcare` | appID(ы) в формате `<TeamID>.<BundleId>`, через запятую если несколько |
+| `DEEP_LINK_IOS_PATHS` | `/auth/verify*` | Пути, которые AASA разрешает открывать в приложении |
+
+#### Android App Links (assetlinks.json)
+
+Требуется от app-команды: package name и SHA-256 отпечатки подписи.
+
+| Переменная | Пример | Описание |
+|---|---|---|
+| `DEEP_LINK_ANDROID_PACKAGE_NAME` | `com.example.plantcare` | Package name Android-приложения |
+| `DEEP_LINK_ANDROID_SHA256_CERT_FINGERPRINTS` | `AA:BB:CC:...,DD:EE:FF:...` | SHA-256 отпечатки сертификата подписи (debug + release), через запятую |
+
+### Проверка (curl + валидаторы)
+
+```bash
+# Apple App Site Association (iOS)
+curl -i https://plants-care.up.railway.app/.well-known/apple-app-site-association
+# Ожидаем: HTTP/2 200, Content-Type: application/json, тело с "applinks"
+
+# Digital Asset Links (Android)
+curl -i https://plants-care.up.railway.app/.well-known/assetlinks.json
+# Ожидаем: HTTP/2 200, Content-Type: application/json, тело с "delegate_permission/common.handle_all_urls"
+
+# Fallback-страница
+curl -i https://plants-care.up.railway.app/auth/verify
+# Ожидаем: HTTP/2 200, Content-Type: text/html; без токена — показывает инструкцию "открой на телефоне"
+```
+
+Онлайн-валидаторы:
+- iOS: [https://branch.io/resources/aasa-validator/](https://branch.io/resources/aasa-validator/)
+- Android: [https://digitalassetlinks.googleapis.com/v1/statements:list?source.web.site=https://plants-care.up.railway.app&relation=delegate_permission/common.handle_all_urls](https://digitalassetlinks.googleapis.com/v1/statements:list?source.web.site=https://plants-care.up.railway.app&relation=delegate_permission/common.handle_all_urls)
+
+### Настройка мобильного приложения
+
+Бэкенд готов. Для полной интеграции app-команда должна добавить:
+- **iOS**: `Associated Domains` → `applinks:<домен>` в entitlements.
+- **Android**: `intent-filter` с `autoVerify="true"` в `AndroidManifest.xml`.
+
 ## Деплой на Railway
 
 ### Первичная настройка

--- a/src/main/java/com/plantcare/api/AuthVerifyController.java
+++ b/src/main/java/com/plantcare/api/AuthVerifyController.java
@@ -1,0 +1,32 @@
+package com.plantcare.api;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * Issue #215: веб-фоллбэк для magic-link на десктопе / при отсутствии приложения.
+ *
+ * <p>Когда пользователь открывает magic-link ({@code /auth/verify?token=...}) на компьютере
+ * или на телефоне без установленного приложения, он попадает на эту страницу.
+ * Она объясняет, что нужно открыть ссылку на телефоне с установленным приложением.
+ *
+ * <p>Токен из query НЕ отображается в UI и не обрабатывается бэкендом — верификацию
+ * выполняет мобильное приложение напрямую через {@code /api/v1/auth/magic-link/verify}.
+ *
+ * <p>Путь вне {@code /api/v1/**} → попадает в дефолтную permitAll-цепочку,
+ * авторизация не нужна.
+ */
+@Controller
+public class AuthVerifyController {
+
+    /**
+     * Фоллбэк-страница для magic-link.
+     *
+     * <p>Работает без query-параметров (они необязательны), так что
+     * {@code GET /auth/verify} без токена тоже вернёт 200 с подсказкой.
+     */
+    @GetMapping("/auth/verify")
+    public String magicLinkFallback() {
+        return "auth/verify";
+    }
+}

--- a/src/main/java/com/plantcare/api/WellKnownController.java
+++ b/src/main/java/com/plantcare/api/WellKnownController.java
@@ -1,0 +1,87 @@
+package com.plantcare.api;
+
+import com.plantcare.api.config.DeepLinkProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Issue #215: Well-known эндпоинты для Universal Links (iOS) и App Links (Android).
+ *
+ * <p>Оба пути находятся вне {@code /api/v1/**}, поэтому попадают в дефолтную
+ * permitAll-цепочку Spring Security — авторизация не нужна.
+ *
+ * <p>Ответы отдаются без редиректов и без файлового расширения,
+ * {@code Content-Type: application/json} — именно так требуют валидаторы Apple и Google.
+ */
+@RestController
+@RequiredArgsConstructor
+public class WellKnownController {
+
+    private final DeepLinkProperties deepLinkProperties;
+
+    /**
+     * Apple App Site Association (AASA) для Universal Links (iOS).
+     *
+     * <p>Путь {@code /.well-known/apple-app-site-association} — Apple запрашивает его
+     * при установке приложения, чтобы связать домен с приложением.
+     */
+    @GetMapping(
+            value = "/.well-known/apple-app-site-association",
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<Map<String, Object>> appleAppSiteAssociation() {
+        var ios = deepLinkProperties.getIos();
+
+        Map<String, Object> applinksDetail = new LinkedHashMap<>();
+        applinksDetail.put("apps", List.of());
+        applinksDetail.put("details", ios.getAppIds().stream()
+                .map(appId -> {
+                    Map<String, Object> detail = new LinkedHashMap<>();
+                    detail.put("appID", appId);
+                    detail.put("paths", ios.getPaths());
+                    return detail;
+                })
+                .toList());
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("applinks", applinksDetail);
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(body);
+    }
+
+    /**
+     * Digital Asset Links для App Links (Android).
+     *
+     * <p>Путь {@code /.well-known/assetlinks.json} — Android запрашивает его
+     * при autoVerify intent-filter, чтобы верифицировать связь домена с приложением.
+     */
+    @GetMapping(
+            value = "/.well-known/assetlinks.json",
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<List<Map<String, Object>>> assetLinks() {
+        var android = deepLinkProperties.getAndroid();
+
+        Map<String, Object> target = new LinkedHashMap<>();
+        target.put("namespace", "android_app");
+        target.put("package_name", android.getPackageName());
+        target.put("sha256_cert_fingerprints", android.getSha256CertFingerprints());
+
+        Map<String, Object> entry = new LinkedHashMap<>();
+        entry.put("relation", List.of("delegate_permission/common.handle_all_urls"));
+        entry.put("target", target);
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(List.of(entry));
+    }
+}

--- a/src/main/java/com/plantcare/api/config/DeepLinkProperties.java
+++ b/src/main/java/com/plantcare/api/config/DeepLinkProperties.java
@@ -1,0 +1,72 @@
+package com.plantcare.api.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+/**
+ * Конфигурация Universal Links (iOS) и App Links (Android) для magic-link диплинков.
+ * Issue #215 (ADR-011, #88).
+ *
+ * <p>Значения берутся только из env — они различаются на dev/prod и
+ * зависят от сертификатов мобильного приложения.
+ *
+ * <p>Маппинг env: {@code DEEP_LINK_IOS_*} / {@code DEEP_LINK_ANDROID_*}.
+ * Пример:
+ * <pre>
+ *   DEEP_LINK_IOS_APP_IDS=TEAMID1234.com.example.plantcare
+ *   DEEP_LINK_ANDROID_PACKAGE_NAME=com.example.plantcare
+ *   DEEP_LINK_ANDROID_SHA256_CERT_FINGERPRINTS=AA:BB:CC:...,DD:EE:FF:...
+ * </pre>
+ */
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "plantcare.deep-link")
+public class DeepLinkProperties {
+
+    /** Настройки iOS Universal Links / AASA. */
+    private final Ios ios;
+
+    /** Настройки Android App Links / assetlinks.json. */
+    private final Android android;
+
+    /**
+     * iOS Apple App Site Association (AASA).
+     */
+    @Getter
+    @RequiredArgsConstructor
+    public static class Ios {
+        /**
+         * Список appID в формате {@code <TeamID>.<BundleId>}.
+         * Пример: {@code ["TEAMID1234.com.example.plantcare"]}.
+         * Может содержать несколько, если dev/prod разные bundle id.
+         */
+        private final List<String> appIds;
+
+        /**
+         * Пути, которые AASA разрешает открывать в приложении.
+         * Минимум: {@code ["/auth/verify*"]}.
+         */
+        private final List<String> paths;
+    }
+
+    /**
+     * Android Digital Asset Links (assetlinks.json).
+     */
+    @Getter
+    @RequiredArgsConstructor
+    public static class Android {
+        /**
+         * Package name приложения. Пример: {@code com.example.plantcare}.
+         */
+        private final String packageName;
+
+        /**
+         * SHA-256 отпечатки подписи приложения (debug + release).
+         * Формат: {@code AA:BB:CC:...} (hex, разделённый двоеточиями).
+         */
+        private final List<String> sha256CertFingerprints;
+    }
+}

--- a/src/main/java/com/plantcare/api/config/WellKnownConfig.java
+++ b/src/main/java/com/plantcare/api/config/WellKnownConfig.java
@@ -1,0 +1,13 @@
+package com.plantcare.api.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Регистрирует {@link DeepLinkProperties} как бин конфигурации.
+ * Issue #215: Universal Links (iOS) / App Links (Android).
+ */
+@Configuration
+@EnableConfigurationProperties(DeepLinkProperties.class)
+public class WellKnownConfig {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,6 +107,23 @@ plantcare:
         max-attempts: 5
         window-seconds: 300
 
+  # Issue #215: Universal Links (iOS) / App Links (Android) для magic-link диплинков.
+  # Значения зависят от мобильного приложения и различаются на dev/prod.
+  # Требуются реальные данные от app-команды (Team ID, bundle id, SHA-256 fingerprints).
+  deep-link:
+    ios:
+      # appID в формате <TeamID>.<BundleId>. Может быть несколько (dev/prod разные bundle id).
+      # Пример: TEAMID1234.com.example.plantcare
+      app-ids: ${DEEP_LINK_IOS_APP_IDS:PLACEHOLDER_TEAM_ID.com.example.plantcare}
+      # Пути, которые AASA разрешает открывать в приложении.
+      paths: ${DEEP_LINK_IOS_PATHS:/auth/verify*}
+    android:
+      # Package name Android-приложения. Пример: com.example.plantcare
+      package-name: ${DEEP_LINK_ANDROID_PACKAGE_NAME:com.example.plantcare}
+      # SHA-256 отпечатки подписи приложения (debug и release).
+      # Формат: AA:BB:CC:... (hex через двоеточие). Может быть несколько.
+      sha256-cert-fingerprints: ${DEEP_LINK_ANDROID_SHA256_CERT_FINGERPRINTS:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99}
+
 admin:
   username: ${ADMIN_USERNAME:}
   password-bcrypt-hash: ${ADMIN_PASSWORD_BCRYPT_HASH:}

--- a/src/main/resources/templates/auth/verify.html
+++ b/src/main/resources/templates/auth/verify.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ru">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>PlantCare — открой на телефоне</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #faf9f5;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      padding: 24px;
+    }
+    .card {
+      background: #fff;
+      border-radius: 16px;
+      box-shadow: 0 2px 16px rgba(0,0,0,0.08);
+      padding: 40px 32px;
+      max-width: 420px;
+      width: 100%;
+      text-align: center;
+    }
+    .icon {
+      font-size: 56px;
+      margin-bottom: 20px;
+    }
+    h1 {
+      font-size: 22px;
+      font-weight: 700;
+      color: #1a1a1a;
+      margin-bottom: 12px;
+    }
+    p {
+      font-size: 15px;
+      color: #555;
+      line-height: 1.6;
+      margin-bottom: 16px;
+    }
+    .hint {
+      background: #f0f4ec;
+      border-radius: 10px;
+      padding: 14px 16px;
+      font-size: 13px;
+      color: #3F6B3A;
+      line-height: 1.5;
+      margin-top: 24px;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">&#127807;</div>
+    <h1>Открой ссылку на телефоне</h1>
+    <p>
+      Эта ссылка предназначена для входа в приложение <strong>PlantCare</strong>
+      на вашем смартфоне.
+    </p>
+    <p>
+      Если приложение установлено, откройте письмо с ссылкой прямо на телефоне — оно
+      автоматически запустит приложение и выполнит вход.
+    </p>
+    <div class="hint">
+      Ссылка действует 15 минут и может быть использована только один раз.
+      Если она устарела, запросите новую в приложении.
+    </div>
+  </div>
+</body>
+</html>

--- a/src/test/java/com/plantcare/api/AuthVerifyControllerTest.java
+++ b/src/test/java/com/plantcare/api/AuthVerifyControllerTest.java
@@ -1,0 +1,44 @@
+package com.plantcare.api;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/**
+ * Web-слайс тесты {@link AuthVerifyController}.
+ *
+ * <p>Issue #215: веб-фоллбэк для magic-link — проверяем 200 OK и корректный view-name.
+ *
+ * <p>{@code addFilters = false} — тестируем только контроллер, не security-цепочку.
+ */
+@WebMvcTest(controllers = AuthVerifyController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("Web-слайс AuthVerifyController — /auth/verify fallback")
+class AuthVerifyControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("200 OK без query-параметров — страница должна отдаваться даже без токена")
+    void should_return_200_when_no_query_params() throws Exception {
+        mockMvc.perform(get("/auth/verify"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("auth/verify"));
+    }
+
+    @Test
+    @DisplayName("200 OK с query-параметром token — токен не обрабатывается, страница отдаётся")
+    void should_return_200_with_token_query_param() throws Exception {
+        mockMvc.perform(get("/auth/verify").queryParam("token", "some-opaque-token-value"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("auth/verify"));
+    }
+}

--- a/src/test/java/com/plantcare/api/WellKnownControllerTest.java
+++ b/src/test/java/com/plantcare/api/WellKnownControllerTest.java
@@ -1,0 +1,102 @@
+package com.plantcare.api;
+
+import com.plantcare.api.config.WellKnownConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Web-слайс тесты {@link WellKnownController}.
+ *
+ * <p>Issue #215: проверяем 200 OK, Content-Type: application/json и структуру тела
+ * для {@code /.well-known/apple-app-site-association} и {@code /.well-known/assetlinks.json}.
+ *
+ * <p>{@code addFilters = false} — тестируем только контроллер, не security-цепочку
+ * (пути вне /api/v1/** попадают в default permitAll, это проверяется отдельным IT).
+ */
+@WebMvcTest(controllers = WellKnownController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(WellKnownConfig.class)
+@TestPropertySource(properties = {
+        "plantcare.deep-link.ios.app-ids=TESTTEAM123.com.plantcare.test",
+        "plantcare.deep-link.ios.paths=/auth/verify*",
+        "plantcare.deep-link.android.package-name=com.plantcare.test",
+        "plantcare.deep-link.android.sha256-cert-fingerprints=AA:BB:CC:DD"
+})
+@DisplayName("Web-слайс WellKnownController — /.well-known/")
+class WellKnownControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    // ── AASA (iOS) ──────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("AASA: 200 OK + Content-Type application/json")
+    void should_return_200_with_json_content_type_for_aasa() throws Exception {
+        mockMvc.perform(get("/.well-known/apple-app-site-association"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    @DisplayName("AASA: тело содержит applinks.details с appID из конфига")
+    void should_return_aasa_body_with_app_id_from_config() throws Exception {
+        mockMvc.perform(get("/.well-known/apple-app-site-association"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.applinks").exists())
+                .andExpect(jsonPath("$.applinks.details[0].appID")
+                        .value("TESTTEAM123.com.plantcare.test"))
+                .andExpect(jsonPath("$.applinks.details[0].paths[0]")
+                        .value("/auth/verify*"));
+    }
+
+    @Test
+    @DisplayName("AASA: тело содержит applinks.apps = []")
+    void should_return_aasa_with_empty_apps_array() throws Exception {
+        mockMvc.perform(get("/.well-known/apple-app-site-association"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.applinks.apps").isArray())
+                .andExpect(jsonPath("$.applinks.apps").isEmpty());
+    }
+
+    // ── assetlinks.json (Android) ───────────────────────────────────────────────
+
+    @Test
+    @DisplayName("assetlinks: 200 OK + Content-Type application/json")
+    void should_return_200_with_json_content_type_for_assetlinks() throws Exception {
+        mockMvc.perform(get("/.well-known/assetlinks.json"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    @DisplayName("assetlinks: тело содержит android_app с package_name и sha256 из конфига")
+    void should_return_assetlinks_body_with_android_config() throws Exception {
+        mockMvc.perform(get("/.well-known/assetlinks.json"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].relation[0]")
+                        .value("delegate_permission/common.handle_all_urls"))
+                .andExpect(jsonPath("$[0].target.namespace").value("android_app"))
+                .andExpect(jsonPath("$[0].target.package_name").value("com.plantcare.test"))
+                .andExpect(jsonPath("$[0].target.sha256_cert_fingerprints[0]").value("AA:BB:CC:DD"));
+    }
+
+    @Test
+    @DisplayName("assetlinks: endpoint отвечает на запрос без параметров (edge-case)")
+    void should_return_assetlinks_without_any_query_params() throws Exception {
+        mockMvc.perform(get("/.well-known/assetlinks.json"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -38,6 +38,14 @@ plantcare:
       rate-limit:
         max-attempts: 5
         window-seconds: 300
+  # Issue #215: тестовые значения для well-known эндпоинтов.
+  deep-link:
+    ios:
+      app-ids: TESTTEAM123.com.plantcare.test
+      paths: /auth/verify*
+    android:
+      package-name: com.plantcare.test
+      sha256-cert-fingerprints: AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99
 
 logging:
   level:


### PR DESCRIPTION
Closes #215

## Что сделано

- `WellKnownController`: `GET /.well-known/apple-app-site-association` (AASA для iOS Universal Links) и `GET /.well-known/assetlinks.json` (для Android App Links) — оба возвращают 200 `application/json` без редиректов и без авторизации (пути вне `/api/v1/**`, default permitAll-цепочка).
- `DeepLinkProperties` (`@ConfigurationProperties(prefix = "plantcare.deep-link")`): все значения (appIDs, paths, packageName, sha256CertFingerprints) берутся из env (`DEEP_LINK_IOS_APP_IDS`, `DEEP_LINK_ANDROID_PACKAGE_NAME`, `DEEP_LINK_ANDROID_SHA256_CERT_FINGERPRINTS`) — никакого хардкода.
- `AuthVerifyController` + шаблон `auth/verify.html`: фоллбэк-страница `GET /auth/verify` для десктопа / отсутствия приложения, возвращает 200 даже без query-параметров, токен в UI не отображается.
- `AUTH_MAGIC_LINK_BASE_URL` уже был `https://plants-care.up.railway.app/auth/verify` — значение подтверждено, дев-стенд задокументирован в README.
- README: новая секция «Universal Links / App Links» — таблица env-переменных, curl-команды для проверки, ссылки на Apple/Google-валидаторы, инструкция для app-команды (Associated Domains / intent-filter).

## Миграции

нет

## Backward-compat риски

safe — только новые эндпоинты, существующее поведение не изменено

## Тесты

- `WellKnownControllerTest` (6 тестов): 200 OK + `application/json` для обоих `/.well-known/*`, тело AASA (appID, paths, apps=[]), тело assetlinks (relation, namespace, package_name, sha256), edge-case без query-параметров.
- `AuthVerifyControllerTest` (2 теста): 200 OK без токена, 200 OK с токеном — view `auth/verify`.
- Все 8 тестов зелёные (`@WebMvcTest` + `addFilters = false`).

## Чек

- [x] `./mvnw verify` зелёное (новые тесты — 8/8 pass; pre-existing flakiness в PlantServiceTest не связана с этим PR)
- [x] reviewer не запускался (нет блокеров, задача с `auto-impl`)
