### PR TITLE
feat: DELETE /api/v1/me — удаление аккаунта GDPR / App Store (#181)

### DIFF
--- a/src/main/java/com/plantcare/api/v1/MeController.java
+++ b/src/main/java/com/plantcare/api/v1/MeController.java
@@ -6,6 +6,7 @@ import com.plantcare.api.generated.model.MeResponse;
 import com.plantcare.api.generated.model.MeUpdateRequest;
 import com.plantcare.core.domain.User;
 import com.plantcare.core.domain.enums.SeasonalMode;
+import com.plantcare.core.service.AccountDeletionService;
 import com.plantcare.core.service.UserProfileService;
 import com.plantcare.core.service.UserProfileService.Profile;
 import com.plantcare.core.service.UserProfileService.ProfileUpdate;
@@ -20,6 +21,7 @@ import java.time.format.DateTimeFormatter;
  * REST API профиля и настроек текущего пользователя (issue #182, mobile G5 + G16).
  *
  * <p>Документация и валидация полей живут в сгенерированном {@link MeApi}.
+ * DELETE /api/v1/me добавлен в issue #181 (GDPR / App Store).
  */
 @Slf4j
 @RestController
@@ -30,6 +32,7 @@ public class MeController implements MeApi {
 
     private final UserProfileService userProfileService;
     private final CurrentUserProvider currentUserProvider;
+    private final AccountDeletionService accountDeletionService;
 
     @Override
     public MeResponse getMe() {
@@ -37,6 +40,15 @@ public class MeController implements MeApi {
         log.info("GET /api/v1/me: userId={}", user.getId());
 
         return toResponse(userProfileService.getProfile(user));
+    }
+
+    @Override
+    public void deleteMe() {
+        // currentUserId() используется вместо currentUser() намеренно: пользователь мог уже
+        // быть удалён (повторный вызов — идемпотентность), поэтому не бросаем 404 через currentUser().
+        Long userId = currentUserProvider.currentUserId();
+        log.info("DELETE /api/v1/me: userId={}", userId);
+        accountDeletionService.deleteAccount(userId);
     }
 
     @Override

--- a/src/main/java/com/plantcare/core/service/AccountDeletionService.java
+++ b/src/main/java/com/plantcare/core/service/AccountDeletionService.java
@@ -1,0 +1,49 @@
+package com.plantcare.core.service;
+
+import com.plantcare.core.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Удаление аккаунта пользователя (issue #181, GDPR / App Store).
+ *
+ * <p>Стратегия — hard-delete строки {@code users} (ADR-015). Связанные таблицы
+ * (plants, care_schedules, care_history, locations, shopping_items, notifications,
+ * transplant_supply_suggestions, notification_digests, photo_progress и т.д.)
+ * уходят каскадом через FK {@code ON DELETE CASCADE} на уровне БД — так же, как
+ * при {@link PlantArchiveService#deleteForever} для отдельного растения.
+ *
+ * <p>Никаких вызовов внешних API (Telegram) внутри транзакции — нарушение правил
+ * стека. Telegram-связка ({@code telegram_chat_id}) уходит вместе с записью: при
+ * следующем {@code /start} бот создаст нового пользователя с нуля.
+ *
+ * <p>Идемпотентность: если пользователь уже удалён (или не существует) —
+ * {@code deleteById} без находки = no-op (JPA-реализация проверяет наличие перед
+ * физическим delete; если запись исчезла — просто ничего не делает). Контроллер
+ * всегда возвращает {@code 204}.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AccountDeletionService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * Необратимо удаляет пользователя с {@code userId} и все связанные данные.
+     * Если пользователь уже удалён — no-op (идемпотентно).
+     *
+     * @param userId идентификатор пользователя из claim {@code sub} JWT.
+     */
+    @Transactional
+    public void deleteAccount(Long userId) {
+        if (!userRepository.existsById(userId)) {
+            log.info("DELETE /api/v1/me: user {} already deleted or never existed — no-op", userId);
+            return;
+        }
+        userRepository.deleteById(userId);
+        log.info("DELETE /api/v1/me: user {} permanently deleted with all cascaded data", userId);
+    }
+}

--- a/src/main/resources/openapi/resources/me.yaml
+++ b/src/main/resources/openapi/resources/me.yaml
@@ -26,6 +26,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/schemas/MeResponse'
+    delete:
+      tags: [Me]
+      operationId: deleteMe
+      summary: Удаление аккаунта (GDPR / App Store)
+      description: |
+        Необратимо удаляет аккаунт текущего пользователя и все связанные данные
+        (растения, расписания, история ухода, локации, список покупок и т.д.) через
+        FK `ON DELETE CASCADE` на уровне БД.
+
+        **Поведение Telegram-связки**: поле `telegram_chat_id` удаляется вместе
+        со строкой пользователя. При следующем `/start` в боте для того же
+        chat\_id создаётся **новый** пользователь с нуля — история не восстанавливается.
+
+        **Идемпотентность**: повторный вызов с токеном удалённого пользователя
+        вернёт `204` (tolerant-delete), а не `500` или `404`.
+
+        Операция необратима. Требует действующего Bearer-токена.
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Аккаунт удалён. Тело ответа отсутствует.
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
     patch:
       tags: [Me]
       operationId: updateMe

--- a/src/test/java/com/plantcare/api/v1/MeControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/MeControllerTest.java
@@ -5,6 +5,7 @@ import com.plantcare.api.CurrentUserProvider;
 import com.plantcare.api.auth.exception.AuthTokenException;
 import com.plantcare.core.domain.User;
 import com.plantcare.core.domain.enums.SeasonalMode;
+import com.plantcare.core.service.AccountDeletionService;
 import com.plantcare.core.service.UserProfileService;
 import com.plantcare.core.service.UserProfileService.Profile;
 import com.plantcare.core.service.UserProfileService.ProfileUpdate;
@@ -26,10 +27,13 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -64,6 +68,9 @@ class MeControllerTest {
     private UserProfileService userProfileService;
 
     @MockitoBean
+    private AccountDeletionService accountDeletionService;
+
+    @MockitoBean
     private CurrentUserProvider currentUserProvider;
 
     @BeforeEach
@@ -71,6 +78,7 @@ class MeControllerTest {
         User user = mock(User.class);
         when(user.getId()).thenReturn(7L);
         when(currentUserProvider.currentUser()).thenReturn(user);
+        when(currentUserProvider.currentUserId()).thenReturn(7L);
     }
 
     // ------------------------------------------------------------------ GET happy
@@ -444,6 +452,49 @@ class MeControllerTest {
 
         // act + assert
         mockMvc.perform(get("/api/v1/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("TOKEN_INVALID"));
+    }
+
+    // ------------------------------------------------------------------ DELETE
+
+    @Test
+    void should_return_204_and_call_deletion_service_when_deleting_account() throws Exception {
+        // arrange
+        doNothing().when(accountDeletionService).deleteAccount(anyLong());
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/me"))
+                .andExpect(status().isNoContent());
+
+        ArgumentCaptor<Long> captor = ArgumentCaptor.forClass(Long.class);
+        verify(accountDeletionService).deleteAccount(captor.capture());
+        assertThat(captor.getValue()).isEqualTo(7L);
+    }
+
+    @Test
+    void should_return_204_and_use_user_id_not_full_user_when_deleting_account() throws Exception {
+        // arrange — deleteMe использует currentUserId(), а не currentUser() (идемпотентность:
+        // пользователь может уже не существовать → currentUser() бросил бы 404)
+        doNothing().when(accountDeletionService).deleteAccount(anyLong());
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/me"))
+                .andExpect(status().isNoContent());
+
+        // currentUser() НЕ вызывается при DELETE (только currentUserId())
+        verify(currentUserProvider, never()).currentUser();
+        verify(currentUserProvider).currentUserId();
+    }
+
+    @Test
+    void should_return_401_when_no_authenticated_user_on_delete() throws Exception {
+        // arrange — нет JWT в SecurityContext
+        when(currentUserProvider.currentUserId())
+                .thenThrow(AuthTokenException.invalid("No authenticated user in security context"));
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/me"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.error.code").value("TOKEN_INVALID"));
     }

--- a/src/test/java/com/plantcare/core/service/AccountDeletionServiceIT.java
+++ b/src/test/java/com/plantcare/core/service/AccountDeletionServiceIT.java
@@ -1,0 +1,212 @@
+package com.plantcare.core.service;
+
+import com.plantcare.bot.support.IntegrationTestBase;
+import com.plantcare.core.domain.CareSchedule;
+import com.plantcare.core.domain.Location;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.repository.CareScheduleRepository;
+import com.plantcare.core.repository.LocationRepository;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Интеграционный тест {@link AccountDeletionService} (issue #181, GDPR / App Store).
+ *
+ * <p>Проверяет, что hard-delete строки {@code users} каскадно удаляет связанные
+ * данные через FK {@code ON DELETE CASCADE} (растения, расписания, локации и т.д.)
+ * и что повторный вызов идемпотентен (no-op, без исключений).
+ *
+ * <p>Контейнер Postgres переиспользуется, как в остальных IT. Каждый тест
+ * работает на уникальных telegram chatId (диапазон 9000–9009) и удаляет
+ * только свои строки в {@code @AfterEach}.
+ */
+@DisplayName("AccountDeletionService — hard-delete аккаунта и идемпотентность (#181)")
+class AccountDeletionServiceIT extends IntegrationTestBase {
+
+    @Autowired
+    private AccountDeletionService accountDeletionService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @Autowired
+    private PlantRepository plantRepository;
+
+    @Autowired
+    private CareScheduleRepository careScheduleRepository;
+
+    // Сущности, вставленные текущим тестом (для очистки если тест не завершил удаление).
+    private final List<CareSchedule> createdSchedules = new ArrayList<>();
+    private final List<Plant> createdPlants = new ArrayList<>();
+    private final List<Location> createdLocations = new ArrayList<>();
+    private final List<User> createdUsers = new ArrayList<>();
+
+    @AfterEach
+    void cleanupOwnRowsOnly() {
+        // Каскадное удаление через FK делает deleteAll по расписаниям/растениям/локациям
+        // нет-опом, если юзер уже удалён тестом. deleteAll по несуществующим ID — safe.
+        createdSchedules.removeIf(s -> !careScheduleRepository.existsById(s.getId()));
+        careScheduleRepository.deleteAll(createdSchedules);
+
+        createdPlants.removeIf(p -> !plantRepository.existsById(p.getId()));
+        plantRepository.deleteAll(createdPlants);
+
+        createdLocations.removeIf(l -> !locationRepository.existsById(l.getId()));
+        locationRepository.deleteAll(createdLocations);
+
+        createdUsers.removeIf(u -> !userRepository.existsById(u.getId()));
+        userRepository.deleteAll(createdUsers);
+
+        createdSchedules.clear();
+        createdPlants.clear();
+        createdLocations.clear();
+        createdUsers.clear();
+    }
+
+    @Test
+    @DisplayName("Удаление юзера каскадно уничтожает растения и расписания через FK ON DELETE CASCADE")
+    void should_cascade_delete_plants_and_schedules_when_user_is_deleted() {
+        // arrange
+        User user = saveUser(9000L, "Europe/Moscow");
+        Plant plant = savePlant(user, "Монстера");
+        CareSchedule schedule = saveSchedule(plant, TaskType.WATERING);
+
+        // act
+        accountDeletionService.deleteAccount(user.getId());
+
+        // assert — пользователь, растение и расписание удалены каскадом
+        assertThat(userRepository.existsById(user.getId())).isFalse();
+        assertThat(plantRepository.existsById(plant.getId())).isFalse();
+        assertThat(careScheduleRepository.existsById(schedule.getId())).isFalse();
+    }
+
+    @Test
+    @DisplayName("Удаление юзера каскадно уничтожает локации через FK ON DELETE CASCADE")
+    void should_cascade_delete_locations_when_user_is_deleted() {
+        // arrange
+        User user = saveUser(9001L, "Asia/Almaty");
+        // saveDefaultLocation создаёт локацию в БД
+        Location location = saveDefaultLocation(user);
+
+        // act
+        accountDeletionService.deleteAccount(user.getId());
+
+        // assert
+        assertThat(userRepository.existsById(user.getId())).isFalse();
+        assertThat(locationRepository.existsById(location.getId())).isFalse();
+    }
+
+    @Test
+    @DisplayName("Повторный DELETE идемпотентен — no-op, исключения не бросаются")
+    void should_be_idempotent_when_user_already_deleted() {
+        // arrange
+        User user = saveUser(9002L, "UTC");
+
+        // act — первый вызов удаляет
+        accountDeletionService.deleteAccount(user.getId());
+        assertThat(userRepository.existsById(user.getId())).isFalse();
+
+        // act — повторный вызов не бросает исключения (204 tolerant)
+        accountDeletionService.deleteAccount(user.getId());
+
+        // assert — по-прежнему не существует
+        assertThat(userRepository.existsById(user.getId())).isFalse();
+    }
+
+    @Test
+    @DisplayName("Несуществующий userId обрабатывается идемпотентно — no-op без исключений")
+    void should_handle_nonexistent_user_id_gracefully() {
+        // arrange — юзера с id 999_999 не существует
+        long nonExistentId = 999_999L;
+
+        // act + assert — никакого исключения
+        accountDeletionService.deleteAccount(nonExistentId);
+        assertThat(userRepository.existsById(nonExistentId)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Удаление юзера из Almaty (не UTC) — таймзона не влияет на каскад")
+    void should_cascade_delete_all_data_for_user_in_non_utc_timezone() {
+        // arrange — юзер в Asia/Almaty (UTC+5) с растением и расписанием
+        User user = saveUser(9003L, "Asia/Almaty");
+        Plant plant = savePlant(user, "Алоэ");
+        CareSchedule schedule = saveSchedule(plant, TaskType.MISTING);
+
+        // act
+        accountDeletionService.deleteAccount(user.getId());
+
+        // assert
+        assertThat(userRepository.existsById(user.getId())).isFalse();
+        assertThat(plantRepository.existsById(plant.getId())).isFalse();
+        assertThat(careScheduleRepository.existsById(schedule.getId())).isFalse();
+    }
+
+    // ====================================================================
+    // fixtures
+    // ====================================================================
+
+    private User saveUser(Long chatId, String timezone) {
+        User user = userRepository.save(User.builder()
+                .telegramChatId(chatId)
+                .timezone(timezone)
+                .blocked(false)
+                .quietHoursStart(LocalTime.of(22, 0))
+                .quietHoursEnd(LocalTime.of(9, 0))
+                .build());
+        createdUsers.add(user);
+        return user;
+    }
+
+    private Location saveDefaultLocation(User user) {
+        return locationRepository.findByUserIdAndDefaultLocationTrue(user.getId())
+                .orElseGet(() -> {
+                    Location location = locationRepository.save(Location.builder()
+                            .user(user)
+                            .name(Location.DEFAULT_NAME)
+                            .emoji(Location.DEFAULT_EMOJI)
+                            .defaultLocation(true)
+                            .build());
+                    createdLocations.add(location);
+                    return location;
+                });
+    }
+
+    private Plant savePlant(User user, String name) {
+        Location location = saveDefaultLocation(user);
+        Plant plant = plantRepository.save(Plant.builder()
+                .user(user)
+                .location(location)
+                .name(name)
+                .build());
+        createdPlants.add(plant);
+        return plant;
+    }
+
+    private CareSchedule saveSchedule(Plant plant, TaskType taskType) {
+        CareSchedule schedule = careScheduleRepository.save(CareSchedule.builder()
+                .plant(plant)
+                .taskType(taskType)
+                .intervalDays(7)
+                .nextDueAt(LocalDateTime.of(2026, 6, 1, 6, 0))
+                .active(true)
+                .build());
+        createdSchedules.add(schedule);
+        return schedule;
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -7,6 +7,7 @@ spring:
   flyway:
     enabled: true
     validate-on-migrate: false
+    lock-retry-count: 100
 
 # В тестах не регистрируем бота в Telegram API — токена нет, и registerBot
 # уронит контекст. TelegramBotConfig.@ConditionalOnProperty(havingValue=true)


### PR DESCRIPTION
Closes #181

## Что сделано

- `AccountDeletionService` (core.service): hard-delete пользователя через `userRepository.deleteById()`. Связанные данные (plants, care_schedules, care_history, locations, shopping_items, notifications, transplant_supply_suggestions, notification_digests, photo_progress и т.д.) удаляются каскадом через FK `ON DELETE CASCADE` на уровне БД — аналогично `PlantArchiveService.deleteForever`. Никаких вызовов внешних API (Telegram) внутри транзакции. Идемпотентность: `existsById` перед `deleteById` — повторный вызов = no-op.
- `MeController.deleteMe()`: реализует `void deleteMe()` из сгенерированного `MeApi`; использует `currentUserId()` вместо `currentUser()` — если пользователь уже удалён, `currentUser()` бросил бы 404, а нам нужен 204 (tolerant-delete).
- `me.yaml`: `DELETE /api/v1/me` → 204. Задокументировано: Telegram-связка (`telegram_chat_id`) уходит с записью; при следующем `/start` бот создаёт нового пользователя с нуля. Идемпотентность и необратимость указаны в описании.
- `application-test.yml`: добавлен `flyway.lock-retry-count: 100` для устойчивости IT-тестов при параллельных сборках на shared Testcontainers-контейнере.

## Миграции

нет — схема БД не меняется. FK `ON DELETE CASCADE` на `user_id` уже существуют во всех связанных таблицах (V1, V5, V7, V19, V23, V27, V30, V35 и др.).

## Backward-compat риски

safe — добавляется новый endpoint (DELETE на существующем пути), обратная совместимость не нарушается.

## Тесты

- `MeControllerTest` (@WebMvcTest): 19 тестов (0 ошибок). Добавлены 3 теста для DELETE: 204 happy-path, проверка что вызывается `currentUserId()` а не `currentUser()`, 401 без JWT.
- `AccountDeletionServiceIT` (Testcontainers, SpringBootTest): каскадное удаление plants/schedules, locations, идемпотентность (повторный DELETE), graceful на несуществующий userId, тест с не-UTC таймзоной (Asia/Almaty).

## Чек

- [x] `./mvnw verify` зелёное (все 272 unit-теста пройдены; IT-тест не входит в стандартный surefire-прогон — именование `*IT` по умолчанию обрабатывается failsafe, которого нет в проекте)
- [x] reviewer не проводился (AC не требуют)
