### PR TITLE
fix: устранить кумулятивный OOM от TimeZoneEngine в тестах (#239)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,4 +30,11 @@ jobs:
     - name: Build with Maven
       env:
         MAVEN_OPTS: "-Xmx512m"
-      run: mvn package -DargLine="-Xmx3g"
+      # Issue #239: TimeZoneEngine теперь единый синглтон на весь прогон JVM
+      # (TimeZoneEngineBean.Holder), поэтому тест-форк больше не держит N копий
+      # гео-датасета и укладывается в дефолтный heap без -Xmx-распухания.
+      # ВАЖНО: не задавать -DargLine здесь — это перезаписывает argLine, в который
+      # jacoco:prepare-agent внедряет свой java-agent, и тогда покрытие не
+      # инструментируется и jacoco:check падает. Heap при необходимости — через
+      # MAVEN_OPTS форка, а не через argLine.
+      run: mvn package

--- a/src/main/java/com/plantcare/core/beans/TimeZoneEngineBean.java
+++ b/src/main/java/com/plantcare/core/beans/TimeZoneEngineBean.java
@@ -4,11 +4,38 @@ import net.iakovlev.timeshape.TimeZoneEngine;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Регистрирует {@link TimeZoneEngine} как Spring-бин.
+ *
+ * <p>{@code TimeZoneEngine.initialize()} грузит гео-датасет всего мира (сотни МБ
+ * в heap) и иммутабелен после построения. В проде это один экземпляр на один
+ * контекст приложения. В тестах же поднимается множество {@code @SpringBootTest}
+ * контекстов с разными ключами кэша (разные {@code Clock}-конфиги, MockMvc,
+ * MockBean), и наивная реализация создавала бы СВОЙ движок на каждый контекст —
+ * несколько сотен-МБ датасетов одновременно живут в heap → кумулятивный
+ * {@code OutOfMemoryError} (issue #239).
+ *
+ * <p>Поэтому реальный движок инициализируется лениво ровно один раз на JVM и
+ * переиспользуется всеми контекстами через статический holder. Поведение в проде
+ * не меняется (тот же полноразмерный движок, единственный экземпляр), а тестовый
+ * прогон перестаёт держать N копий датасета.
+ */
 @Configuration
 public class TimeZoneEngineBean {
 
     @Bean
     public TimeZoneEngine timeZoneEngine() {
-        return TimeZoneEngine.initialize();
+        return Holder.INSTANCE;
+    }
+
+    /**
+     * Lazy-инициализация по идиоме holder-класса: датасет грузится при первом
+     * обращении к {@link #INSTANCE}, потокобезопасно и без явной синхронизации.
+     */
+    private static final class Holder {
+        private static final TimeZoneEngine INSTANCE = TimeZoneEngine.initialize();
+
+        private Holder() {
+        }
     }
 }

--- a/src/test/java/com/plantcare/admin/AdminAuthenticationTest.java
+++ b/src/test/java/com/plantcare/admin/AdminAuthenticationTest.java
@@ -1,13 +1,12 @@
 package com.plantcare.admin;
 
+import com.plantcare.admin.ratelimit.LoginRateLimiter;
 import com.plantcare.bot.support.IntegrationTestBase;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.Matchers.containsString;
@@ -23,17 +22,30 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName("Admin authentication — form login flow")
 class AdminAuthenticationTest extends IntegrationTestBase {
 
+    // Credentials match application-test.yml (admin.username / admin.password-bcrypt-hash).
+    // Using the same fixed values as all other admin tests ensures Spring reuses one cached
+    // ApplicationContext — and therefore one TimeZoneEngine — across AdminAuthenticationTest,
+    // AdminDashboardTest, AdminLayoutTest, AdminRateLimitTest, AdminUserDetailTest,
+    // AdminUserListTest (issue #239).
     private static final String USERNAME = "admin";
-    private static final String PASSWORD = "test-password-123";
-    private static final String BCRYPT_HASH = new BCryptPasswordEncoder(12).encode(PASSWORD);
-
-    @DynamicPropertySource
-    static void adminProps(DynamicPropertyRegistry registry) {
-        registry.add("admin.username", () -> USERNAME);
-        registry.add("admin.password-bcrypt-hash", () -> BCRYPT_HASH);
-    }
+    // Plain-text password whose bcrypt hash (cost 10) is stored in application-test.yml.
+    private static final String PASSWORD = "test-admin-password";
 
     @Autowired private MockMvc mockMvc;
+    @Autowired private LoginRateLimiter loginRateLimiter;
+
+    /**
+     * Сбрасываем login-rate-limiter перед каждым тестом. Раньше каждый admin-тест
+     * поднимал свой контекст (разные креды → разный ключ кэша), поэтому имел свой
+     * чистый лимитер. После консолидации контекстов (issue #239) лимитер общий с
+     * {@code AdminRateLimitTest}, который специально исчерпывает 5 попыток с того же
+     * IP (127.0.0.1, дефолтный remoteAddr MockMvc) — без сброса логин-флоу-тесты
+     * ловили бы 429 вместо ожидаемых 401/302.
+     */
+    @BeforeEach
+    void resetRateLimiter() {
+        loginRateLimiter.reset("127.0.0.1");
+    }
 
     @Test
     @DisplayName("GET /admin без авторизации → 302 на /admin/login")

--- a/src/test/java/com/plantcare/admin/AdminDashboardTest.java
+++ b/src/test/java/com/plantcare/admin/AdminDashboardTest.java
@@ -9,9 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,14 +21,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @DisplayName("Admin Dashboard — метрики и Stuck/Recent блоки")
 class AdminDashboardTest extends IntegrationTestBase {
-
-    private static final String BCRYPT_HASH = new BCryptPasswordEncoder(12).encode("anything");
-
-    @DynamicPropertySource
-    static void adminProps(DynamicPropertyRegistry registry) {
-        registry.add("admin.username", () -> "admin");
-        registry.add("admin.password-bcrypt-hash", () -> BCRYPT_HASH);
-    }
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/plantcare/admin/AdminDisabledTest.java
+++ b/src/test/java/com/plantcare/admin/AdminDisabledTest.java
@@ -1,10 +1,12 @@
 package com.plantcare.admin;
 
 import com.plantcare.bot.support.IntegrationTestBase;
+import net.iakovlev.timeshape.TimeZoneEngine;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
@@ -16,6 +18,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @DisplayName("Admin disabled — env-переменные не заданы")
 class AdminDisabledTest extends IntegrationTestBase {
+
+    // Admin is disabled in this test (empty username/password-hash), which forces a separate
+    // Spring context. Mock the TimeZoneEngine so its heavy geo-dataset is NOT loaded here —
+    // the real engine is tested in AwaitingTimezoneStateHandlerTest.
+    @MockBean
+    TimeZoneEngine timeZoneEngine;
 
     @DynamicPropertySource
     static void adminProps(DynamicPropertyRegistry registry) {

--- a/src/test/java/com/plantcare/admin/AdminLayoutTest.java
+++ b/src/test/java/com/plantcare/admin/AdminLayoutTest.java
@@ -5,9 +5,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.Matchers.containsString;
@@ -19,15 +16,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @DisplayName("Admin layout — рендеринг базового шаблона")
 class AdminLayoutTest extends IntegrationTestBase {
-
-    private static final String BCRYPT_HASH =
-            new BCryptPasswordEncoder(12).encode("anything");
-
-    @DynamicPropertySource
-    static void adminProps(DynamicPropertyRegistry registry) {
-        registry.add("admin.username", () -> "admin");
-        registry.add("admin.password-bcrypt-hash", () -> BCRYPT_HASH);
-    }
 
     @Autowired private MockMvc mockMvc;
 

--- a/src/test/java/com/plantcare/admin/AdminRateLimitTest.java
+++ b/src/test/java/com/plantcare/admin/AdminRateLimitTest.java
@@ -1,13 +1,12 @@
 package com.plantcare.admin;
 
+import com.plantcare.admin.ratelimit.LoginRateLimiter;
 import com.plantcare.bot.support.IntegrationTestBase;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -18,30 +17,31 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName("Admin login rate limit — 5/мин")
 class AdminRateLimitTest extends IntegrationTestBase {
 
-    private static final String USERNAME = "admin";
-    private static final String BCRYPT_HASH =
-            new BCryptPasswordEncoder(12).encode("correct-password");
-
-    @DynamicPropertySource
-    static void adminProps(DynamicPropertyRegistry registry) {
-        registry.add("admin.username", () -> USERNAME);
-        registry.add("admin.password-bcrypt-hash", () -> BCRYPT_HASH);
-    }
-
     @Autowired private MockMvc mockMvc;
+    @Autowired private LoginRateLimiter loginRateLimiter;
+
+    /**
+     * Стартуем с чистого лимитера: контекст общий с другими admin-тестами (issue #239),
+     * поэтому неудачные логины из соседних тестов могли бы заполнить счётчик 127.0.0.1
+     * и сломать ассерты на первые 5 попыток (401).
+     */
+    @BeforeEach
+    void resetRateLimiter() {
+        loginRateLimiter.reset("127.0.0.1");
+    }
 
     @Test
     @DisplayName("6-я попытка за минуту → 429")
     void sixthAttemptIsRateLimited() throws Exception {
         for (int i = 0; i < 5; i++) {
             mockMvc.perform(post("/admin/login")
-                            .param("username", USERNAME)
+                            .param("username", "admin")
                             .param("password", "wrong-" + i)
                             .with(csrf()))
                     .andExpect(status().isUnauthorized());
         }
         mockMvc.perform(post("/admin/login")
-                        .param("username", USERNAME)
+                        .param("username", "admin")
                         .param("password", "wrong-final")
                         .with(csrf()))
                 .andExpect(status().isTooManyRequests());

--- a/src/test/java/com/plantcare/admin/AdminUserDetailTest.java
+++ b/src/test/java/com/plantcare/admin/AdminUserDetailTest.java
@@ -7,9 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.Matchers.containsString;
@@ -21,14 +18,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @DisplayName("Admin user detail — read-only данные")
 class AdminUserDetailTest extends IntegrationTestBase {
-
-    private static final String BCRYPT_HASH = new BCryptPasswordEncoder(12).encode("anything");
-
-    @DynamicPropertySource
-    static void adminProps(DynamicPropertyRegistry registry) {
-        registry.add("admin.username", () -> "admin");
-        registry.add("admin.password-bcrypt-hash", () -> BCRYPT_HASH);
-    }
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/plantcare/admin/AdminUserListTest.java
+++ b/src/test/java/com/plantcare/admin/AdminUserListTest.java
@@ -7,9 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.Matchers.containsString;
@@ -22,14 +19,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @DisplayName("Admin Users list — фильтры, поиск, пагинация")
 class AdminUserListTest extends IntegrationTestBase {
-
-    private static final String BCRYPT_HASH = new BCryptPasswordEncoder(12).encode("anything");
-
-    @DynamicPropertySource
-    static void adminProps(DynamicPropertyRegistry registry) {
-        registry.add("admin.username", () -> "admin");
-        registry.add("admin.password-bcrypt-hash", () -> BCRYPT_HASH);
-    }
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/plantcare/bot/support/FixedClockTestConfig.java
+++ b/src/test/java/com/plantcare/bot/support/FixedClockTestConfig.java
@@ -1,0 +1,37 @@
+package com.plantcare.bot.support;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+/**
+ * Общая тестовая конфигурация с фиксированным {@link Clock}.
+ *
+ * <p>Импортируется несколькими интеграционными тестами вместо определения
+ * дублирующих inner-классов {@code FixedClockConfig} в каждом тесте. Это
+ * гарантирует, что все тесты с одинаковым FIXED_NOW получают <em>один</em>
+ * кэшированный {@code ApplicationContext} Spring (а значит — один экземпляр
+ * {@link net.iakovlev.timeshape.TimeZoneEngine}), а не N отдельных контекстов
+ * с N отдельными движками (issue #239).
+ *
+ * <p>Выбранный момент {@code 2026-05-25T00:30:00Z} (00:30 UTC) специально
+ * создаёт пограничный кейс для восточных TZ (Asia/Almaty UTC+5): локальная
+ * дата уже «сегодня», тогда как UTC-полночь и локальная-полночь расходятся
+ * на день — это проверяет TZ-кейсы на границе суток.
+ */
+@TestConfiguration
+public class FixedClockTestConfig {
+
+    /** Фиксированный «сейчас» для детерминированных тестов с Clock. */
+    public static final Instant FIXED_NOW = Instant.parse("2026-05-25T00:30:00Z");
+
+    @Bean
+    @Primary
+    public Clock fixedClock() {
+        return Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+    }
+}

--- a/src/test/java/com/plantcare/core/beans/TimeZoneEngineBeanIT.java
+++ b/src/test/java/com/plantcare/core/beans/TimeZoneEngineBeanIT.java
@@ -1,0 +1,57 @@
+package com.plantcare.core.beans;
+
+import com.plantcare.bot.support.IntegrationTestBase;
+import net.iakovlev.timeshape.TimeZoneEngine;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Интеграционный тест, гарантирующий, что реальный {@link TimeZoneEngine} корректно
+ * загружается и резолвит координаты в не-UTC таймзону (требование CLAUDE.md, issue #239).
+ *
+ * <p>Зависит от основного контекста приложения ({@link IntegrationTestBase}), в котором
+ * {@code TimeZoneEngine} регистрируется как ленивый бин. Этот тест первым обращается к
+ * движку — тем самым инициируя загрузку гео-датасета ровно в одном из контекстов прогона.
+ */
+@DisplayName("TimeZoneEngineBean — реальный движок резолвит не-UTC координаты")
+class TimeZoneEngineBeanIT extends IntegrationTestBase {
+
+    @Autowired
+    private TimeZoneEngine timeZoneEngine;
+
+    @Test
+    @DisplayName("Координаты Москвы → Europe/Moscow (UTC+3, не UTC)")
+    void should_resolve_moscow_coordinates_to_europe_moscow_timezone() {
+        // arrange — координаты центра Москвы
+        double lat = 55.7558;
+        double lon = 37.6173;
+
+        // act
+        Optional<ZoneId> result = timeZoneEngine.query(lat, lon);
+
+        // assert
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo("Europe/Moscow");
+    }
+
+    @Test
+    @DisplayName("Координаты Алматы → Asia/Almaty (UTC+5, не UTC)")
+    void should_resolve_almaty_coordinates_to_asia_almaty_timezone() {
+        // arrange — координаты Алматы
+        double lat = 43.2220;
+        double lon = 76.8512;
+
+        // act
+        Optional<ZoneId> result = timeZoneEngine.query(lat, lon);
+
+        // assert
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo("Asia/Almaty");
+    }
+}

--- a/src/test/java/com/plantcare/core/metrics/PrometheusEndpointIntegrationTest.java
+++ b/src/test/java/com/plantcare/core/metrics/PrometheusEndpointIntegrationTest.java
@@ -17,9 +17,10 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Smoke-тест публичной доступности /actuator/prometheus в test-профиле.
+ * Smoke-тест публичной доступности /actuator/prometheus в test-профиле
+ * без admin-кредов.
  *
- * <p>В тестовом конфиге admin-креды не заданы → {@code prometheusSecurityFilterChain}
+ * <p>Когда admin.username/password-bcrypt-hash пусты → {@code prometheusSecurityFilterChain}
  * c {@link org.springframework.boot.autoconfigure.condition.ConditionalOnExpression}
  * не регистрируется, и эндпоинт падает в default chain (permitAll). Это
  * ожидаемое поведение — реальная защита через basic-auth проверяется только
@@ -55,13 +56,19 @@ class PrometheusEndpointIntegrationTest {
         registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
         registry.add("spring.datasource.username", POSTGRES::getUsername);
         registry.add("spring.datasource.password", POSTGRES::getPassword);
+        // Explicitly disable admin panel so prometheusSecurityFilterChain is NOT registered
+        // and /actuator/prometheus remains public (falls through to the default permitAll chain).
+        // This overrides the admin.* defaults set in application-test.yml, which exist to
+        // stabilise context-cache keys for the full-context admin integration tests.
+        registry.add("admin.username", () -> "");
+        registry.add("admin.password-bcrypt-hash", () -> "");
     }
 
     @Autowired private TestRestTemplate restTemplate;
     @Autowired private MetricsService metricsService;
 
     @Test
-    @DisplayName("Endpoint отдаёт 200 OK в test-профиле (без admin-кредов)")
+    @DisplayName("Endpoint отдаёт 200 OK когда admin отключён (пустые креды)")
     void should_return_200_when_admin_disabled_in_test_profile() {
         ResponseEntity<String> response = restTemplate.getForEntity("/actuator/prometheus", String.class);
 

--- a/src/test/java/com/plantcare/core/service/HealthScoreServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/HealthScoreServiceTest.java
@@ -11,17 +11,14 @@ import com.plantcare.core.repository.LocationRepository;
 import com.plantcare.core.repository.PlantRepository;
 import com.plantcare.core.repository.UserRepository;
 import com.plantcare.core.service.HealthScoreService.HealthScore;
+import com.plantcare.bot.support.FixedClockTestConfig;
 import com.plantcare.bot.support.IntegrationTestBase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
 
-import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -53,24 +50,11 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
  * </ul>
  */
 @DisplayName("HealthScoreService — health-score растения (issue #138)")
-@Import(HealthScoreServiceTest.FixedClockConfig.class)
+@Import(FixedClockTestConfig.class)
 class HealthScoreServiceTest extends IntegrationTestBase {
 
-    /**
-     * Фиксированный «сейчас». 00:30 UTC выбрано специально: для восточных TZ
-     * (Almaty UTC+5) локальная дата уже «сегодня», а UTC-полночь окна и
-     * локальная-полночь окна расходятся на день — это и проверяет TZ-кейс.
-     */
-    static final Instant FIXED_NOW = Instant.parse("2026-05-25T00:30:00Z");
-
-    @TestConfiguration
-    static class FixedClockConfig {
-        @Bean
-        @Primary
-        Clock fixedClock() {
-            return Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
-        }
-    }
+    /** Фиксированный «сейчас» — делегируем к общей конфигурации. */
+    static final Instant FIXED_NOW = FixedClockTestConfig.FIXED_NOW;
 
     @Autowired private HealthScoreService service;
 

--- a/src/test/java/com/plantcare/core/service/PlantDiagnosisReportServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/PlantDiagnosisReportServiceTest.java
@@ -14,17 +14,14 @@ import com.plantcare.core.repository.UserRepository;
 import com.plantcare.core.service.PlantDiagnosisReportService.DiagnosisReport;
 import com.plantcare.core.service.PlantDiagnosisReportService.Issue;
 import com.plantcare.core.service.PlantDiagnosisReportService.Severity;
+import com.plantcare.bot.support.FixedClockTestConfig;
 import com.plantcare.bot.support.IntegrationTestBase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
 
-import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -58,24 +55,11 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
  * </ul>
  */
 @DisplayName("PlantDiagnosisReportService — пассивная диагностика (issue #193)")
-@Import(PlantDiagnosisReportServiceTest.FixedClockConfig.class)
+@Import(FixedClockTestConfig.class)
 class PlantDiagnosisReportServiceTest extends IntegrationTestBase {
 
-    /**
-     * Фиксированный «сейчас». 00:30 UTC специально: для восточных TZ (Almaty UTC+5)
-     * локальная дата уже «сегодня», а UTC-полночь и локальная-полночь расходятся на
-     * день — это и эксплуатирует TZ-кейс.
-     */
-    static final Instant FIXED_NOW = Instant.parse("2026-05-25T00:30:00Z");
-
-    @TestConfiguration
-    static class FixedClockConfig {
-        @Bean
-        @Primary
-        Clock fixedClock() {
-            return Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
-        }
-    }
+    /** Фиксированный «сейчас» — делегируем к общей конфигурации. */
+    static final Instant FIXED_NOW = FixedClockTestConfig.FIXED_NOW;
 
     @Autowired private PlantDiagnosisReportService service;
 

--- a/src/test/java/com/plantcare/core/service/TodayApiServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/TodayApiServiceTest.java
@@ -12,21 +12,17 @@ import com.plantcare.core.repository.LocationRepository;
 import com.plantcare.core.repository.PlantRepository;
 import com.plantcare.core.repository.UserRepository;
 import com.plantcare.core.service.TodayApiService.TodayTask;
+import com.plantcare.bot.support.FixedClockTestConfig;
 import com.plantcare.bot.support.IntegrationTestBase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
 
-import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
@@ -39,32 +35,21 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
  * {@code care_history} ↔ {@code care_schedules} проверяются на настоящих записях,
  * а не на моках репозитория.
  *
- * <p>{@link Clock}-бин подменён фиксированным {@link #FIXED_NOW}, чтобы границы окна
- * «сегодня» в TZ юзера были детерминированными.
+ * <p>{@link com.plantcare.bot.support.FixedClockTestConfig} подменяет {@code Clock}-бин
+ * фиксированным моментом {@link FixedClockTestConfig#FIXED_NOW}, чтобы границы окна
+ * «сегодня» в TZ юзера были детерминированными. Общий конфиг обеспечивает совместное
+ * использование {@code ApplicationContext} между тестами (issue #239).
  *
  * <p>Покрывает AC #184: pending; done-сегодня (с уехавшим вперёд nextDueAt);
  * дедуп pending+done; ретро-отметка (вчера) не считается сегодня; cancelled не
  * считается; пустой день; не-UTC TZ на границе суток.
  */
 @DisplayName("TodayApiService — done-фид /today (issue #184)")
-@Import(TodayApiServiceTest.FixedClockConfig.class)
+@Import(FixedClockTestConfig.class)
 class TodayApiServiceTest extends IntegrationTestBase {
 
-    /**
-     * Фиксированный «сейчас» 00:30 UTC: для восточных TZ (Almaty UTC+5) локальная
-     * дата уже «сегодня», а UTC-полночь окна и локальная-полночь расходятся на день —
-     * это проверяет TZ-кейс на границе суток.
-     */
-    static final Instant FIXED_NOW = Instant.parse("2026-05-25T00:30:00Z");
-
-    @TestConfiguration
-    static class FixedClockConfig {
-        @Bean
-        @Primary
-        Clock fixedClock() {
-            return Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
-        }
-    }
+    /** Фиксированный «сейчас» — делегируем к общей конфигурации. */
+    static final Instant FIXED_NOW = FixedClockTestConfig.FIXED_NOW;
 
     @Autowired private TodayApiService service;
 

--- a/src/test/java/com/plantcare/core/service/UserProfileServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/UserProfileServiceTest.java
@@ -1,5 +1,6 @@
 package com.plantcare.core.service;
 
+import com.plantcare.bot.support.FixedClockTestConfig;
 import com.plantcare.bot.support.IntegrationTestBase;
 import com.plantcare.core.domain.CareHistory;
 import com.plantcare.core.domain.CareSchedule;
@@ -19,17 +20,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
 
-import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
@@ -52,24 +48,11 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
  * IANA-tz → IllegalArgumentException.
  */
 @DisplayName("UserProfileService — профиль и настройки /me (issue #182 + #180)")
-@Import(UserProfileServiceTest.FixedClockConfig.class)
+@Import(FixedClockTestConfig.class)
 class UserProfileServiceTest extends IntegrationTestBase {
 
-    /**
-     * Фиксированный «сейчас» 00:30 UTC. Для восточных TZ (Almaty UTC+5) локальная дата
-     * уже «сегодня», а UTC-полночь и локальная-полночь расходятся на день — это и
-     * проверяет граничный TZ-кейс счётчика tasksToday.
-     */
-    static final Instant FIXED_NOW = Instant.parse("2026-05-25T00:30:00Z");
-
-    @TestConfiguration
-    static class FixedClockConfig {
-        @Bean
-        @Primary
-        Clock fixedClock() {
-            return Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
-        }
-    }
+    /** Фиксированный «сейчас» — делегируем к общей конфигурации. */
+    static final Instant FIXED_NOW = FixedClockTestConfig.FIXED_NOW;
 
     @Autowired private UserProfileService service;
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -48,6 +48,15 @@ plantcare:
       package-name: com.plantcare.test
       sha256-cert-fingerprints: AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99
 
+# Issue #239: фиксированные admin-credentials для тестового профиля.
+# Хеш вычислен однократно (bcrypt cost 10, пароль "test-admin-password").
+# Статическое значение гарантирует стабильный ключ кэша ApplicationContext:
+# тесты, использующие только эти свойства, переиспользуют один контекст
+# вместо создания нового контекста на каждый класс.
+admin:
+  username: admin
+  password-bcrypt-hash: "$2y$10$upAKCz5ubY566NaebWzo0Ory65gtZad52dMeGc9u625aXmpcyFiWe"
+
 logging:
   level:
     org.hibernate.SQL: WARN


### PR DESCRIPTION
## Проблема

«Java CI with Maven» на `develop` падал: 18 errors в `com.plantcare.admin.*` —
`OutOfMemoryError: Java heap space` при создании бина `timeZoneEngine`. Каждый
`@SpringBootTest` поднимал свой ApplicationContext со своим `TimeZoneEngine`
(гео-датасет всего мира, сотни МБ). Контексты с разными ключами кэша держали
несколько движков в heap одновременно → к админским тестам heap исчерпан.

## Решение (архитектурно, без отключения тестов)

- **`TimeZoneEngineBean`**: реальный движок — единый ленивый синглтон на весь
  прогон JVM (holder-идиома). Поведение в проде идентично (один полноразмерный
  движок), но тест-форк больше не держит N копий датасета. Это и убирает
  кумулятивный OOM, независимо от числа контекстов.
- **Консолидация контекстов** (ускоряет прогон, уменьшает число форков):
  общий `FixedClockTestConfig` вместо дублей `FixedClockConfig`; статические
  admin-креды в `application-test.yml` вместо случайных bcrypt-хешей через
  `@DynamicPropertySource` → стабильный ключ кэша → переиспользование контекста.
- **`@MockBean TimeZoneEngine`** там, где гео-резолвинг не нужен и контекст всё
  равно отдельный (`AdminDisabledTest`).
- **Новый `TimeZoneEngineBeanIT`**: реальный движок резолвит не-UTC координаты
  (`Europe/Moscow`, `Asia/Almaty`) — выполнено требование CLAUDE.md о тесте с
  реальным движком и не-UTC таймзоной.
- **Сброс login-rate-limiter в `@BeforeEach`** admin-тестов: после консолидации
  контекстов лимитер общий (keyed by IP, MockMvc = 127.0.0.1), и login-флоу-тесты
  больше не наследуют исчерпанный `AdminRateLimitTest` счётчик.
- **`maven.yml`**: убран `-DargLine="-Xmx..."`. Он перезаписывал `argLine`, в
  который `jacoco:prepare-agent` внедряет свой java-agent — без агента покрытие
  не инструментировалось и `jacoco:check` падал бы сразу после починки OOM.
  Синглтон укладывается в дефолтный heap тест-форка, гигабайты больше не нужны.

## Проверка (локально, JDK 21, UTC — как CI)

`mvn package` (точная CI-команда) зелёный:
- **1618 тестов, 0 failures / 0 errors / 0 skipped**
- `TimeZoneEngine` инициализируется **ровно один раз** за прогон (лог: один
  `Initializing with bounding box`)
- **0** `OutOfMemoryError`
- coverage LINE **0.570** ≥ gate 0.49 (не уменьшено)

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)