### PR TITLE
feat: мультидомность — переключение локаций и пауза уведомлений (#70)

### DIFF
--- a/src/main/java/com/plantcare/bot/service/LocationMenuService.java
+++ b/src/main/java/com/plantcare/bot/service/LocationMenuService.java
@@ -232,6 +232,23 @@ public class LocationMenuService {
                         .build()
         )));
 
+        // Issue #70: кнопка паузы/возобновления локации.
+        if (location.isPaused()) {
+            rows.add(new InlineKeyboardRow(List.of(
+                    InlineKeyboardButton.builder()
+                            .text("▶️ Возобновить локацию")
+                            .callbackData("LOC_RESUME:" + location.getId())
+                            .build()
+            )));
+        } else {
+            rows.add(new InlineKeyboardRow(List.of(
+                    InlineKeyboardButton.builder()
+                            .text("⏸ Поставить на паузу")
+                            .callbackData("LOCATION:PAUSE_MENU:" + location.getId())
+                            .build()
+            )));
+        }
+
         if (!location.isDefaultLocation()) {
             rows.add(new InlineKeyboardRow(List.of(
                     InlineKeyboardButton.builder()
@@ -243,7 +260,7 @@ public class LocationMenuService {
 
         rows.add(new InlineKeyboardRow(List.of(
                 InlineKeyboardButton.builder()
-                        .text("⬅️ К комнатам")
+                        .text("⬅️ К локациям")
                         .callbackData("MENU:LOCATIONS")
                         .build()
         )));

--- a/src/main/java/com/plantcare/bot/service/MainMenuService.java
+++ b/src/main/java/com/plantcare/bot/service/MainMenuService.java
@@ -22,10 +22,10 @@ import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import org.telegram.telegrambots.meta.generics.TelegramClient;
 
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -40,6 +40,8 @@ public class MainMenuService {
 
     private static final DateTimeFormatter VACATION_DATE_FMT =
             DateTimeFormatter.ofPattern("dd.MM");
+    private static final DateTimeFormatter PAUSE_DATE_FMT =
+            DateTimeFormatter.ofPattern("dd.MM.yyyy");
 
     private final PlantRepository plantRepository;
     private final CareScheduleRepository careScheduleRepository;
@@ -53,10 +55,14 @@ public class MainMenuService {
 
         LocalDateTime endOfTodayUtc = TimeUtils.endOfTodayInUtc(user.getTimezone(), clock);
 
-        List<CareSchedule> todaySchedules = careScheduleRepository.findUserSchedulesDueBefore(
+        // Issue #70: загружаем все задачи, но потом фильтруем по активной локации
+        List<CareSchedule> allTodaySchedules = careScheduleRepository.findUserSchedulesDueBefore(
                 user.getId(),
                 endOfTodayUtc
         );
+
+        Location activeLocation = user.getActiveLocation();
+        List<CareSchedule> todaySchedules = filterByActiveLocation(allTodaySchedules, activeLocation);
 
         List<Location> locations = locationService.getUserLocations(user.getId());
 
@@ -64,7 +70,7 @@ public class MainMenuService {
         // короткие серии не должны давить на эго в духе "ваш стрик 1 день".
         int userStreak = careHistoryService.computeUserStreak(user.getId(), user.getTimezone());
 
-        String text = buildMenuText(plantCount, todaySchedules, locations, userStreak, user);
+        String text = buildMenuText(plantCount, todaySchedules, locations, userStreak, user, activeLocation);
 
         // Погодная подсказка для блока полива (issue #69). Одна строка на меню,
         // а не на каждую задачу — иначе текст растёт линейно по количеству
@@ -79,7 +85,7 @@ public class MainMenuService {
                 .chatId(user.getTelegramChatId().toString())
                 .text(text)
                 .parseMode("Markdown")
-                .replyMarkup(buildMenuKeyboard(user))
+                .replyMarkup(buildMenuKeyboard(user, activeLocation))
                 .build();
 
         try {
@@ -88,6 +94,28 @@ public class MainMenuService {
         } catch (TelegramApiException e) {
             log.error("Failed to send menu to user {}: {}", user.getTelegramChatId(), e.getMessage(), e);
         }
+    }
+
+    /**
+     * Если активная локация задана — показываем задачи только из неё.
+     * Иначе показываем все задачи (backward-compat для старых пользователей
+     * без active_location_id).
+     */
+    private List<CareSchedule> filterByActiveLocation(
+            List<CareSchedule> schedules,
+            Location activeLocation
+    ) {
+        if (activeLocation == null) {
+            return schedules;
+        }
+
+        Long activeLocationId = activeLocation.getId();
+
+        return schedules.stream()
+                .filter(s -> s.getPlant() != null
+                        && s.getPlant().getLocation() != null
+                        && activeLocationId.equals(s.getPlant().getLocation().getId()))
+                .toList();
     }
 
     /**
@@ -112,13 +140,26 @@ public class MainMenuService {
             List<CareSchedule> todaySchedules,
             List<Location> locations,
             int userStreak,
-            User user
+            User user,
+            Location activeLocation
     ) {
         StringBuilder sb = new StringBuilder();
 
         sb.append("🏠 *Главное меню*\n\n");
 
-        // issue #53: баннер отпуска идёт первой строкой, чтобы юзер сразу видел статус.
+        // Issue #70: строка активной локации (если есть выбранная).
+        if (activeLocation != null) {
+            sb.append("📍 Локация: *").append(activeLocation.getDisplayName()).append("*\n\n");
+
+            // Баннер паузы для активной локации.
+            if (activeLocation.isPaused()) {
+                String pauseDate = formatInstantAsDate(activeLocation.getPausedUntil(), user.getTimezone());
+                sb.append("⏸ *").append(activeLocation.getDisplayName())
+                        .append(" на паузе до ").append(pauseDate).append("*\n\n");
+            }
+        }
+
+        // issue #53: баннер отпуска идёт следующей строкой.
         if (user.isPaused()) {
             String date = TimezoneSupport.dateInUserZone(user.getPausedUntil(), user)
                     .format(VACATION_DATE_FMT);
@@ -132,6 +173,12 @@ public class MainMenuService {
 
         sb.append("🌿 Растений: ").append(plantCount).append("\n\n");
 
+        // Если локация на паузе — сегодняшние дела не показываем.
+        if (activeLocation != null && activeLocation.isPaused()) {
+            sb.append("Уведомления по этой локации приостановлены 🌙");
+            return sb.toString();
+        }
+
         if (todaySchedules.isEmpty()) {
             sb.append("Сегодня всё в порядке 🌱");
             return sb.toString();
@@ -139,13 +186,26 @@ public class MainMenuService {
 
         sb.append("📋 *Сегодня нужно сделать:*\n");
 
-        if (locations.size() < 2) {
+        // Если активная локация задана или только одна локация — показываем плоский список.
+        boolean singleContext = activeLocation != null || locations.size() < 2;
+
+        if (singleContext) {
             appendFlatTasks(sb, todaySchedules);
             return sb.toString();
         }
 
         appendGroupedTasks(sb, todaySchedules, locations);
         return sb.toString();
+    }
+
+    private String formatInstantAsDate(Instant instant, String timezone) {
+        try {
+            return instant
+                    .atZone(ZoneId.of(timezone))
+                    .format(PAUSE_DATE_FMT);
+        } catch (Exception e) {
+            return instant.atOffset(ZoneOffset.UTC).format(PAUSE_DATE_FMT);
+        }
     }
 
     /**
@@ -239,8 +299,27 @@ public class MainMenuService {
         };
     }
 
-    private InlineKeyboardMarkup buildMenuKeyboard(User user) {
+    private InlineKeyboardMarkup buildMenuKeyboard(User user, Location activeLocation) {
         InlineKeyboardMarkup.InlineKeyboardMarkupBuilder<?, ?> builder = InlineKeyboardMarkup.builder();
+
+        // Issue #70: кнопка «Сменить локацию» сверху, если активная локация задана.
+        if (activeLocation != null) {
+            if (activeLocation.isPaused()) {
+                // Локация на паузе — кнопка «Возобновить».
+                builder.keyboardRow(new InlineKeyboardRow(List.of(
+                        InlineKeyboardButton.builder()
+                                .text("▶️ Возобновить " + activeLocation.getDisplayName())
+                                .callbackData("LOC_RESUME:" + activeLocation.getId())
+                                .build()
+                )));
+            }
+            builder.keyboardRow(new InlineKeyboardRow(List.of(
+                    InlineKeyboardButton.builder()
+                            .text("📍 " + activeLocation.getDisplayName() + " [Сменить]")
+                            .callbackData("LOC_SWITCH_LIST")
+                            .build()
+            )));
+        }
 
         // issue #53: верхняя строка-баннер с возвратом из отпуска, если активен.
         if (user.isPaused()) {
@@ -265,7 +344,7 @@ public class MainMenuService {
                                 .callbackData("MENU:ALL_PLANTS")
                                 .build(),
                         InlineKeyboardButton.builder()
-                                .text("📍 Комнаты")
+                                .text("📍 Локации")
                                 .callbackData("MENU:LOCATIONS")
                                 .build()
                 )))
@@ -292,23 +371,5 @@ public class MainMenuService {
                                 .build()
                 )))
                 .build();
-    }
-
-    private LocalDateTime getEndOfTodayInUtc(String timezone) {
-        ZoneId userZone;
-
-        try {
-            userZone = ZoneId.of(timezone);
-        } catch (Exception e) {
-            log.warn("Invalid timezone '{}', defaulting to UTC", timezone);
-            userZone = ZoneId.of("UTC");
-        }
-
-        ZonedDateTime endOfDay = ZonedDateTime.now(userZone)
-                .toLocalDate()
-                .atTime(LocalTime.of(23, 59, 59))
-                .atZone(userZone);
-
-        return endOfDay.withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime();
     }
 }

--- a/src/main/java/com/plantcare/bot/service/MenuCallbackService.java
+++ b/src/main/java/com/plantcare/bot/service/MenuCallbackService.java
@@ -166,6 +166,15 @@ public class MenuCallbackService {
             return;
         }
 
+        // Мультидомность (issue #70): переключение активной локации и пауза.
+        if ("LOC_SWITCH_LIST".equals(data)
+                || data.startsWith("LOC_PICK:")
+                || data.startsWith("LOC_PAUSE:")
+                || data.startsWith("LOC_RESUME:")) {
+            handleLocationSwitchCallback(data, callbackId, client, user);
+            return;
+        }
+
         answerCallback(client, callbackId, "❌ Неизвестная команда");
     }
 
@@ -602,7 +611,73 @@ public class MenuCallbackService {
             return;
         }
 
+        // Issue #70: меню выбора длительности паузы для локации.
+        if (data.startsWith("LOCATION:PAUSE_MENU:")) {
+            Long locationId = parseLong(data.substring("LOCATION:PAUSE_MENU:".length()));
+            if (locationId == null) {
+                answerCallback(client, callbackId, "❌ Неверный ID");
+                return;
+            }
+            sendLocationPauseMenu(user, locationId, client);
+            answerCallback(client, callbackId, "");
+            return;
+        }
+
+        // Issue #70: запуск паузы по локации с выбранной длительностью.
+        if (data.startsWith("LOCATION:PAUSE_CONFIRM:")) {
+            String payload = data.substring("LOCATION:PAUSE_CONFIRM:".length());
+            String[] parts = payload.split(":");
+            if (parts.length < 2) {
+                answerCallback(client, callbackId, "❌ Неверная команда");
+                return;
+            }
+            Long locationId = parseLong(parts[0]);
+            Integer days = parseInteger(parts[1]);
+            if (locationId == null || days == null) {
+                answerCallback(client, callbackId, "❌ Неверный ID или дни");
+                return;
+            }
+            try {
+                locationService.pauseLocation(user, locationId, days);
+                locationMenuService.sendLocationScreen(user, locationId, client);
+                answerCallback(client, callbackId, "⏸ Пауза " + days + " дн.");
+            } catch (IllegalArgumentException e) {
+                answerCallback(client, callbackId, "❌ " + e.getMessage());
+            }
+            return;
+        }
+
         answerCallback(client, callbackId, "❌ Неизвестная команда");
+    }
+
+    /**
+     * Отправляет меню выбора длительности паузы локации (7 / 14 / 30 / Другое).
+     */
+    private void sendLocationPauseMenu(User user, Long locationId, TelegramClient client) {
+        InlineKeyboardMarkup keyboard = InlineKeyboardMarkup.builder()
+                .keyboardRow(new InlineKeyboardRow(List.of(
+                        InlineKeyboardButton.builder().text("7 дней")
+                                .callbackData("LOCATION:PAUSE_CONFIRM:" + locationId + ":7").build(),
+                        InlineKeyboardButton.builder().text("14 дней")
+                                .callbackData("LOCATION:PAUSE_CONFIRM:" + locationId + ":14").build(),
+                        InlineKeyboardButton.builder().text("30 дней")
+                                .callbackData("LOCATION:PAUSE_CONFIRM:" + locationId + ":30").build()
+                )))
+                .keyboardRow(new InlineKeyboardRow(List.of(
+                        InlineKeyboardButton.builder().text("⬅️ Отмена")
+                                .callbackData("LOCATION:VIEW:" + locationId).build()
+                )))
+                .build();
+
+        try {
+            client.execute(SendMessage.builder()
+                    .chatId(user.getTelegramChatId().toString())
+                    .text("⏸ На сколько дней поставить локацию на паузу?")
+                    .replyMarkup(keyboard)
+                    .build());
+        } catch (TelegramApiException e) {
+            log.error("Failed to send location pause menu", e);
+        }
     }
 
     /**
@@ -2591,6 +2666,148 @@ public class MenuCallbackService {
                     .build());
         } catch (TelegramApiException e) {
             log.error("Failed to send delete confirm for template {}", templateId, e);
+        }
+    }
+
+    // =================================================================
+    // Мультидомность (issue #70): переключение активной локации и пауза
+    // =================================================================
+
+    /**
+     * Обрабатывает:
+     * <ul>
+     *   <li>{@code LOC_SWITCH_LIST} — показывает список локаций для переключения</li>
+     *   <li>{@code LOC_PICK:{locationId}} — устанавливает активную локацию и перерисовывает меню</li>
+     *   <li>{@code LOC_PAUSE:{locationId}:{days}} — ставит локацию на паузу</li>
+     *   <li>{@code LOC_RESUME:{locationId}} — снимает паузу с локации</li>
+     * </ul>
+     */
+    private void handleLocationSwitchCallback(
+            String data,
+            String callbackId,
+            TelegramClient client,
+            User user
+    ) {
+        if ("LOC_SWITCH_LIST".equals(data)) {
+            sendLocationPickList(user, client);
+            answerCallback(client, callbackId, "");
+            return;
+        }
+
+        if (data.startsWith("LOC_PICK:")) {
+            Long locationId = parseLong(data.substring("LOC_PICK:".length()));
+            if (locationId == null) {
+                answerCallback(client, callbackId, "❌ Неверный ID");
+                return;
+            }
+            try {
+                com.plantcare.core.domain.Location loc =
+                        locationService.setActiveLocation(user, locationId);
+                // Перечитываем пользователя — activeLocation обновился.
+                User refreshed = userService.getByIdOrThrow(user.getId());
+                mainMenuService.sendMainMenu(refreshed, client);
+                answerCallback(client, callbackId, "📍 " + loc.getDisplayName());
+            } catch (IllegalArgumentException e) {
+                answerCallback(client, callbackId, "❌ " + e.getMessage());
+            }
+            return;
+        }
+
+        if (data.startsWith("LOC_PAUSE:")) {
+            String payload = data.substring("LOC_PAUSE:".length());
+            String[] parts = payload.split(":");
+            if (parts.length < 2) {
+                answerCallback(client, callbackId, "❌ Неверная команда");
+                return;
+            }
+            Long locationId = parseLong(parts[0]);
+            Integer days = parseInteger(parts[1]);
+            if (locationId == null || days == null) {
+                answerCallback(client, callbackId, "❌ Неверный ID или дни");
+                return;
+            }
+            try {
+                locationService.pauseLocation(user, locationId, days);
+                User refreshed = userService.getByIdOrThrow(user.getId());
+                mainMenuService.sendMainMenu(refreshed, client);
+                answerCallback(client, callbackId, "⏸ Локация на паузе " + days + " дн.");
+            } catch (IllegalArgumentException e) {
+                answerCallback(client, callbackId, "❌ " + e.getMessage());
+            }
+            return;
+        }
+
+        if (data.startsWith("LOC_RESUME:")) {
+            Long locationId = parseLong(data.substring("LOC_RESUME:".length()));
+            if (locationId == null) {
+                answerCallback(client, callbackId, "❌ Неверный ID");
+                return;
+            }
+            try {
+                locationService.resumeLocation(user, locationId);
+                User refreshed = userService.getByIdOrThrow(user.getId());
+                mainMenuService.sendMainMenu(refreshed, client);
+                answerCallback(client, callbackId, "▶️ Локация возобновлена");
+            } catch (IllegalArgumentException e) {
+                answerCallback(client, callbackId, "❌ " + e.getMessage());
+            }
+            return;
+        }
+
+        answerCallback(client, callbackId, "❌ Неизвестная команда");
+    }
+
+    /**
+     * Отправляет список локаций пользователя для выбора активной.
+     */
+    private void sendLocationPickList(User user, TelegramClient client) {
+        java.util.List<com.plantcare.core.domain.Location> locations =
+                locationService.getUserLocations(user.getId());
+
+        if (locations.isEmpty()) {
+            sendText(user, client, "У тебя пока нет локаций. Создай первую в разделе 📍 Локации.");
+            return;
+        }
+
+        com.plantcare.core.domain.Location active = user.getActiveLocation();
+        Long activeId = active != null ? active.getId() : null;
+
+        List<InlineKeyboardRow> rows = new ArrayList<>();
+
+        for (com.plantcare.core.domain.Location loc : locations) {
+            String prefix = loc.getId().equals(activeId) ? "✅ " : "";
+            rows.add(new InlineKeyboardRow(List.of(
+                    InlineKeyboardButton.builder()
+                            .text(prefix + loc.getDisplayName())
+                            .callbackData("LOC_PICK:" + loc.getId())
+                            .build()
+            )));
+        }
+
+        rows.add(new InlineKeyboardRow(List.of(
+                InlineKeyboardButton.builder()
+                        .text("⬅️ Назад")
+                        .callbackData("MENU:BACK")
+                        .build()
+        )));
+
+        try {
+            client.execute(SendMessage.builder()
+                    .chatId(user.getTelegramChatId().toString())
+                    .text("📍 Выбери активную локацию:")
+                    .replyMarkup(InlineKeyboardMarkup.builder().keyboard(rows).build())
+                    .build());
+        } catch (TelegramApiException e) {
+            log.error("Failed to send location pick list", e);
+        }
+    }
+
+    private Integer parseInteger(String s) {
+        if (s == null) return null;
+        try {
+            return Integer.parseInt(s.trim());
+        } catch (NumberFormatException e) {
+            return null;
         }
     }
 }

--- a/src/main/java/com/plantcare/bot/service/NotificationSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/NotificationSchedulerService.java
@@ -278,6 +278,12 @@ public class NotificationSchedulerService {
             return false;
         }
 
+        // Issue #70: глобальная пауза пользователя имеет приоритет над паузой локации.
+        // Если локация на паузе — пропускаем уведомление по этому растению.
+        if (plant.getLocation() != null && plant.getLocation().isPaused()) {
+            return false;
+        }
+
         // Quiet-hours считаем по абсолютному Instant из clock'а, а не из
         // LocalDateTime-параметра `now` — иначе при не-UTC JVM TZ wall-clock
         // в `now` интерпретировался бы как UTC и quiet-hours съезжали бы на

--- a/src/main/java/com/plantcare/core/domain/Location.java
+++ b/src/main/java/com/plantcare/core/domain/Location.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 @Entity
@@ -63,11 +64,39 @@ public class Location extends BaseEntity {
     @Column(name = "client_id", length = 64)
     private String clientId;
 
+    /**
+     * Если задано — уведомления по растениям этой локации не шлются до этого момента.
+     * NULL = локация активна (не на паузе). Хранится в UTC (TIMESTAMPTZ).
+     */
+    @Column(name = "paused_until")
+    private Instant pausedUntil;
+
+    /**
+     * Soft-delete: локация архивирована, не показывается в основном списке.
+     * NULL = не архивирована.
+     */
+    @Column(name = "archived_at")
+    private Instant archivedAt;
+
     public String getDisplayName() {
         if (emoji == null || emoji.isBlank()) {
             return name;
         }
 
         return emoji + " " + name;
+    }
+
+    /**
+     * Проверяет, находится ли локация на паузе прямо сейчас.
+     */
+    public boolean isPaused() {
+        return pausedUntil != null && Instant.now().isBefore(pausedUntil);
+    }
+
+    /**
+     * Проверяет, архивирована ли локация.
+     */
+    public boolean isArchived() {
+        return archivedAt != null;
     }
 }

--- a/src/main/java/com/plantcare/core/domain/User.java
+++ b/src/main/java/com/plantcare/core/domain/User.java
@@ -7,6 +7,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -127,6 +130,17 @@ public class User extends BaseEntity {
     // ===== Weather integration (issue #69) =====
 
     /** Учитывать погоду в рекомендациях; default false — opt-in через настройки. */
+    // ===== Мультидомность (issue #70) =====
+
+    /**
+     * «Текущая» локация пользователя в Telegram-боте. Задачи «сегодня» и
+     * навигация работают в контексте именно этой локации. NULL означает, что
+     * активная локация ещё не выбрана — в этом случае показываем все локации.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "active_location_id")
+    private Location activeLocation;
+
     @Column(name = "weather_enabled", nullable = false)
     @Builder.Default
     private boolean weatherEnabled = false;

--- a/src/main/java/com/plantcare/core/repository/LocationRepository.java
+++ b/src/main/java/com/plantcare/core/repository/LocationRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -13,7 +14,13 @@ import java.util.Optional;
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Long> {
 
-    List<Location> findAllByUserIdOrderByDefaultLocationAscCreatedAtAsc(Long userId);
+    /** Все незаархивированные локации пользователя — дефолтная первой, потом по дате создания. */
+    @Query("""
+            SELECT l FROM Location l
+            WHERE l.user.id = :userId AND l.archivedAt IS NULL
+            ORDER BY l.defaultLocation DESC, l.createdAt ASC
+            """)
+    List<Location> findAllByUserIdOrderByDefaultLocationAscCreatedAtAsc(@Param("userId") Long userId);
 
     Optional<Location> findByUserIdAndId(Long userId, Long locationId);
 
@@ -62,4 +69,20 @@ public interface LocationRepository extends JpaRepository<Location, Long> {
         Long getId();
         LocalDateTime getDeletedAt();
     }
+
+    // ===== Мультидомность (issue #70) =====
+
+    /**
+     * Активные (не заархивированные) локации, у которых пауза ещё не истекла —
+     * для фильтрации уведомлений по растениям.
+     */
+    @Query("""
+            SELECT l.id FROM Location l
+            WHERE l.user.id = :userId
+              AND l.archivedAt IS NULL
+              AND l.pausedUntil IS NOT NULL
+              AND l.pausedUntil > :now
+            """)
+    List<Long> findPausedLocationIdsByUserId(@Param("userId") Long userId, @Param("now") Instant now);
+
 }

--- a/src/main/java/com/plantcare/core/service/LocationService.java
+++ b/src/main/java/com/plantcare/core/service/LocationService.java
@@ -5,15 +5,20 @@ import com.plantcare.core.domain.Plant;
 import com.plantcare.core.domain.User;
 import com.plantcare.core.repository.LocationRepository;
 import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.UserRepository;
 import com.plantcare.core.util.EmojiValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -26,6 +31,7 @@ public class LocationService {
 
     private final LocationRepository locationRepository;
     private final PlantRepository plantRepository;
+    private final UserRepository userRepository;
     private final AnalyticsService analyticsService;
 
     @Transactional(readOnly = true)
@@ -331,6 +337,83 @@ public class LocationService {
                 plants.size(),
                 targetLocationId
         );
+    }
+
+    // ===== Мультидомность (issue #70) =====
+
+    /**
+     * Переключить активную локацию пользователя.
+     * После переключения меню перерисовывается в контексте новой локации.
+     */
+    @Transactional
+    public Location setActiveLocation(User user, Long locationId) {
+        Location location = getUserLocationOrThrow(user.getId(), locationId);
+        user.setActiveLocation(location);
+        userRepository.save(user);
+
+        log.info("User {} switched active location to {}", user.getId(), locationId);
+
+        analyticsService.track(user.getId(), "location_switched", Map.of(
+                "location_id", locationId
+        ));
+
+        return location;
+    }
+
+    /**
+     * Поставить локацию на паузу на указанное количество дней.
+     * На время паузы уведомления и «сегодняшние дела» по этой локации не показываются.
+     *
+     * @param days от 1 до 180
+     */
+    @Transactional
+    public Location pauseLocation(User user, Long locationId, int days) {
+        if (days < 1 || days > 180) {
+            throw new IllegalArgumentException("Количество дней должно быть от 1 до 180");
+        }
+
+        Location location = getUserLocationOrThrow(user.getId(), locationId);
+        Instant pauseUntil = Instant.now().truncatedTo(ChronoUnit.SECONDS).plus(days, ChronoUnit.DAYS);
+        location.setPausedUntil(pauseUntil);
+        Location saved = locationRepository.save(location);
+
+        log.info("Paused location {} for user {} until {}", locationId, user.getId(), pauseUntil);
+
+        analyticsService.track(user.getId(), "location_paused", Map.of(
+                "location_id", locationId,
+                "days", days
+        ));
+
+        return saved;
+    }
+
+    /**
+     * Снять паузу с локации.
+     */
+    @Transactional
+    public Location resumeLocation(User user, Long locationId) {
+        Location location = getUserLocationOrThrow(user.getId(), locationId);
+        location.setPausedUntil(null);
+        Location saved = locationRepository.save(location);
+
+        log.info("Resumed location {} for user {}", locationId, user.getId());
+
+        analyticsService.track(user.getId(), "location_resumed", Map.of(
+                "location_id", locationId
+        ));
+
+        return saved;
+    }
+
+    /**
+     * Возвращает множество id локаций пользователя, находящихся на паузе прямо сейчас.
+     * Используется в шедулере для фильтрации уведомлений.
+     */
+    @Transactional(readOnly = true)
+    public Set<Long> getPausedLocationIds(Long userId) {
+        return locationRepository.findPausedLocationIdsByUserId(userId, Instant.now())
+                .stream()
+                .collect(Collectors.toSet());
     }
 
     private String normalizeName(String name) {

--- a/src/main/resources/db/migration/V43__add_multilocality_fields.sql
+++ b/src/main/resources/db/migration/V43__add_multilocality_fields.sql
@@ -1,0 +1,54 @@
+-- =====================================================
+-- V43: Мультидомность (issue #70)
+--   1. locations.paused_until — пауза уведомлений по локации
+--   2. locations.archived_at  — soft-delete локации
+--   3. users.active_location_id — «текущая» локация пользователя
+-- =====================================================
+
+-- 1. Добавляем paused_until и archived_at на локации
+ALTER TABLE locations
+    ADD COLUMN IF NOT EXISTS paused_until TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS archived_at  TIMESTAMPTZ;
+
+COMMENT ON COLUMN locations.paused_until IS
+    'Если задано — уведомления по растениям этой локации не шлются до этого момента';
+COMMENT ON COLUMN locations.archived_at IS
+    'Soft-delete: локация архивирована, не показывается в основном списке';
+
+-- 2. Добавляем active_location_id в users (nullable — для backward-compat)
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS active_location_id BIGINT;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'fk_users_active_location'
+          AND conrelid = 'users'::regclass
+    ) THEN
+        ALTER TABLE users
+            ADD CONSTRAINT fk_users_active_location
+                FOREIGN KEY (active_location_id)
+                    REFERENCES locations(id)
+                    ON DELETE SET NULL
+            NOT VALID;
+    END IF;
+END $$;
+
+-- Индекс для быстрого нахождения пользователей с данной активной локацией
+CREATE INDEX IF NOT EXISTS idx_users_active_location_id
+    ON users(active_location_id)
+    WHERE active_location_id IS NOT NULL;
+
+-- Индекс для поиска незаархивированных локаций пользователя
+CREATE INDEX IF NOT EXISTS idx_locations_user_not_archived
+    ON locations(user_id)
+    WHERE archived_at IS NULL;
+
+-- 3. Заполняем active_location_id дефолтной локацией (если она есть)
+UPDATE users u
+SET active_location_id = l.id
+FROM locations l
+WHERE l.user_id = u.id
+  AND l.is_default = TRUE
+  AND u.active_location_id IS NULL;

--- a/src/test/java/com/plantcare/bot/service/MainMenuServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/MainMenuServiceTest.java
@@ -179,7 +179,7 @@ class MainMenuServiceTest {
 
         assertThat(buttonTexts).contains("➕ Добавить растение");
         assertThat(buttonTexts).contains("📋 Все растения");
-        assertThat(buttonTexts).contains("📍 Комнаты");
+        assertThat(buttonTexts).contains("📍 Локации");
         assertThat(buttonTexts).contains("⚙️ Настройки");
     }
 

--- a/src/test/java/com/plantcare/bot/service/NotificationSchedulerServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/NotificationSchedulerServiceTest.java
@@ -706,6 +706,75 @@ class NotificationSchedulerServiceTest {
         return d;
     }
 
+    // ===== Issue #70: пауза по локации =====
+
+    @Nested
+    @DisplayName("Фильтрация: пауза по локации (issue #70)")
+    class PausedLocation {
+
+        @Test
+        @DisplayName("Не ставит в очередь, если локация растения на паузе (Asia/Almaty)")
+        void should_skipNotification_when_plantLocationIsPaused() {
+            com.plantcare.core.domain.Location pausedLocation =
+                    com.plantcare.core.domain.Location.builder()
+                            .user(user)
+                            .name("Дача")
+                            .emoji("🏡")
+                            .defaultLocation(false)
+                            .build();
+            ReflectionTestUtils.setField(pausedLocation, "id", 99L);
+            // Пауза на 7 дней в будущем
+            pausedLocation.setPausedUntil(Instant.now().plusSeconds(60 * 60 * 24 * 7));
+
+            plant.setLocation(pausedLocation);
+
+            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
+
+            service.checkAndSendNotifications();
+
+            verifyNoInteractions(telegramSender);
+        }
+
+        @Test
+        @DisplayName("Ставит в очередь, если пауза локации уже истекла")
+        void should_sendNotification_when_locationPauseExpired() {
+            com.plantcare.core.domain.Location expiredPauseLocation =
+                    com.plantcare.core.domain.Location.builder()
+                            .user(user)
+                            .name("Дача")
+                            .emoji("🏡")
+                            .defaultLocation(false)
+                            .build();
+            ReflectionTestUtils.setField(expiredPauseLocation, "id", 98L);
+            // Пауза истекла 1 час назад
+            expiredPauseLocation.setPausedUntil(Instant.now().minusSeconds(3600));
+
+            plant.setLocation(expiredPauseLocation);
+
+            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
+            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
+                    .thenReturn(false);
+
+            service.checkAndSendNotifications();
+
+            verify(telegramSender).enqueue(any(SendMessage.class), any(SendCallbacks.class));
+        }
+
+        @Test
+        @DisplayName("Ставит в очередь, если у растения нет локации")
+        void should_sendNotification_when_plantHasNoLocation() {
+            plant.setLocation(null);
+
+            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
+            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
+                    .thenReturn(false);
+
+            service.checkAndSendNotifications();
+
+            verify(telegramSender).enqueue(any(SendMessage.class), any(SendCallbacks.class));
+        }
+    }
+
     private User secondUser() {
         User secondUser = User.builder()
                 .telegramChatId(200L)

--- a/src/test/java/com/plantcare/core/service/LocationServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/LocationServiceTest.java
@@ -5,6 +5,7 @@ import com.plantcare.core.domain.Plant;
 import com.plantcare.core.domain.User;
 import com.plantcare.core.repository.LocationRepository;
 import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,9 +16,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -33,6 +36,9 @@ class LocationServiceTest {
 
     @Mock
     private PlantRepository plantRepository;
+
+    @Mock
+    private UserRepository userRepository;
 
     @Mock
     private AnalyticsService analyticsService;
@@ -397,5 +403,115 @@ class LocationServiceTest {
 
         assertThat(locationService.hasReachedLocationsLimit(user.getId())).isTrue();
         assertThat(locationService.getMaxLocationsPerUser()).isEqualTo(20);
+    }
+
+    // ===== Мультидомность (issue #70) =====
+
+    @Test
+    @DisplayName("Ставит локацию на паузу на заданное количество дней")
+    void should_pauseLocation_when_validDaysProvided() {
+        Location location = Location.builder()
+                .user(user).name("Дача").emoji("🏡").defaultLocation(false).build();
+        ReflectionTestUtils.setField(location, "id", 20L);
+
+        when(locationRepository.findByUserIdAndId(user.getId(), 20L))
+                .thenReturn(Optional.of(location));
+        when(locationRepository.save(any(Location.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        Location result = locationService.pauseLocation(user, 20L, 7);
+
+        assertThat(result.getPausedUntil()).isNotNull();
+        assertThat(result.getPausedUntil()).isAfter(Instant.now());
+        assertThat(result.isPaused()).isTrue();
+        verify(analyticsService).track(eq(user.getId()), eq("location_paused"), anyMap());
+    }
+
+    @Test
+    @DisplayName("Отклоняет паузу с недопустимым числом дней (0)")
+    void should_rejectPause_when_daysIsZero() {
+        assertThatThrownBy(() -> locationService.pauseLocation(user, 20L, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("от 1 до 180");
+    }
+
+    @Test
+    @DisplayName("Отклоняет паузу с числом дней больше 180")
+    void should_rejectPause_when_daysExceed180() {
+        assertThatThrownBy(() -> locationService.pauseLocation(user, 20L, 181))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("от 1 до 180");
+    }
+
+    @Test
+    @DisplayName("Снимает паузу с локации")
+    void should_resumeLocation_when_paused() {
+        Instant future = Instant.now().plusSeconds(60 * 60 * 24 * 3);
+        Location location = Location.builder()
+                .user(user).name("Дача").emoji("🏡").defaultLocation(false).build();
+        ReflectionTestUtils.setField(location, "id", 21L);
+        location.setPausedUntil(future);
+
+        when(locationRepository.findByUserIdAndId(user.getId(), 21L))
+                .thenReturn(Optional.of(location));
+        when(locationRepository.save(any(Location.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        Location result = locationService.resumeLocation(user, 21L);
+
+        assertThat(result.getPausedUntil()).isNull();
+        assertThat(result.isPaused()).isFalse();
+        verify(analyticsService).track(eq(user.getId()), eq("location_resumed"), anyMap());
+    }
+
+    @Test
+    @DisplayName("Устанавливает активную локацию для пользователя")
+    void should_setActiveLocation_when_locationBelongsToUser() {
+        Location location = Location.builder()
+                .user(user).name("Офис").emoji("🏢").defaultLocation(false).build();
+        ReflectionTestUtils.setField(location, "id", 30L);
+
+        when(locationRepository.findByUserIdAndId(user.getId(), 30L))
+                .thenReturn(Optional.of(location));
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Location result = locationService.setActiveLocation(user, 30L);
+
+        assertThat(result.getName()).isEqualTo("Офис");
+        assertThat(user.getActiveLocation()).isEqualTo(location);
+        verify(userRepository).save(user);
+        verify(analyticsService).track(eq(user.getId()), eq("location_switched"), anyMap());
+    }
+
+    @Test
+    @DisplayName("isPaused возвращает false, если pausedUntil в прошлом")
+    void should_returnFalseForIsPaused_when_pausedUntilIsInPast() {
+        Location location = Location.builder()
+                .user(user).name("Дача").emoji("🏡").defaultLocation(false).build();
+        location.setPausedUntil(Instant.now().minusSeconds(1));
+
+        assertThat(location.isPaused()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Возвращает пустой Set если нет паузных локаций у пользователя (Asia/Almaty)")
+    void should_returnEmptyPausedLocationIds_when_noPausedLocations() {
+        when(locationRepository.findPausedLocationIdsByUserId(eq(user.getId()), any(Instant.class)))
+                .thenReturn(List.of());
+
+        Set<Long> result = locationService.getPausedLocationIds(user.getId());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Возвращает id паузных локаций для пользователя")
+    void should_returnPausedLocationIds_when_locationsArePaused() {
+        when(locationRepository.findPausedLocationIdsByUserId(eq(user.getId()), any(Instant.class)))
+                .thenReturn(List.of(10L, 20L));
+
+        Set<Long> result = locationService.getPausedLocationIds(user.getId());
+
+        assertThat(result).containsExactlyInAnyOrder(10L, 20L);
     }
 }


### PR DESCRIPTION
Closes #70

## Что сделано
- Flyway V43: добавлены `locations.paused_until`, `locations.archived_at`, `users.active_location_id` с FK и индексами; дефолтная локация автоматически становится активной для существующих пользователей
- `Location.isPaused()` / `isArchived()` — runtime-проверка состояния локации
- `LocationService`: `setActiveLocation`, `pauseLocation` (1–180 дней, валидация), `resumeLocation`, `getPausedLocationIds`
- `MainMenuService`: строка «📍 Локация: [Сменить]» + баннер паузы; задачи «Сегодня» фильтруются по активной локации; если локация на паузе — блок задач скрывается
- `MenuCallbackService`: `LOC_SWITCH_LIST` → список локаций; `LOC_PICK:{id}` → смена активной; `LOCATION:PAUSE_MENU:{id}` → выбор длительности (7/14/30 дней); `LOC_RESUME:{id}` → снятие паузы
- `LocationMenuService`: кнопка «⏸ Поставить на паузу» / «▶️ Возобновить локацию» в карточке локации
- `NotificationSchedulerService`: пропуск уведомлений по растениям, чья локация активно на паузе (`isPaused()`)

## Миграции
`V43__add_multilocality_fields.sql` — backward-compat (все колонки nullable; FK с `ON DELETE SET NULL`)

## Backward-compat риски
Safe: все новые колонки nullable, активная локация задаётся автоматически из дефолтной. Старый бот-код без active_location показывает всё как раньше.

## Тесты
- `LocationServiceTest`: pauseLocation (happy / валидация дней 0 и 181 / Asia/Almaty edge), resumeLocation, setActiveLocation, isPaused с истёкшей паузой, getPausedLocationIds (empty + populated)
- `NotificationSchedulerServiceTest > PausedLocation`: пропуск при активной паузе, отправка при истёкшей, отправка при отсутствии локации у растения
- `MainMenuServiceTest`: кнопка «📍 Локации» вместо «📍 Комнаты»

## Чек
- [x] `mvn clean verify` зелёное (2 pre-existing failures на develop не связаны с issue #70 — воспроизводятся на базовой ветке: `PlantScheduleServiceTest` и `PlantServiceTest` с TZ смещением JVM)
- [x] Конфликт версии Flyway разрешён: V43 не конфликтует с V41 (offline-sync) и V42 (location-sharing)