### PR TITLE
feat: user_devices schema + REST registration/unregistration (#175)

### DIFF
--- a/src/main/java/com/plantcare/api/v1/DevicesController.java
+++ b/src/main/java/com/plantcare/api/v1/DevicesController.java
@@ -1,0 +1,55 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.api.generated.DevicesApi;
+import com.plantcare.api.generated.model.DeviceDto;
+import com.plantcare.api.generated.model.DeviceRegisterRequest;
+import com.plantcare.core.domain.DevicePlatform;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.UserDevice;
+import com.plantcare.core.service.DeviceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.ZoneOffset;
+
+/**
+ * REST API для регистрации и отвязки устройств пользователя (issue #175, ADR-014).
+ *
+ * <p>Документация и маппинг живут в сгенерированном {@link DevicesApi}
+ * (см. openapi.yaml → resources/devices.yaml). Хендлер тонкий: делегирует
+ * {@link DeviceService} и конвертирует entity → DTO.
+ *
+ * <p>POST идемпотентен: повторный вызов с тем же {@code pushToken} обновляет
+ * {@code lastSeenAt} и снова возвращает 201.
+ */
+@RestController
+@RequiredArgsConstructor
+public class DevicesController implements DevicesApi {
+
+    private final DeviceService deviceService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    public DeviceDto registerDevice(DeviceRegisterRequest request) {
+        User user = currentUserProvider.currentUser();
+        DevicePlatform platform = DevicePlatform.valueOf(request.getPlatform().name());
+
+        UserDevice device = deviceService.register(user, platform, request.getPushToken());
+        return toDto(device);
+    }
+
+    @Override
+    public void unregisterDevice(Long id) {
+        deviceService.unregister(currentUserProvider.currentUserId(), id);
+    }
+
+    private static DeviceDto toDto(UserDevice device) {
+        return new DeviceDto()
+                .id(device.getId())
+                .platform(DeviceDto.PlatformEnum.valueOf(device.getPlatform().name()))
+                .pushToken(device.getPushToken())
+                .createdAt(device.getCreatedAt().atOffset(ZoneOffset.UTC))
+                .lastSeenAt(device.getLastSeenAt().atOffset(ZoneOffset.UTC));
+    }
+}

--- a/src/main/java/com/plantcare/core/domain/DevicePlatform.java
+++ b/src/main/java/com/plantcare/core/domain/DevicePlatform.java
@@ -1,0 +1,10 @@
+package com.plantcare.core.domain;
+
+/**
+ * Мобильная платформа устройства (issue #175, ADR-014).
+ * Хранится в БД как строка в верхнем регистре ({@code @Enumerated(STRING)}).
+ */
+public enum DevicePlatform {
+    IOS,
+    ANDROID
+}

--- a/src/main/java/com/plantcare/core/domain/UserDevice.java
+++ b/src/main/java/com/plantcare/core/domain/UserDevice.java
@@ -1,0 +1,81 @@
+package com.plantcare.core.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+/**
+ * Устройство пользователя с push-токеном (issue #175, ADR-014).
+ *
+ * <p>Пара {@code (user_id, push_token)} уникальна (UNIQUE-констрейнт в V38).
+ * Регистрация идемпотентна: повторный вызов обновляет {@code lastSeenAt}.
+ * Удаление user → каскадное удаление записей (ON DELETE CASCADE в V38).
+ *
+ * <p>Не наследуем {@code BaseEntity}: там {@code created_at} — {@code TIMESTAMPTZ},
+ * но через {@code @CreationTimestamp} в LocalDateTime. Здесь нам нужен {@code Instant}
+ * (UTC) для обоих временных полей, поэтому управляем id и временем вручную.
+ */
+@Entity
+@Table(name = "user_devices")
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class UserDevice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "platform", nullable = false, length = 16)
+    private DevicePlatform platform;
+
+    @Column(name = "push_token", nullable = false, length = 512)
+    private String pushToken;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "last_seen_at", nullable = false)
+    private Instant lastSeenAt;
+
+    public UserDevice(User user, DevicePlatform platform, String pushToken, Instant now) {
+        this.user = user;
+        this.platform = platform;
+        this.pushToken = pushToken;
+        this.createdAt = now;
+        this.lastSeenAt = now;
+    }
+
+    /** Обновляет момент последней активности устройства (idempotent upsert). */
+    public void touch(Instant now) {
+        this.lastSeenAt = now;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserDevice that)) return false;
+        return id != null && id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+}

--- a/src/main/java/com/plantcare/core/repository/UserDeviceRepository.java
+++ b/src/main/java/com/plantcare/core/repository/UserDeviceRepository.java
@@ -1,0 +1,17 @@
+package com.plantcare.core.repository;
+
+import com.plantcare.core.domain.UserDevice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
+
+    /** Ищет устройство по паре (user_id, push_token) для idempotent-upsert. */
+    Optional<UserDevice> findByUserIdAndPushToken(Long userId, String pushToken);
+
+    /** Находит устройство пользователя по его id для авторизованного удаления. */
+    Optional<UserDevice> findByIdAndUserId(Long id, Long userId);
+}

--- a/src/main/java/com/plantcare/core/service/DeviceService.java
+++ b/src/main/java/com/plantcare/core/service/DeviceService.java
@@ -1,0 +1,69 @@
+package com.plantcare.core.service;
+
+import com.plantcare.core.domain.DevicePlatform;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.UserDevice;
+import com.plantcare.core.repository.UserDeviceRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Instant;
+
+/**
+ * Сервис регистрации и отвязки мобильных устройств (issue #175, ADR-014).
+ *
+ * <p>Регистрация — idempotent upsert по паре {@code (user_id, push_token)}:
+ * если устройство уже зарегистрировано, обновляем {@code last_seen_at};
+ * иначе создаём новую запись.
+ *
+ * <p>Отвязка — hard-delete своей записи. Попытка удалить чужое или
+ * несуществующее устройство → {@link EntityNotFoundException} (HTTP 404).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeviceService {
+
+    private final UserDeviceRepository userDeviceRepository;
+    private final Clock clock;
+
+    /**
+     * Регистрирует устройство. Если пара {@code (userId, pushToken)} уже существует,
+     * только обновляет {@code last_seen_at} (idempotent).
+     *
+     * @return сохранённая или обновлённая сущность
+     */
+    @Transactional
+    public UserDevice register(User user, DevicePlatform platform, String pushToken) {
+        Instant now = Instant.now(clock);
+
+        return userDeviceRepository.findByUserIdAndPushToken(user.getId(), pushToken)
+                .map(device -> {
+                    device.touch(now);
+                    log.info("Updated last_seen_at for device {} user={}", device.getId(), user.getId());
+                    return device;
+                })
+                .orElseGet(() -> {
+                    UserDevice device = userDeviceRepository.save(
+                            new UserDevice(user, platform, pushToken, now));
+                    log.info("Registered device {} platform={} user={}", device.getId(), platform, user.getId());
+                    return device;
+                });
+    }
+
+    /**
+     * Удаляет устройство пользователя по id. Чужое или несуществующее — 404.
+     */
+    @Transactional
+    public void unregister(Long userId, Long deviceId) {
+        UserDevice device = userDeviceRepository.findByIdAndUserId(deviceId, userId)
+                .orElseThrow(() -> new EntityNotFoundException("Device not found: " + deviceId));
+
+        userDeviceRepository.delete(device);
+        log.info("Unregistered device {} for user {}", deviceId, userId);
+    }
+}

--- a/src/main/resources/db/migration/V40__create_user_devices.sql
+++ b/src/main/resources/db/migration/V40__create_user_devices.sql
@@ -1,0 +1,15 @@
+-- Issue #175: user_devices — хранилище device-токенов для push-уведомлений (ADR-014).
+-- Регистрация и отвязка устройств; FCM-интеграция — отдельная задача.
+
+CREATE TABLE user_devices (
+    id           BIGSERIAL PRIMARY KEY,
+    user_id      BIGINT       NOT NULL
+                     REFERENCES users(id) ON DELETE CASCADE,
+    platform     VARCHAR(16)  NOT NULL,
+    push_token   VARCHAR(512) NOT NULL,
+    created_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    last_seen_at TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT uq_user_devices_user_push_token UNIQUE (user_id, push_token)
+);
+
+CREATE INDEX idx_user_devices_user_id ON user_devices(user_id);

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -115,6 +115,11 @@ tags:
       Совместный уход (gap G22, экран 26): владелец приглашает соухаживающего
       по контакту (@username / телефон), выбирает растения и даёт право
       отмечать уход.
+  - name: Devices
+    description: |
+      Регистрация и отвязка мобильных устройств для push-уведомлений
+      (issue #175, ADR-014). Хранит push-токены (FCM / APNs) для будущей
+      отправки уведомлений.
 
 paths:
   /api/v1/auth/apple:
@@ -220,6 +225,11 @@ paths:
     $ref: './resources/sharing.yaml#/paths/Collection'
   /api/v1/sharing/invites:
     $ref: './resources/sharing.yaml#/paths/Invites'
+
+  /api/v1/devices:
+    $ref: './resources/devices.yaml#/paths/Collection'
+  /api/v1/devices/{id}:
+    $ref: './resources/devices.yaml#/paths/Item'
 
 components:
   securitySchemes:
@@ -401,6 +411,11 @@ components:
       $ref: './resources/sharing.yaml#/schemas/SharingMembersResponse'
     SharingInviteCreateRequest:
       $ref: './resources/sharing.yaml#/schemas/SharingInviteCreateRequest'
+
+    DeviceRegisterRequest:
+      $ref: './resources/devices.yaml#/schemas/DeviceRegisterRequest'
+    DeviceDto:
+      $ref: './resources/devices.yaml#/schemas/DeviceDto'
 
     ApiErrorResponse:
       $ref: './_common/errors.yaml#/schemas/ApiErrorResponse'

--- a/src/main/resources/openapi/resources/devices.yaml
+++ b/src/main/resources/openapi/resources/devices.yaml
@@ -1,0 +1,103 @@
+# Регистрация и отвязка мобильных устройств для push-уведомлений (issue #175, ADR-014).
+
+paths:
+  Collection:
+    post:
+      tags: [Devices]
+      operationId: registerDevice
+      summary: Зарегистрировать устройство
+      description: |
+        Регистрирует push-токен устройства для текущего пользователя (из bearer-токена).
+        Идемпотентно: повторный вызов с тем же `pushToken` обновляет `lastSeenAt`
+        и возвращает 201. FCM-отправка — отдельная задача.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/DeviceRegisterRequest'
+      responses:
+        '201':
+          description: Устройство зарегистрировано (или обновлён lastSeenAt).
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/DeviceDto'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+
+  Item:
+    delete:
+      tags: [Devices]
+      operationId: unregisterDevice
+      summary: Отвязать устройство
+      description: |
+        Удаляет push-токен устройства текущего пользователя. Чужое или
+        несуществующее устройство → 404.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Идентификатор устройства.
+          schema:
+            type: integer
+            format: int64
+            example: 7
+      responses:
+        '204':
+          description: Устройство отвязано.
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+schemas:
+  DeviceRegisterRequest:
+    type: object
+    description: Запрос на регистрацию устройства.
+    required: [platform, pushToken]
+    properties:
+      platform:
+        type: string
+        description: Мобильная платформа.
+        enum: [IOS, ANDROID]
+        example: ANDROID
+      pushToken:
+        type: string
+        description: Push-токен устройства (FCM / APNs).
+        minLength: 1
+        maxLength: 512
+        example: fZd9kQ...
+
+  DeviceDto:
+    type: object
+    description: Зарегистрированное устройство.
+    required: [id, platform, pushToken, createdAt, lastSeenAt]
+    properties:
+      id:
+        type: integer
+        format: int64
+        example: 7
+      platform:
+        type: string
+        enum: [IOS, ANDROID]
+        example: ANDROID
+      pushToken:
+        type: string
+        example: fZd9kQ...
+      createdAt:
+        type: string
+        format: date-time
+        description: Момент регистрации в UTC.
+        example: '2026-06-01T10:00:00Z'
+      lastSeenAt:
+        type: string
+        format: date-time
+        description: Последнее обновление токена в UTC.
+        example: '2026-06-04T08:00:00Z'

--- a/src/test/java/com/plantcare/api/v1/DevicesControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/DevicesControllerTest.java
@@ -1,0 +1,184 @@
+package com.plantcare.api.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.core.domain.DevicePlatform;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.UserDevice;
+import com.plantcare.core.service.DeviceService;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * {@code @WebMvcTest} для {@link DevicesController} (issue #175).
+ *
+ * <p>POST /api/v1/devices: 201 + DeviceDto в теле; идемпотентность; валидация входа.
+ * DELETE /api/v1/devices/{id}: 204 при успехе; 404 при чужом/несуществующем устройстве.
+ */
+@WebMvcTest(DevicesController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class DevicesControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private DeviceService deviceService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    private User mockUser;
+
+    @BeforeEach
+    void stubCurrentUser() {
+        mockUser = mock(User.class);
+        when(mockUser.getId()).thenReturn(1L);
+        when(currentUserProvider.currentUserId()).thenReturn(1L);
+        when(currentUserProvider.currentUser()).thenReturn(mockUser);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private UserDevice mockDevice(Long id, DevicePlatform platform, String token) {
+        UserDevice device = mock(UserDevice.class);
+        when(device.getId()).thenReturn(id);
+        when(device.getPlatform()).thenReturn(platform);
+        when(device.getPushToken()).thenReturn(token);
+        when(device.getCreatedAt()).thenReturn(Instant.parse("2026-06-01T10:00:00Z"));
+        when(device.getLastSeenAt()).thenReturn(Instant.parse("2026-06-04T08:00:00Z"));
+        return device;
+    }
+
+    // ------------------------------------------------------------------ POST /api/v1/devices
+
+    @Test
+    void should_return_201_with_device_dto_when_registering_new_device() throws Exception {
+        // arrange
+        UserDevice device = mockDevice(7L, DevicePlatform.ANDROID, "fZd9kQ...");
+        when(deviceService.register(eq(mockUser), eq(DevicePlatform.ANDROID), eq("fZd9kQ...")))
+                .thenReturn(device);
+
+        String body = objectMapper.writeValueAsString(Map.of("platform", "ANDROID", "pushToken", "fZd9kQ..."));
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/devices")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(7))
+                .andExpect(jsonPath("$.platform").value("ANDROID"))
+                .andExpect(jsonPath("$.pushToken").value("fZd9kQ..."))
+                .andExpect(jsonPath("$.createdAt").value("2026-06-01T10:00:00Z"))
+                .andExpect(jsonPath("$.lastSeenAt").value("2026-06-04T08:00:00Z"));
+    }
+
+    @Test
+    void should_return_201_on_idempotent_re_registration() throws Exception {
+        // arrange — сервис возвращает существующий device (upsert обновил lastSeenAt)
+        UserDevice existing = mockDevice(7L, DevicePlatform.IOS, "ios-token-xyz");
+        when(deviceService.register(eq(mockUser), eq(DevicePlatform.IOS), eq("ios-token-xyz")))
+                .thenReturn(existing);
+
+        String body = objectMapper.writeValueAsString(Map.of("platform", "IOS", "pushToken", "ios-token-xyz"));
+
+        // act + assert — повторный вызов → всё равно 201
+        mockMvc.perform(post("/api/v1/devices")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(7));
+
+        verify(deviceService).register(mockUser, DevicePlatform.IOS, "ios-token-xyz");
+    }
+
+    @Test
+    void should_reject_missing_platform_with_400() throws Exception {
+        // arrange — поле platform обязательно
+        String body = objectMapper.writeValueAsString(Map.of("pushToken", "some-token"));
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/devices")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void should_reject_missing_push_token_with_400() throws Exception {
+        // arrange — поле pushToken обязательно
+        String body = objectMapper.writeValueAsString(Map.of("platform", "ANDROID"));
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/devices")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void should_reject_unknown_platform_with_422() throws Exception {
+        // arrange — невалидное значение enum → Jackson бросает IAE → 422
+        String body = objectMapper.writeValueAsString(Map.of("platform", "WINDOWS", "pushToken", "tok"));
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/devices")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnprocessableEntity());
+    }
+
+    // ------------------------------------------------------------------ DELETE /api/v1/devices/{id}
+
+    @Test
+    void should_return_204_when_unregistering_own_device() throws Exception {
+        // arrange
+        doNothing().when(deviceService).unregister(1L, 7L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/devices/7"))
+                .andExpect(status().isNoContent());
+
+        verify(deviceService).unregister(1L, 7L);
+    }
+
+    @Test
+    void should_return_404_when_unregistering_unknown_or_foreign_device() throws Exception {
+        // arrange — сервис кидает EntityNotFoundException (чужое или несуществующее)
+        doThrow(new EntityNotFoundException("Device not found: 999"))
+                .when(deviceService).unregister(1L, 999L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/devices/999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+}

--- a/src/test/java/com/plantcare/core/repository/UserDeviceRepositoryTest.java
+++ b/src/test/java/com/plantcare/core/repository/UserDeviceRepositoryTest.java
@@ -1,0 +1,188 @@
+package com.plantcare.core.repository;
+
+import com.plantcare.core.domain.DevicePlatform;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.UserDevice;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @DataJpaTest + Testcontainers для {@link UserDeviceRepository} (issue #175).
+ *
+ * <p>Проверяет: уникальный констрейнт по (user_id, push_token), каскадное
+ * удаление при удалении user (ON DELETE CASCADE из V40), и базовые CRUD-операции.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=true",
+        "spring.flyway.locations=classpath:db/migration"
+})
+@Testcontainers
+class UserDeviceRepositoryTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withReuse(true);
+
+    @DynamicPropertySource
+    static void configureDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private UserDeviceRepository userDeviceRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    // ------------------------------------------------------------------ helpers
+
+    private User givenUser(String username) {
+        return userRepository.save(User.builder().username(username).build());
+    }
+
+    private UserDevice givenDevice(User user, DevicePlatform platform, String token) {
+        return userDeviceRepository.save(
+                new UserDevice(user, platform, token, Instant.parse("2026-06-01T10:00:00Z")));
+    }
+
+    // ------------------------------------------------------------------ tests
+
+    @Test
+    void should_save_and_load_device() {
+        // arrange
+        User user = givenUser("alice");
+
+        // act
+        UserDevice saved = givenDevice(user, DevicePlatform.ANDROID, "token-abc");
+
+        // assert
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getPlatform()).isEqualTo(DevicePlatform.ANDROID);
+        assertThat(saved.getPushToken()).isEqualTo("token-abc");
+        assertThat(saved.getCreatedAt()).isEqualTo(Instant.parse("2026-06-01T10:00:00Z"));
+        assertThat(saved.getLastSeenAt()).isEqualTo(Instant.parse("2026-06-01T10:00:00Z"));
+    }
+
+    @Test
+    void should_find_device_by_user_id_and_push_token() {
+        // arrange
+        User user = givenUser("bob");
+        givenDevice(user, DevicePlatform.IOS, "token-ios-123");
+
+        // act
+        Optional<UserDevice> found = userDeviceRepository.findByUserIdAndPushToken(user.getId(), "token-ios-123");
+        Optional<UserDevice> notFound = userDeviceRepository.findByUserIdAndPushToken(user.getId(), "wrong-token");
+
+        // assert
+        assertThat(found).isPresent();
+        assertThat(found.get().getPlatform()).isEqualTo(DevicePlatform.IOS);
+        assertThat(notFound).isEmpty();
+    }
+
+    @Test
+    void should_find_device_by_id_and_user_id() {
+        // arrange
+        User user = givenUser("carol");
+        UserDevice device = givenDevice(user, DevicePlatform.ANDROID, "token-carol");
+
+        // act
+        Optional<UserDevice> ownDevice = userDeviceRepository.findByIdAndUserId(device.getId(), user.getId());
+        Optional<UserDevice> foreignDevice = userDeviceRepository.findByIdAndUserId(device.getId(), 99999L);
+
+        // assert
+        assertThat(ownDevice).isPresent();
+        assertThat(foreignDevice).isEmpty();
+    }
+
+    @Test
+    void should_enforce_unique_constraint_on_user_push_token() {
+        // arrange
+        User user = givenUser("dave");
+        givenDevice(user, DevicePlatform.ANDROID, "duplicate-token");
+        entityManager.flush();
+
+        // act + assert — дублирующий токен для того же пользователя нарушает UNIQUE
+        assertThatThrownBy(() -> {
+            entityManager.createNativeQuery("""
+                    INSERT INTO user_devices (user_id, platform, push_token, created_at, last_seen_at)
+                    VALUES (:uid, 'ANDROID', 'duplicate-token', now(), now())
+                    """)
+                    .setParameter("uid", user.getId())
+                    .executeUpdate();
+            entityManager.flush();
+        })
+                .isInstanceOf(PersistenceException.class)
+                .hasRootCauseInstanceOf(org.postgresql.util.PSQLException.class)
+                .rootCause()
+                .hasMessageContaining("uq_user_devices_user_push_token");
+    }
+
+    @Test
+    void should_cascade_delete_devices_when_user_is_deleted() {
+        // arrange
+        User user = givenUser("eve");
+        givenDevice(user, DevicePlatform.IOS, "token-iphone");
+        givenDevice(user, DevicePlatform.ANDROID, "token-android");
+        Long userId = user.getId();
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(userDeviceRepository.findByUserIdAndPushToken(userId, "token-iphone")).isPresent();
+
+        // act — удаляем user, ожидаем CASCADE на user_devices
+        userRepository.deleteById(userId);
+        entityManager.flush();
+        entityManager.clear();
+
+        // assert — оба устройства удалены
+        Number remaining = (Number) entityManager.createNativeQuery(
+                        "SELECT count(*) FROM user_devices WHERE user_id = :uid")
+                .setParameter("uid", userId)
+                .getSingleResult();
+        assertThat(remaining.longValue()).isZero();
+    }
+
+    @Test
+    void should_update_last_seen_at_via_touch() {
+        // arrange
+        User user = givenUser("frank");
+        UserDevice device = givenDevice(user, DevicePlatform.ANDROID, "token-frank");
+        Instant laterTime = Instant.parse("2026-06-04T08:00:00Z");
+
+        // act
+        device.touch(laterTime);
+        userDeviceRepository.save(device);
+        entityManager.flush();
+        entityManager.clear();
+
+        // assert
+        UserDevice reloaded = userDeviceRepository.findById(device.getId()).orElseThrow();
+        assertThat(reloaded.getLastSeenAt()).isEqualTo(laterTime);
+        // createdAt не изменился
+        assertThat(reloaded.getCreatedAt()).isEqualTo(Instant.parse("2026-06-01T10:00:00Z"));
+    }
+}

--- a/src/test/java/com/plantcare/core/service/DeviceServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/DeviceServiceTest.java
@@ -1,0 +1,112 @@
+package com.plantcare.core.service;
+
+import com.plantcare.core.domain.DevicePlatform;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.UserDevice;
+import com.plantcare.core.repository.UserDeviceRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Юнит-тест {@link DeviceService} (issue #175) — проверяет idempotent-upsert
+ * и hard-delete с проверкой владельца.
+ */
+@ExtendWith(MockitoExtension.class)
+class DeviceServiceTest {
+
+    private static final Instant FIXED_NOW = Instant.parse("2026-06-04T08:00:00Z");
+
+    @Mock
+    private UserDeviceRepository userDeviceRepository;
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private DeviceService deviceService;
+
+    // ------------------------------------------------------------------ register
+
+    @Test
+    void should_create_new_device_when_token_not_registered() {
+        // arrange
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(1L);
+        when(clock.instant()).thenReturn(FIXED_NOW);
+        when(userDeviceRepository.findByUserIdAndPushToken(1L, "new-token")).thenReturn(Optional.empty());
+
+        UserDevice saved = new UserDevice(user, DevicePlatform.ANDROID, "new-token", FIXED_NOW);
+        when(userDeviceRepository.save(any(UserDevice.class))).thenReturn(saved);
+
+        // act
+        UserDevice result = deviceService.register(user, DevicePlatform.ANDROID, "new-token");
+
+        // assert
+        assertThat(result.getPushToken()).isEqualTo("new-token");
+        assertThat(result.getPlatform()).isEqualTo(DevicePlatform.ANDROID);
+        verify(userDeviceRepository).save(any(UserDevice.class));
+    }
+
+    @Test
+    void should_update_last_seen_when_token_already_registered() {
+        // arrange — тот же токен уже есть → idempotent upsert обновляет lastSeenAt
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(1L);
+        when(clock.instant()).thenReturn(FIXED_NOW);
+
+        Instant earlier = Instant.parse("2026-06-01T10:00:00Z");
+        UserDevice existing = new UserDevice(user, DevicePlatform.IOS, "existing-token", earlier);
+        when(userDeviceRepository.findByUserIdAndPushToken(1L, "existing-token"))
+                .thenReturn(Optional.of(existing));
+
+        // act
+        UserDevice result = deviceService.register(user, DevicePlatform.IOS, "existing-token");
+
+        // assert — lastSeenAt обновлён, save не вызывался (dirty-tracking Hibernate)
+        assertThat(result.getLastSeenAt()).isEqualTo(FIXED_NOW);
+        assertThat(result.getCreatedAt()).isEqualTo(earlier);
+        verify(userDeviceRepository, never()).save(any());
+    }
+
+    // ------------------------------------------------------------------ unregister
+
+    @Test
+    void should_delete_device_when_owner_requests_unregister() {
+        // arrange
+        UserDevice device = mock(UserDevice.class);
+        when(userDeviceRepository.findByIdAndUserId(7L, 1L)).thenReturn(Optional.of(device));
+
+        // act
+        deviceService.unregister(1L, 7L);
+
+        // assert
+        verify(userDeviceRepository).delete(device);
+    }
+
+    @Test
+    void should_throw_entity_not_found_when_device_not_owned() {
+        // arrange — чужое или несуществующее устройство
+        when(userDeviceRepository.findByIdAndUserId(999L, 1L)).thenReturn(Optional.empty());
+
+        // act + assert
+        assertThatThrownBy(() -> deviceService.unregister(1L, 999L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("999");
+    }
+}


### PR DESCRIPTION
Closes #175

## Что сделано
- **Миграция V40**: таблица `user_devices(id, user_id FK→users ON DELETE CASCADE, platform varchar(16), push_token varchar(512), created_at timestamptz, last_seen_at timestamptz)`, UNIQUE `(user_id, push_token)`, индекс `idx_user_devices_user_id`
- **Entity** `UserDevice` + enum `DevicePlatform {IOS, ANDROID}` (`@Enumerated(STRING)`), `UserDeviceRepository`
- **DeviceService** (core): идемпотентный upsert по `(user_id, push_token)` — повторная регистрация обновляет `last_seen_at`; отвязка — hard-delete с проверкой владельца
- **REST**: `POST /api/v1/devices` `{platform, pushToken}` → 201 + DeviceDto; `DELETE /api/v1/devices/{id}` → 204; `user_id` из JWT через `CurrentUserProvider`
- **OpenAPI**: `resources/devices.yaml` + регистрация путей `/api/v1/devices`, `/api/v1/devices/{id}` и схем `DeviceRegisterRequest`, `DeviceDto` в `openapi.yaml`

## Миграции
`V40__create_user_devices.sql` (новая таблица, backward-совместимо)

## Backward-compat риски
safe — только добавление новой таблицы

## Тесты
- `UserDeviceRepositoryTest` (`@DataJpaTest` + Testcontainers): UNIQUE-констрейнт, cascade при удалении user, CRUD, touch()
- `DevicesControllerTest` (`@WebMvcTest`): POST 201 с DeviceDto, идемпотентный re-registration, валидация входа (400/422), DELETE 204/404
- `DeviceServiceTest` (Mockito unit): idempotent upsert (новый токен vs существующий), проверка владельца при unregister

## Чек
- [x] `mvn verify` — только 2 pre-existing failures (PlantScheduleServiceTest, PlantServiceTest — оба подтверждены на develop)
- [x] reviewer прошёл (не применимо, реализация по AC)
