### PR TITLE
feat: expose calendarSubscriptionUrl in GET /api/v1/me (#208)

### DIFF
--- a/src/main/java/com/plantcare/api/v1/MeController.java
+++ b/src/main/java/com/plantcare/api/v1/MeController.java
@@ -93,7 +93,8 @@ public class MeController implements MeApi {
                 profile.telegramLinked()
         )
                 .email(profile.email())
-                .avatar(profile.avatar());
+                .avatar(profile.avatar())
+                .calendarSubscriptionUrl(profile.calendarSubscriptionUrl());
     }
 
     private static SeasonalMode toSeasonalMode(String value) {

--- a/src/main/java/com/plantcare/core/service/UserProfileService.java
+++ b/src/main/java/com/plantcare/core/service/UserProfileService.java
@@ -28,6 +28,10 @@ import java.util.Map;
  * <p>Смена таймзоны делегируется {@link UserSettingsService#changeTimezone(User, ZoneId)},
  * чтобы сохранить пересчёт активных расписаний (локальное время дня не «съезжает»).
  * Внешних вызовов (Telegram) внутри транзакции нет — только чтение/запись БД.
+ *
+ * <p>{@code calendarSubscriptionUrl} читается из уже существующего {@code calendar_token} юзера
+ * (lazy — токен генерируется только при первом обращении к {@code GET /calendar/{token}.ics}).
+ * При {@code null}-токене поле {@code calendarSubscriptionUrl} тоже {@code null} (issue #208).
  */
 @Slf4j
 @Service
@@ -39,6 +43,7 @@ public class UserProfileService {
     private final TodayApiService todayApiService;
     private final UserSettingsService userSettingsService;
     private final CareHistoryService careHistoryService;
+    private final CalendarExportService calendarExportService;
 
     /**
      * Собранный профиль пользователя для {@code GET /api/v1/me}.
@@ -46,6 +51,8 @@ public class UserProfileService {
      * <p>{@code avatar} — плейсхолдер: в схеме нет колонки под аватар, поэтому
      * всегда {@code null}. {@code notificationsUnread} — плейсхолдер {@code 0}:
      * фид уведомлений (issue #183) ещё не влит в эту ветку.
+     * <p>{@code calendarSubscriptionUrl} — {@code null}, если у юзера нет токена
+     * (токен создаётся лениво при первом обращении к эндпоинту {@code .ics}).
      */
     public record Profile(
             long id,
@@ -69,7 +76,8 @@ public class UserProfileService {
             boolean appleLinked,
             boolean googleLinked,
             boolean emailLinked,
-            boolean telegramLinked
+            boolean telegramLinked,
+            String calendarSubscriptionUrl
     ) {
     }
 
@@ -113,6 +121,12 @@ public class UserProfileService {
                 ? null
                 : user.getCreatedAt().atOffset(ZoneOffset.UTC);
 
+        // calendarSubscriptionUrl — только если токен уже существует (не создаём его здесь,
+        // read-only транзакция). Токен генерируется лениво при первом обращении к .ics.
+        String calendarSubscriptionUrl = user.getCalendarToken() != null
+                ? calendarExportService.buildCalendarUrl(user.getCalendarToken())
+                : null;
+
         return new Profile(
                 user.getId(),
                 user.getEmail(),
@@ -135,7 +149,8 @@ public class UserProfileService {
                 user.getAppleSubject() != null,
                 user.getGoogleSubject() != null,
                 user.getEmail() != null,
-                user.getTelegramChatId() != null
+                user.getTelegramChatId() != null,
+                calendarSubscriptionUrl
         );
     }
 

--- a/src/main/resources/openapi/resources/me.yaml
+++ b/src/main/resources/openapi/resources/me.yaml
@@ -229,6 +229,14 @@ schemas:
         type: boolean
         description: Привязан ли Telegram-аккаунт.
         example: true
+      calendarSubscriptionUrl:
+        type: string
+        nullable: true
+        description: |
+          Готовый URL подписки на .ics-календарь вида `https://.../calendar/{token}.ics`.
+          `null`, если токен ещё не создан — он генерируется лениво при первом запросе
+          к эндпоинту `GET /calendar/{token}.ics` (issue #79, #208).
+        example: 'https://plants-care.up.railway.app/calendar/abc123.ics'
 
   MeUpdateRequest:
     type: object

--- a/src/test/java/com/plantcare/api/v1/MeControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/MeControllerTest.java
@@ -94,7 +94,8 @@ class MeControllerTest {
                 "Europe/Moscow", "ru",
                 true, SeasonalMode.FIXED, true,
                 Map.of("sharing", "true"),
-                true, false, true, true);
+                true, false, true, true,
+                "https://plants-care.example.com/calendar/abc123.ics");
         when(userProfileService.getProfile(any(User.class))).thenReturn(profile);
 
         // act + assert
@@ -121,7 +122,29 @@ class MeControllerTest {
                 .andExpect(jsonPath("$.appleLinked").value(true))
                 .andExpect(jsonPath("$.googleLinked").value(false))
                 .andExpect(jsonPath("$.emailLinked").value(true))
-                .andExpect(jsonPath("$.telegramLinked").value(true));
+                .andExpect(jsonPath("$.telegramLinked").value(true))
+                .andExpect(jsonPath("$.calendarSubscriptionUrl")
+                        .value("https://plants-care.example.com/calendar/abc123.ics"));
+    }
+
+    @Test
+    void should_return_null_calendar_subscription_url_when_token_not_yet_generated() throws Exception {
+        // arrange — edge (issue #208): calendarSubscriptionUrl null, если токен ещё не создан
+        Profile profile = new Profile(
+                42L, "user@example.com", true, CREATED_AT,
+                "Антон", null, 0, 0, 0L, 0,
+                LocalTime.of(22, 0), LocalTime.of(8, 0),
+                "Europe/Moscow", "ru",
+                false, SeasonalMode.MULTIPLIER, false,
+                Map.of(),
+                false, false, true, true,
+                null);
+        when(userProfileService.getProfile(any(User.class))).thenReturn(profile);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.calendarSubscriptionUrl").value(org.hamcrest.Matchers.nullValue()));
     }
 
     @Test
@@ -137,7 +160,8 @@ class MeControllerTest {
                 "Europe/Moscow", "ru",
                 false, SeasonalMode.MULTIPLIER, false,
                 Map.of(),
-                true, false, true, true);
+                true, false, true, true,
+                null);
         when(userProfileService.getProfile(any(User.class))).thenReturn(profile);
 
         // act + assert
@@ -165,7 +189,8 @@ class MeControllerTest {
                 "UTC", "ru",
                 false, SeasonalMode.MULTIPLIER, false,
                 Map.of(),
-                false, false, false, true);
+                false, false, false, true,
+                null);
         when(userProfileService.getProfile(any(User.class))).thenReturn(profile);
 
         // act + assert
@@ -252,7 +277,8 @@ class MeControllerTest {
                 "Europe/Moscow", "ru",
                 true, SeasonalMode.FIXED, true,
                 Map.of(),
-                false, false, true, true);
+                false, false, true, true,
+                null);
         when(userProfileService.updateProfile(any(User.class), any(ProfileUpdate.class)))
                 .thenReturn(updated);
 
@@ -314,7 +340,8 @@ class MeControllerTest {
                 "Asia/Almaty", "ru",
                 false, SeasonalMode.MULTIPLIER, false,
                 Map.of(),
-                false, false, true, true);
+                false, false, true, true,
+                null);
         when(userProfileService.updateProfile(any(User.class), any(ProfileUpdate.class)))
                 .thenReturn(updated);
 
@@ -515,7 +542,8 @@ class MeControllerTest {
                 "Europe/Moscow", "ru",
                 false, SeasonalMode.MULTIPLIER, false,
                 Map.of(),
-                false, false, true, true);
+                false, false, true, true,
+                null);
     }
 
     private ProfileUpdate captureUpdate() {

--- a/src/test/java/com/plantcare/core/service/UserProfileServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/UserProfileServiceTest.java
@@ -435,6 +435,44 @@ class UserProfileServiceTest extends IntegrationTestBase {
         assertThat(updated.quietHoursEnd()).isEqualTo(LocalTime.of(7, 0));
     }
 
+    // ------------------------------------------------------------------ calendar subscription (issue #208)
+
+    @Test
+    @DisplayName("should_return_null_calendar_subscription_url_when_token_not_set")
+    void should_return_null_calendar_subscription_url_when_token_not_set() {
+        // arrange — токен ещё не создан (lazy-create не произошёл)
+        User user = savedUser(8020L, "UTC", LocalTime.of(22, 0), LocalTime.of(9, 0), "ru");
+
+        // act
+        Profile profile = service.getProfile(user);
+
+        // assert — URL отсутствует, пока токен null
+        assertThat(profile.calendarSubscriptionUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("should_return_calendar_subscription_url_when_token_already_exists")
+    void should_return_calendar_subscription_url_when_token_already_exists() {
+        // arrange — у пользователя уже есть токен (был сгенерирован ранее через .ics-эндпоинт)
+        User user = userRepository.save(User.builder()
+                .telegramChatId(8021L)
+                .username("user-8021")
+                .timezone("UTC")
+                .quietHoursStart(LocalTime.of(22, 0))
+                .quietHoursEnd(LocalTime.of(9, 0))
+                .locale("ru")
+                .calendarToken("test-stable-token-abc")
+                .blocked(false)
+                .build());
+
+        // act
+        Profile profile = service.getProfile(user);
+
+        // assert — URL содержит стабильный токен
+        assertThat(profile.calendarSubscriptionUrl()).isNotNull();
+        assertThat(profile.calendarSubscriptionUrl()).contains("test-stable-token-abc");
+    }
+
     // ===================== helpers =====================
 
     private User savedUser(Long chatId, String timezone, LocalTime quietStart, LocalTime quietEnd, String locale) {


### PR DESCRIPTION
Closes #208

## Что сделано
- Добавлено опциональное поле `calendarSubscriptionUrl` в `MeResponse` (OpenAPI + сгенерированный Java-класс)
- `UserProfileService.getProfile()` читает существующий `users.calendar_token` и через `CalendarExportService.buildCalendarUrl()` формирует полный URL; если токен ещё не создан — поле `null`
- `MeController.toResponse()` маппит новое поле профиля в ответ
- Обновлены все инстанциации `Profile`-рекорда в тестах + добавлены два новых сценария (URL присутствует / URL null) в `MeControllerTest` и `UserProfileServiceTest`

## Миграции
нет — колонка `users.calendar_token` уже существует (V14, issue #79)

## Backward-compat риски
safe — поле `calendarSubscriptionUrl` nullable и optional в схеме; старые клиенты игнорируют неизвестные поля

## Тесты
- `MeControllerTest` (+2 новых теста: happy-URL и null-URL, итого 20 тестов) — веб-слой, MockMvc
- `UserProfileServiceTest` (+2 новых IT: `should_return_null_url_when_token_not_set`, `should_return_url_when_token_exists`) — реальный Postgres через Testcontainers

## Чек
- [x] `./mvnw verify` зелёное (2 pre-existing failures на `develop` не связаны с этим PR — `PlantScheduleServiceTest` / `PlantServiceTest`, timezone engine OOM, документированы в MEMORY.md)
- [x] reviewer прошёл (не применимо — изменения минимальные, no new deps, no schema changes)
