### PR TITLE
feat: vacation mode REST API — POST/DELETE/GET /api/v1/vacation (#189)

### DIFF
--- a/src/main/java/com/plantcare/api/v1/VacationController.java
+++ b/src/main/java/com/plantcare/api/v1/VacationController.java
@@ -1,0 +1,73 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.api.generated.VacationApi;
+import com.plantcare.api.generated.model.VacationRequest;
+import com.plantcare.api.generated.model.VacationResponse;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+/**
+ * REST API режима отпуска (issue #189, mobile G21, экран 25).
+ *
+ * <p>Документация и mapping живут в сгенерированном {@link VacationApi}
+ * (см. openapi/resources/vacation.yaml). Контроллер тонкий: делегирование
+ * {@link UserService} и формирование ответа.
+ *
+ * <p>Поведение дедлайнов: расписания НЕ переносятся. Просроченные задачи
+ * накапливаются и отображаются в welcome-back сводке через
+ * {@code VacationSchedulerService} после окончания отпуска.
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class VacationController implements VacationApi {
+
+    private final UserService userService;
+    private final CurrentUserProvider currentUserProvider;
+    private final Clock clock;
+
+    @Override
+    public VacationResponse getVacation() {
+        User user = currentUserProvider.currentUser();
+        log.debug("GET /api/v1/vacation: userId={}", user.getId());
+        return toResponse(user);
+    }
+
+    @Override
+    public VacationResponse startVacation(VacationRequest vacationRequest) {
+        User user = currentUserProvider.currentUser();
+        log.info("POST /api/v1/vacation: userId={}, from={}, to={}",
+                user.getId(), vacationRequest.getFrom(), vacationRequest.getTo());
+
+        User updated = userService.startVacationByDateRange(
+                user, vacationRequest.getFrom(), vacationRequest.getTo());
+        return toResponse(updated);
+    }
+
+    @Override
+    public void endVacation() {
+        User user = currentUserProvider.currentUser();
+        log.info("DELETE /api/v1/vacation: userId={}", user.getId());
+        userService.endVacation(user);
+    }
+
+    private VacationResponse toResponse(User user) {
+        LocalDateTime pausedUntil = user.getPausedUntil();
+        LocalDateTime now = LocalDateTime.now(clock);
+        boolean active = pausedUntil != null && pausedUntil.isAfter(now);
+
+        VacationResponse response = new VacationResponse(active);
+        if (active) {
+            response.pausedUntil(pausedUntil.atOffset(ZoneOffset.UTC));
+        }
+        return response;
+    }
+}

--- a/src/main/java/com/plantcare/core/service/UserService.java
+++ b/src/main/java/com/plantcare/core/service/UserService.java
@@ -10,7 +10,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -171,6 +173,47 @@ public class UserService {
     public User endVacation(User user) {
         user.setPausedUntil(null);
         log.info("Vacation ended for user {}", user.getTelegramChatId());
+        return userRepository.save(user);
+    }
+
+    /**
+     * Включить отпуск по диапазону дат (issue #189, REST API).
+     *
+     * <p>{@code from} — начало отпуска (дата), {@code to} — конец (включительно).
+     * {@code paused_until} устанавливается на конец дня {@code to} в таймзоне юзера
+     * (23:59:59), переведённое в UTC. Это гарантирует паузу до полуночи дня
+     * возвращения в локальном времени пользователя.
+     *
+     * <p>Дедлайны расписаний не переносятся — просроченные задачи показываются
+     * в сводке «С возвращением!» после окончания отпуска (VacationSchedulerService).
+     *
+     * @param from начало отпуска (обычно сегодня или в будущем)
+     * @param to   конец отпуска (включительно), должен быть ≥ from
+     * @throws IllegalArgumentException если to < from или длительность > {@value #MAX_VACATION_DAYS} дней
+     */
+    @Transactional
+    public User startVacationByDateRange(User user, LocalDate from, LocalDate to) {
+        if (to.isBefore(from)) {
+            throw new IllegalArgumentException(
+                    "'to' date must not be before 'from' date: from=" + from + ", to=" + to);
+        }
+        long days = from.until(to, java.time.temporal.ChronoUnit.DAYS) + 1; // включительно
+        if (days > MAX_VACATION_DAYS) {
+            throw new IllegalArgumentException(
+                    "Vacation duration must not exceed " + MAX_VACATION_DAYS + " days, got: " + days);
+        }
+
+        ZoneId userZone = resolveZone(user.getTimezone());
+        // Конец дня 'to' в таймзоне юзера → UTC
+        LocalDateTime pausedUntilUtc = ZonedDateTime.of(to, LocalTime.of(23, 59, 59), userZone)
+                .withZoneSameInstant(ZoneOffset.UTC)
+                .toLocalDateTime();
+
+        user.setPausedUntil(pausedUntilUtc);
+        log.info(
+                "Vacation started (date-range) for user {}: from={} to={}, paused_until={} UTC (tz={})",
+                user.getId(), from, to, pausedUntilUtc, userZone
+        );
         return userRepository.save(user);
     }
 

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -104,6 +104,12 @@ tags:
     description: |
       Персистентный inbox уведомлений пользователя для мобильного приложения
       (gap G17): лента со счётчиком непрочитанных и идемпотентная отметка прочтения.
+  - name: Vacation
+    description: |
+      Режим отпуска (issue #189, mobile G21, экран 25): пользователь задаёт
+      диапазон дат отъезда; на этот период напоминания приостанавливаются.
+      Дедлайны не переносятся — просроченные задачи показываются в сводке
+      «С возвращением!» после окончания отпуска.
   - name: Sharing
     description: |
       Совместный уход (gap G22, экран 26): владелец приглашает соухаживающего
@@ -203,6 +209,9 @@ paths:
     $ref: './resources/notifications.yaml#/paths/Collection'
   /api/v1/notifications/{id}/read:
     $ref: './resources/notifications.yaml#/paths/Item'
+
+  /api/v1/vacation:
+    $ref: './resources/vacation.yaml#/paths/Vacation'
 
   /api/v1/me:
     $ref: './resources/me.yaml#/paths/Me'
@@ -378,6 +387,11 @@ components:
       $ref: './resources/notifications.yaml#/schemas/NotificationDto'
     NotificationsResponse:
       $ref: './resources/notifications.yaml#/schemas/NotificationsResponse'
+
+    VacationRequest:
+      $ref: './resources/vacation.yaml#/schemas/VacationRequest'
+    VacationResponse:
+      $ref: './resources/vacation.yaml#/schemas/VacationResponse'
 
     SharingStatus:
       $ref: './resources/sharing.yaml#/schemas/SharingStatus'

--- a/src/main/resources/openapi/resources/vacation.yaml
+++ b/src/main/resources/openapi/resources/vacation.yaml
@@ -1,0 +1,127 @@
+# Vacation mode API (issue #189, mobile G21, screen 25).
+# Allows authenticated users to enable/disable vacation mode (pause reminders).
+# Dates are accepted as YYYY-MM-DD strings. The backend converts them to
+# the end of the 'to' day in the user's timezone, stored as paused_until (UTC).
+# Behaviour during vacation: push reminders are silenced; deadlines are NOT
+# moved — overdue tasks accumulate and are shown in the welcome-back message.
+
+paths:
+  Vacation:
+    get:
+      tags: [Vacation]
+      operationId: getVacation
+      summary: Текущее состояние режима отпуска
+      description: |
+        Возвращает активный период отпуска или объект с `active = false`,
+        если отпуск не включён. «Активен» — `paused_until IS NOT NULL
+        AND paused_until > now()`.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Статус режима отпуска.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/VacationResponse'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+
+    post:
+      tags: [Vacation]
+      operationId: startVacation
+      summary: Включить режим отпуска
+      description: |
+        Включает режим отпуска: напоминания приостанавливаются с текущего
+        момента до конца дня `to` в таймзоне пользователя.
+
+        **Поведение дедлайнов:** дедлайны расписаний **не переносятся**.
+        Пока отпуск активен, задачи накапливаются как просроченные и
+        отображаются в сводке «С возвращением!» сразу после окончания отпуска.
+        Это предсказуемо и понятно пользователю.
+
+        **Идемпотентность:** повторный POST перезаписывает `paused_until`
+        (продление текущего отпуска). Если `to` < `from` или длительность
+        > 60 дней → `400`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/VacationRequest'
+            example:
+              from: '2026-06-01'
+              to: '2026-06-14'
+      responses:
+        '200':
+          description: Режим отпуска включён.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/VacationResponse'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+
+    delete:
+      tags: [Vacation]
+      operationId: endVacation
+      summary: Выключить режим отпуска досрочно
+      description: |
+        Досрочно завершает режим отпуска — `paused_until` сбрасывается в `null`,
+        напоминания возобновляются немедленно. Идемпотентен: если отпуск уже
+        неактивен, возвращает `204` без ошибки.
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Режим отпуска выключен (или уже был выключен).
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+
+schemas:
+  VacationRequest:
+    type: object
+    description: Запрос на включение режима отпуска.
+    required:
+      - from
+      - to
+    properties:
+      from:
+        type: string
+        format: date
+        description: |
+          Начало отпуска (включительно). Формат `YYYY-MM-DD`. Как правило,
+          сегодняшняя дата или ближайшая в будущем.
+        example: '2026-06-01'
+      to:
+        type: string
+        format: date
+        description: |
+          Конец отпуска (включительно). Формат `YYYY-MM-DD`. Должно быть
+          ≥ `from` и не более 60 дней от `from`.
+        example: '2026-06-14'
+
+  VacationResponse:
+    type: object
+    description: |
+      Статус режима отпуска. Если отпуск не активен — `active = false`
+      и `pausedUntil = null`.
+    required:
+      - active
+    properties:
+      active:
+        type: boolean
+        description: '`true` — режим отпуска сейчас включён.'
+        example: true
+      pausedUntil:
+        type: string
+        format: date-time
+        nullable: true
+        description: |
+          Момент до которого паузированы напоминания (UTC). `null` если отпуск
+          неактивен.
+        example: '2026-06-14T20:59:59Z'

--- a/src/test/java/com/plantcare/api/v1/VacationControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/VacationControllerTest.java
@@ -1,0 +1,288 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.api.auth.exception.AuthTokenException;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Слайс-тест {@link VacationController} (issue #189).
+ *
+ * <p>Проверяет веб-слой: маршрутизацию, формат запроса/ответа, Bean Validation,
+ * маппинг ошибок и делегирование {@link UserService}. Сервис и провайдер замоканы.
+ */
+@WebMvcTest(VacationController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class VacationControllerTest {
+
+    /** Фиксированный момент: 2026-06-04T12:00:00Z. */
+    private static final Instant FIXED_NOW = Instant.parse("2026-06-04T12:00:00Z");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    /** Фиксированные часы для детерминированного active-check. */
+    @MockitoBean
+    private Clock clock;
+
+    private User mockUser;
+
+    @BeforeEach
+    void stubCurrentUser() {
+        mockUser = mock(User.class);
+        when(mockUser.getId()).thenReturn(42L);
+        when(currentUserProvider.currentUser()).thenReturn(mockUser);
+        // Фиксируем часы для детерминированного active-check в VacationController
+        when(clock.instant()).thenReturn(FIXED_NOW);
+        when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+    }
+
+    // ------------------------------------------------------------------ GET happy
+
+    @Test
+    void should_return_active_vacation_status_when_paused_until_is_in_the_future() throws Exception {
+        // arrange — paused_until в будущем (2026-06-14 23:59:59 UTC)
+        LocalDateTime future = LocalDateTime.of(2026, 6, 14, 23, 59, 59);
+        when(mockUser.getPausedUntil()).thenReturn(future);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/vacation"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.active").value(true))
+                .andExpect(jsonPath("$.pausedUntil").exists());
+    }
+
+    @Test
+    void should_return_inactive_vacation_status_when_paused_until_is_null() throws Exception {
+        // arrange — отпуск не активен
+        when(mockUser.getPausedUntil()).thenReturn(null);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/vacation"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.active").value(false))
+                .andExpect(jsonPath("$.pausedUntil").doesNotExist());
+    }
+
+    @Test
+    void should_return_inactive_when_paused_until_is_in_the_past() throws Exception {
+        // arrange — paused_until в прошлом (отпуск завершён)
+        LocalDateTime past = LocalDateTime.of(2026, 6, 3, 10, 0, 0);
+        when(mockUser.getPausedUntil()).thenReturn(past);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/vacation"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.active").value(false));
+    }
+
+    // ------------------------------------------------------------------ POST happy
+
+    @Test
+    void should_start_vacation_and_return_active_response_when_valid_date_range() throws Exception {
+        // arrange — сервис возвращает юзера с paused_until в будущем
+        LocalDateTime pausedUntil = LocalDateTime.of(2026, 6, 14, 23, 59, 59);
+        User updatedUser = mock(User.class);
+        when(updatedUser.getPausedUntil()).thenReturn(pausedUntil);
+        when(userService.startVacationByDateRange(any(User.class), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(updatedUser);
+
+        String body = """
+                {"from": "2026-06-01", "to": "2026-06-14"}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/vacation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.active").value(true))
+                .andExpect(jsonPath("$.pausedUntil").exists());
+
+        // Проверяем, что в сервис ушли правильные даты
+        verify(userService).startVacationByDateRange(
+                any(User.class),
+                eq(LocalDate.of(2026, 6, 1)),
+                eq(LocalDate.of(2026, 6, 14))
+        );
+    }
+
+    @Test
+    void should_return_400_when_to_is_before_from() throws Exception {
+        // arrange — сервис кидает IllegalArgumentException на «to < from»
+        when(userService.startVacationByDateRange(any(User.class), any(LocalDate.class), any(LocalDate.class)))
+                .thenThrow(new IllegalArgumentException("'to' date must not be before 'from' date"));
+
+        String body = """
+                {"from": "2026-06-14", "to": "2026-06-01"}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/vacation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("BAD_REQUEST"));
+    }
+
+    @Test
+    void should_return_400_when_duration_exceeds_60_days() throws Exception {
+        // arrange — сервис кидает IllegalArgumentException на превышение лимита
+        when(userService.startVacationByDateRange(any(User.class), any(LocalDate.class), any(LocalDate.class)))
+                .thenThrow(new IllegalArgumentException("Vacation duration must not exceed 60 days"));
+
+        String body = """
+                {"from": "2026-06-01", "to": "2026-09-01"}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/vacation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("BAD_REQUEST"));
+    }
+
+    @Test
+    void should_return_400_validation_error_when_from_is_missing() throws Exception {
+        // arrange — 'from' обязателен по спеке (@NotNull на DTO)
+        String body = """
+                {"to": "2026-06-14"}
+                """;
+
+        // act + assert — Bean Validation отбивает до сервиса
+        mockMvc.perform(post("/api/v1/vacation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+
+        verify(userService, never()).startVacationByDateRange(any(), any(), any());
+    }
+
+    @Test
+    void should_return_400_validation_error_when_to_is_missing() throws Exception {
+        // arrange — 'to' обязателен по спеке (@NotNull на DTO)
+        String body = """
+                {"from": "2026-06-01"}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/vacation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+
+        verify(userService, never()).startVacationByDateRange(any(), any(), any());
+    }
+
+    @Test
+    void should_return_400_when_date_format_is_invalid() throws Exception {
+        // arrange — некорректный формат даты
+        String body = """
+                {"from": "01-06-2026", "to": "14-06-2026"}
+                """;
+
+        // act + assert — Jackson не может распарсить дату → 400
+        mockMvc.perform(post("/api/v1/vacation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+
+        verify(userService, never()).startVacationByDateRange(any(), any(), any());
+    }
+
+    // ------------------------------------------------------------------ DELETE happy
+
+    @Test
+    void should_return_204_when_vacation_is_ended() throws Exception {
+        // arrange — endVacation возвращает юзера (не используем ответ)
+        when(userService.endVacation(any(User.class))).thenReturn(mockUser);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/vacation"))
+                .andExpect(status().isNoContent());
+
+        verify(userService).endVacation(mockUser);
+    }
+
+    @Test
+    void should_return_204_when_vacation_is_already_inactive_idempotent() throws Exception {
+        // arrange — отпуск неактивен, endVacation идемпотентна (ставит null → null)
+        when(mockUser.getPausedUntil()).thenReturn(null);
+        when(userService.endVacation(any(User.class))).thenReturn(mockUser);
+
+        // act + assert — 204 в любом случае
+        mockMvc.perform(delete("/api/v1/vacation"))
+                .andExpect(status().isNoContent());
+
+        verify(userService).endVacation(mockUser);
+    }
+
+    // ------------------------------------------------------------------ Auth
+
+    @Test
+    void should_return_401_when_no_authenticated_user_on_get() throws Exception {
+        // arrange — нет JWT
+        when(currentUserProvider.currentUser())
+                .thenThrow(AuthTokenException.invalid("No authenticated user in security context"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/vacation"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("TOKEN_INVALID"));
+    }
+
+    @Test
+    void should_return_401_when_no_authenticated_user_on_post() throws Exception {
+        // arrange — нет JWT
+        when(currentUserProvider.currentUser())
+                .thenThrow(AuthTokenException.invalid("No authenticated user in security context"));
+
+        String body = """
+                {"from": "2026-06-01", "to": "2026-06-14"}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/vacation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("TOKEN_INVALID"));
+    }
+
+}

--- a/src/test/java/com/plantcare/core/service/UserServiceVacationDateRangeTest.java
+++ b/src/test/java/com/plantcare/core/service/UserServiceVacationDateRangeTest.java
@@ -1,0 +1,198 @@
+package com.plantcare.core.service;
+
+import com.plantcare.core.domain.User;
+import com.plantcare.core.repository.UserRepository;
+import com.plantcare.bot.support.IntegrationTestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Интеграционные тесты {@link UserService#startVacationByDateRange} (issue #189).
+ *
+ * <p>Проверяем что:
+ * <ul>
+ *   <li>paused_until = конец дня 'to' в TZ юзера, переведённый в UTC;</li>
+ *   <li>на не-UTC TZ результат правильный (Asia/Almaty, Europe/Moscow);</li>
+ *   <li>to = from — граничное значение, 1 день, допустим;</li>
+ *   <li>to &lt; from или длительность > 60 дней — IllegalArgumentException.</li>
+ * </ul>
+ */
+@Import(UserServiceVacationDateRangeTest.FixedClockConfig.class)
+@DisplayName("UserService.startVacationByDateRange (issue #189)")
+class UserServiceVacationDateRangeTest extends IntegrationTestBase {
+
+    /** Фиксированный момент: 2026-06-04T10:00:00Z. */
+    static final Instant FIXED_NOW = Instant.parse("2026-06-04T10:00:00Z");
+
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private UserRepository userRepository;
+
+    @AfterEach
+    void cleanup() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("paused_until = конец дня 'to' в UTC (UTC юзер)")
+    void should_set_paused_until_to_end_of_to_day_in_utc_when_user_is_utc() {
+        // arrange
+        User user = newUser(800L, "UTC");
+        LocalDate from = LocalDate.of(2026, 6, 10);
+        LocalDate to = LocalDate.of(2026, 6, 14);
+
+        // act
+        User updated = userService.startVacationByDateRange(user, from, to);
+
+        // assert — конец дня 14 июня UTC = 2026-06-14T23:59:59Z
+        LocalDateTime expected = LocalDateTime.of(2026, 6, 14, 23, 59, 59);
+        assertThat(updated.getPausedUntil()).isEqualTo(expected);
+
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(reloaded.getPausedUntil()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("paused_until учитывает смещение Asia/Almaty (UTC+5)")
+    void should_offset_paused_until_correctly_when_user_is_asia_almaty() {
+        // arrange — UTC+5
+        User user = newUser(801L, "Asia/Almaty");
+        LocalDate from = LocalDate.of(2026, 6, 10);
+        LocalDate to = LocalDate.of(2026, 6, 14);
+
+        // act
+        User updated = userService.startVacationByDateRange(user, from, to);
+
+        // assert — конец дня 14 июня в Asia/Almaty = 2026-06-14T23:59:59+05:00
+        //           → UTC = 2026-06-14T18:59:59Z
+        LocalDateTime expected = ZonedDateTime.of(to, LocalTime.of(23, 59, 59), ZoneId.of("Asia/Almaty"))
+                .withZoneSameInstant(ZoneOffset.UTC)
+                .toLocalDateTime();
+
+        assertThat(updated.getPausedUntil()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("paused_until учитывает смещение Europe/Moscow (UTC+3)")
+    void should_offset_paused_until_correctly_when_user_is_europe_moscow() {
+        // arrange — UTC+3
+        User user = newUser(802L, "Europe/Moscow");
+        LocalDate from = LocalDate.of(2026, 6, 1);
+        LocalDate to = LocalDate.of(2026, 6, 14);
+
+        // act
+        User updated = userService.startVacationByDateRange(user, from, to);
+
+        // assert
+        LocalDateTime expected = ZonedDateTime.of(to, LocalTime.of(23, 59, 59), ZoneId.of("Europe/Moscow"))
+                .withZoneSameInstant(ZoneOffset.UTC)
+                .toLocalDateTime();
+
+        assertThat(updated.getPausedUntil()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Граница: from == to допустимо (1 день отпуска)")
+    void should_accept_single_day_vacation_when_from_equals_to() {
+        // arrange
+        User user = newUser(803L, "UTC");
+        LocalDate date = LocalDate.of(2026, 6, 10);
+
+        // act
+        User updated = userService.startVacationByDateRange(user, date, date);
+
+        // assert — paused_until = конец этого же дня
+        assertThat(updated.getPausedUntil()).isEqualTo(LocalDateTime.of(2026, 6, 10, 23, 59, 59));
+    }
+
+    @Test
+    @DisplayName("Граница: ровно 60 дней допустимо")
+    void should_accept_exactly_60_day_vacation() {
+        // arrange
+        User user = newUser(804L, "UTC");
+        LocalDate from = LocalDate.of(2026, 6, 1);
+        LocalDate to = from.plusDays(59); // 60 дней включительно: from + 59 дней (оба включительно)
+
+        // act — не должно бросить
+        User updated = userService.startVacationByDateRange(user, from, to);
+
+        assertThat(updated.getPausedUntil()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("to < from → IllegalArgumentException")
+    void should_throw_when_to_is_before_from() {
+        User user = newUser(805L, "UTC");
+
+        assertThatThrownBy(() -> userService.startVacationByDateRange(
+                user,
+                LocalDate.of(2026, 6, 14),
+                LocalDate.of(2026, 6, 1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("'to' date must not be before 'from' date");
+    }
+
+    @Test
+    @DisplayName("Длительность > 60 дней → IllegalArgumentException")
+    void should_throw_when_duration_exceeds_60_days() {
+        User user = newUser(806L, "UTC");
+
+        assertThatThrownBy(() -> userService.startVacationByDateRange(
+                user,
+                LocalDate.of(2026, 6, 1),
+                LocalDate.of(2026, 9, 1))) // 92 дня
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("60");
+    }
+
+    @Test
+    @DisplayName("Повторный POST перезаписывает paused_until (идемпотентность)")
+    void should_overwrite_paused_until_on_repeated_call() {
+        // arrange — первый вызов
+        User user = newUser(807L, "UTC");
+        userService.startVacationByDateRange(user, LocalDate.of(2026, 6, 10), LocalDate.of(2026, 6, 14));
+
+        // act — второй вызов с другим диапазоном
+        User updated = userService.startVacationByDateRange(user, LocalDate.of(2026, 6, 10), LocalDate.of(2026, 6, 20));
+
+        // assert — paused_until = конец 20 июня
+        assertThat(updated.getPausedUntil()).isEqualTo(LocalDateTime.of(2026, 6, 20, 23, 59, 59));
+    }
+
+    private User newUser(Long chatId, String timezone) {
+        User u = User.builder()
+                .telegramChatId(chatId)
+                .timezone(timezone)
+                .blocked(false)
+                .build();
+        return userRepository.save(u);
+    }
+
+    @TestConfiguration
+    static class FixedClockConfig {
+        @Bean
+        @Primary
+        public Clock fixedClock() {
+            return Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+        }
+    }
+}


### PR DESCRIPTION
Closes #189

## Что сделано
- `POST /api/v1/vacation {from, to}` — включает режим отпуска; `paused_until` устанавливается на конец дня `to` в таймзоне пользователя (UTC). Идемпотентен: повторный POST перезаписывает `paused_until`. Валидация: `to >= from`, длительность ≤ 60 дней → `400`.
- `DELETE /api/v1/vacation` — досрочно завершает отпуск (`paused_until = null`), идемпотентен: `204` даже если отпуск уже неактивен.
- `GET /api/v1/vacation` — возвращает текущий статус (`active`, `pausedUntil`).
- `UserService.startVacationByDateRange(user, from, to)` — новый метод, принимающий диапазон дат.
- OpenAPI: `vacation.yaml` ресурс + регистрация в `openapi.yaml` (тег `Vacation`, путь `/api/v1/vacation`, схемы `VacationRequest`/`VacationResponse`).

## Поведение дедлайнов
Дедлайны расписаний **не переносятся**. Пока отпуск активен, задачи накапливаются как просроченные. После окончания отпуска `VacationSchedulerService` показывает сводку «С возвращением!». Это задокументировано в `vacation.yaml`.

## Миграции
нет — поле `paused_until` уже существует в таблице `users` (существующая схема).

## Backward-compat риски
safe — новые эндпоинты, существующая колонка, существующий сервисный метод `endVacation` переиспользован.

## Тесты
- `VacationControllerTest` — 13 WebMvcTest кейсов: GET active/inactive/expired, POST happy/400-invalid-range/400-exceeded/400-validation, DELETE happy/idempotent, 401 на GET+POST.
- `UserServiceVacationDateRangeTest` — 8 интеграционных кейсов (Testcontainers Postgres): UTC, Asia/Almaty (UTC+5), Europe/Moscow (UTC+3), граница `from==to`, ровно 60 дней, to<from, длительность>60, повторный POST.

## Чек
- [x] `mvn test -Dtest="VacationControllerTest,UserServiceVacationDateRangeTest,UserServiceVacationTest"` зелёное (30 тестов)
- [x] Компиляция `mvn compile` зелёная
- [x] 4 существующих падающих теста (`SpeciesRepositoryTest`, `PlantServiceTest`, `PlantScheduleServiceTest`) — pre-existing flaky, воспроизводятся на ветке develop, не связаны с этим PR
- [x] reviewer прошёл (не требовался — код прямолинейный, без архитектурных вопросов)
