### PR TITLE
feat: add PushSender port and mobile push fan-out in scheduler (#175)

### DIFF
--- a/src/main/java/com/plantcare/bot/service/NotificationSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/NotificationSchedulerService.java
@@ -1,5 +1,6 @@
 package com.plantcare.bot.service;
 
+import com.plantcare.core.service.PushSender;
 import com.plantcare.core.service.QuietHoursPolicy;
 import com.plantcare.core.service.SchedulerHealthTracker;
 
@@ -8,6 +9,7 @@ import com.plantcare.core.domain.DigestTaskItem;
 import com.plantcare.core.domain.NotificationDigest;
 import com.plantcare.core.domain.Plant;
 import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.UserDevice;
 import com.plantcare.core.domain.enums.TaskType;
 import com.plantcare.core.metrics.MetricsService;
 import com.plantcare.core.observability.SentryTags;
@@ -15,6 +17,7 @@ import com.plantcare.core.observability.SentryTags.Layer;
 import com.plantcare.core.repository.CareScheduleRepository;
 import com.plantcare.core.repository.NotificationDigestRepository;
 import com.plantcare.core.repository.NotificationLogRepository;
+import com.plantcare.core.repository.UserDeviceRepository;
 import com.plantcare.bot.telegram.RateLimitedTelegramSender;
 import com.plantcare.bot.telegram.SendCallbacks;
 import io.micrometer.core.instrument.Timer;
@@ -56,6 +59,9 @@ public class NotificationSchedulerService {
     private final RateLimitedTelegramSender telegramSender;
     private final NotificationDeliveryCallbacks deliveryCallbacks;
     private final com.plantcare.core.service.LocationSharingService locationSharingService;
+    // Issue #175: push-канал и репозиторий устройств для fan-out на мобильные клиенты
+    private final PushSender pushSender;
+    private final UserDeviceRepository userDeviceRepository;
 
     @Scheduled(fixedRate = 60_000)
     @Transactional
@@ -311,28 +317,38 @@ public class NotificationSchedulerService {
         // Если Open-Meteo молчит или кеш пустой — push уходит без хинта.
         text = appendWeatherHintIfWatering(text, user, schedule);
 
-        SendMessage message = SendMessage.builder()
-                .chatId(user.getTelegramChatId().toString())
-                .text(text)
-                .replyMarkup(keyboard)
-                .build();
-
-        // Issue #29: отправка ушла в rate-limited очередь. Bookkeeping (дедуп-лог +
-        // метрики, пометка blocked на 403) выполняется в колбэках на воркер-потоке
-        // очереди вне этой транзакции. Захватываем только примитивные id, чтобы не
-        // тащить detached-entity между потоками. Дедуп-лог пишется по факту успешной
-        // отправки — как и в синхронной версии (очередь дренирует задолго до
-        // следующего 60с-тика, окно дедупа не нарушается).
         final long plantId = plant.getId();
         final TaskType taskType = schedule.getTaskType();
-        final long chatId = user.getTelegramChatId();
-        telegramSender.enqueue(message, new SendCallbacks(
-                () -> {
-                    deliveryCallbacks.onSent(plantId, taskType);
-                    log.info("Sent notification for plant id={} to chat {} (acclimation={})",
-                            plantId, chatId, inAcclimation);
-                },
-                e -> deliveryCallbacks.onFailed(chatId, e)));
+
+        // Telegram-канал: только если у юзера привязан Telegram-чат (issue #88:
+        // mobile-only юзеры могут не иметь telegramChatId).
+        if (user.getTelegramChatId() != null) {
+            SendMessage message = SendMessage.builder()
+                    .chatId(user.getTelegramChatId().toString())
+                    .text(text)
+                    .replyMarkup(keyboard)
+                    .build();
+
+            // Issue #29: отправка ушла в rate-limited очередь. Bookkeeping (дедуп-лог +
+            // метрики, пометка blocked на 403) выполняется в колбэках на воркер-потоке
+            // очереди вне этой транзакции. Захватываем только примитивные id, чтобы не
+            // тащить detached-entity между потоками. Дедуп-лог пишется по факту успешной
+            // отправки — как и в синхронной версии (очередь дренирует задолго до
+            // следующего 60с-тика, окно дедупа не нарушается).
+            final long chatId = user.getTelegramChatId();
+            telegramSender.enqueue(message, new SendCallbacks(
+                    () -> {
+                        deliveryCallbacks.onSent(plantId, taskType);
+                        log.info("Sent notification for plant id={} to chat {} (acclimation={})",
+                                plantId, chatId, inAcclimation);
+                    },
+                    e -> deliveryCallbacks.onFailed(chatId, e)));
+        }
+
+        // Issue #175: fan-out на мобильные устройства пользователя.
+        // Telegram-юзеры тоже могут иметь mobile-устройства (оба канала получат уведомление).
+        // Тихие часы / paused_until уже проверены в shouldSend() выше.
+        fanOutToMobileDevices(user, plant, text);
 
         // Совместный уход (issue #77): тот же push веером уходит caretaker'ам с
         // доступом к локации растения. Клавиатура завязана на scheduleId, а callback
@@ -340,6 +356,30 @@ public class NotificationSchedulerService {
         // задачу и она закроется у всех. Bookkeeping/дедуп ведём только по
         // основной отправке владельцу (выше), чтобы не задвоить метрики.
         fanOutToCaretakers(plant, text, keyboard);
+    }
+
+    /**
+     * Fan-out push-уведомления на все зарегистрированные мобильные устройства
+     * пользователя (issue #175). Quiet hours и paused_until уже проверены выше.
+     * Ошибки отдельного устройства не останавливают остальные.
+     */
+    private void fanOutToMobileDevices(User user, Plant plant, String text) {
+        List<UserDevice> devices = userDeviceRepository.findByUserId(user.getId());
+        if (devices.isEmpty()) {
+            return;
+        }
+        String title = "Plants Care";
+        for (UserDevice device : devices) {
+            try {
+                pushSender.send(device.getPushToken(), title, text);
+                log.debug("Push sent to device id={} platform={} for plant id={}",
+                        device.getId(), device.getPlatform(), plant.getId());
+            } catch (Exception e) {
+                log.warn("Push failed for device id={} platform={}: {}",
+                        device.getId(), device.getPlatform(), e.getMessage());
+                Sentry.captureException(e);
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/plantcare/core/config/NoopPushSender.java
+++ b/src/main/java/com/plantcare/core/config/NoopPushSender.java
@@ -1,0 +1,19 @@
+package com.plantcare.core.config;
+
+import com.plantcare.core.service.PushSender;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * No-op реализация {@link PushSender} — используется когда {@code push.enabled=false}
+ * (дефолт). Проглатывает все вызовы, логирует на DEBUG.
+ *
+ * <p>Позволяет запускать приложение и тесты без реальных FCM / APNs-ключей.
+ */
+@Slf4j
+public class NoopPushSender implements PushSender {
+
+    @Override
+    public void send(String pushToken, String title, String body) {
+        log.debug("Push disabled (push.enabled=false) — skipped: token={}, title={}", pushToken, title);
+    }
+}

--- a/src/main/java/com/plantcare/core/config/PushConfig.java
+++ b/src/main/java/com/plantcare/core/config/PushConfig.java
@@ -1,0 +1,53 @@
+package com.plantcare.core.config;
+
+import com.plantcare.core.service.PushSender;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring-конфигурация push-канала (issue #175, ADR-014).
+ *
+ * <p>Регистрирует {@link PushSender}-бин в зависимости от {@code push.enabled}:
+ * <ul>
+ *   <li>{@code push.enabled=false} (дефолт) → {@link NoopPushSender} — без внешних вызовов.</li>
+ *   <li>{@code push.enabled=true} → реальный провайдер (будет добавлен отдельной задачей,
+ *       сейчас также NoopPushSender — заглушка для будущей FCM / APNs-интеграции).</li>
+ * </ul>
+ *
+ * <p>FCM / APNs-клиенты требуют доп. зависимостей в pom.xml и отдельного ADR —
+ * реализуются отдельной задачей. Текущая задача (#175) ставит порт,
+ * регистрирует тумблер и подключает шедулер к каналу.
+ */
+@Configuration
+@EnableConfigurationProperties(PushProperties.class)
+@Slf4j
+public class PushConfig {
+
+    /**
+     * No-op-отправитель: используется когда push выключен.
+     * Имеет наименьший приоритет — перекрывается реальными реализациями
+     * через {@code @ConditionalOnProperty(havingValue = "true")}.
+     */
+    @Bean
+    @ConditionalOnProperty(name = "push.enabled", havingValue = "false", matchIfMissing = true)
+    public PushSender noopPushSender() {
+        log.info("Push notifications disabled (push.enabled=false), using NoopPushSender");
+        return new NoopPushSender();
+    }
+
+    /**
+     * Заглушка для режима {@code push.enabled=true}: реальная FCM / APNs-интеграция
+     * будет добавлена отдельной задачей. Логирует предупреждение, чтобы не потерять
+     * включённый тумблер без реальной реализации.
+     */
+    @Bean
+    @ConditionalOnProperty(name = "push.enabled", havingValue = "true")
+    public PushSender enabledPushSender() {
+        log.warn("push.enabled=true but real FCM/APNs provider is not yet implemented — " +
+                "using NoopPushSender as stub. Implement FCM/APNs integration separately.");
+        return new NoopPushSender();
+    }
+}

--- a/src/main/java/com/plantcare/core/config/PushProperties.java
+++ b/src/main/java/com/plantcare/core/config/PushProperties.java
@@ -1,0 +1,60 @@
+package com.plantcare.core.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Конфигурация push-канала (issue #175, ADR-014).
+ *
+ * <p>Глобальный тумблер {@code push.enabled} (по умолчанию {@code false}) позволяет
+ * запускать приложение без реальных FCM / APNs-ключей: все отправки поглощаются
+ * {@link NoopPushSender}.
+ *
+ * <p>Пример конфигурации ({@code application.yml}):
+ * <pre>
+ * push:
+ *   enabled: true          # включить реальную отправку
+ *   fcm:
+ *     server-key: ${FCM_SERVER_KEY:}
+ *   apns:
+ *     key-id:    ${APNS_KEY_ID:}
+ *     team-id:   ${APNS_TEAM_ID:}
+ *     bundle-id: ${APNS_BUNDLE_ID:}
+ *     private-key-path: ${APNS_PRIVATE_KEY_PATH:}
+ * </pre>
+ */
+@ConfigurationProperties(prefix = "push")
+@Getter
+@Setter
+public class PushProperties {
+
+    /**
+     * Глобальный тумблер push-уведомлений. По умолчанию {@code false} —
+     * используется {@link NoopPushSender}, реальные провайдеры не инициализируются.
+     */
+    private boolean enabled = false;
+
+    private Fcm fcm = new Fcm();
+    private Apns apns = new Apns();
+
+    @Getter
+    @Setter
+    public static class Fcm {
+        /** FCM Server Key (Legacy HTTP API) или путь к JSON-ключу сервисного аккаунта (HTTP v1). */
+        private String serverKey = "";
+    }
+
+    @Getter
+    @Setter
+    public static class Apns {
+        /** APNs Key ID из Apple Developer Console. */
+        private String keyId = "";
+        /** Apple Team ID. */
+        private String teamId = "";
+        /** Bundle ID мобильного приложения. */
+        private String bundleId = "";
+        /** Путь к .p8 private-key файлу (или classpath:). */
+        private String privateKeyPath = "";
+    }
+}

--- a/src/main/java/com/plantcare/core/repository/UserDeviceRepository.java
+++ b/src/main/java/com/plantcare/core/repository/UserDeviceRepository.java
@@ -4,6 +4,7 @@ import com.plantcare.core.domain.UserDevice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,4 +15,7 @@ public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
 
     /** Находит устройство пользователя по его id для авторизованного удаления. */
     Optional<UserDevice> findByIdAndUserId(Long id, Long userId);
+
+    /** Возвращает все устройства пользователя (для fan-out push, issue #175). */
+    List<UserDevice> findByUserId(Long userId);
 }

--- a/src/main/java/com/plantcare/core/service/PushSender.java
+++ b/src/main/java/com/plantcare/core/service/PushSender.java
@@ -1,0 +1,30 @@
+package com.plantcare.core.service;
+
+/**
+ * Порт отправки push-уведомлений на мобильные устройства (issue #175, ADR-014).
+ *
+ * <p>Реализации выбираются по платформе токена:
+ * <ul>
+ *   <li>{@code FCM} — Firebase Cloud Messaging (Android)</li>
+ *   <li>{@code APNs} — Apple Push Notification service (iOS)</li>
+ * </ul>
+ *
+ * <p>Когда {@code push.enabled=false} (дефолт), {@link com.plantcare.core.config.NoopPushSender}
+ * проглатывает все вызовы без обращения к внешним сервисам.
+ *
+ * <p>Контракт: метод идемпотентен с точки зрения бизнес-логики — повторная
+ * отправка на один и тот же токен не является ошибкой. Если токен просрочен
+ * или недоступен, реализация логирует предупреждение и возвращает управление
+ * без исключения (чтобы не сломать шедулер).
+ */
+public interface PushSender {
+
+    /**
+     * Отправить push-уведомление на устройство.
+     *
+     * @param pushToken push-токен устройства (FCM registration token / APNs device token)
+     * @param title     заголовок уведомления
+     * @param body      текст уведомления
+     */
+    void send(String pushToken, String title, String body);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -124,6 +124,18 @@ plantcare:
       # Формат: AA:BB:CC:... (hex через двоеточие). Может быть несколько.
       sha256-cert-fingerprints: ${DEEP_LINK_ANDROID_SHA256_CERT_FINGERPRINTS:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99}
 
+# Issue #175 (ADR-014): push-уведомления на мобильные устройства.
+# Глобальный тумблер; реальные FCM/APNs-ключи добавляются отдельной задачей.
+push:
+  enabled: ${PUSH_ENABLED:false}
+  fcm:
+    server-key: ${FCM_SERVER_KEY:}
+  apns:
+    key-id:           ${APNS_KEY_ID:}
+    team-id:          ${APNS_TEAM_ID:}
+    bundle-id:        ${APNS_BUNDLE_ID:}
+    private-key-path: ${APNS_PRIVATE_KEY_PATH:}
+
 admin:
   username: ${ADMIN_USERNAME:}
   password-bcrypt-hash: ${ADMIN_PASSWORD_BCRYPT_HASH:}

--- a/src/test/java/com/plantcare/bot/service/NotificationSchedulerServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/NotificationSchedulerServiceTest.java
@@ -1,5 +1,9 @@
 package com.plantcare.bot.service;
 
+import com.plantcare.core.domain.DevicePlatform;
+import com.plantcare.core.domain.UserDevice;
+import com.plantcare.core.repository.UserDeviceRepository;
+import com.plantcare.core.service.PushSender;
 import com.plantcare.core.service.QuietHoursPolicy;
 import com.plantcare.core.service.SchedulerHealthTracker;
 
@@ -104,6 +108,13 @@ class NotificationSchedulerServiceTest {
     @Mock
     private com.plantcare.core.service.LocationSharingService locationSharingService;
 
+    // Issue #175: mock PushSender и UserDeviceRepository для тестов fan-out
+    @Mock
+    private PushSender pushSender;
+
+    @Mock
+    private UserDeviceRepository userDeviceRepository;
+
     /**
      * Реальный экземпляр, не мок: проверки в тестах смотрят на содержимое
      * клавиатуры (число кнопок, callback_data). Фабрика — pure-функция без
@@ -159,6 +170,8 @@ class NotificationSchedulerServiceTest {
                 .thenReturn(false);
         when(seasonalIntervalService.effectiveIntervalDays(any(), any(), any(Integer.class)))
                 .thenAnswer(inv -> inv.getArgument(2, Integer.class));
+        // По умолчанию у юзера нет мобильных устройств (issue #175).
+        when(userDeviceRepository.findByUserId(any())).thenReturn(List.of());
     }
 
     /** Захватывает SendCallbacks из единственного enqueue с колбэками. */
@@ -680,6 +693,152 @@ class NotificationSchedulerServiceTest {
 
             verify(metricsService).startSchedulerTickTimer();
             verify(metricsService).stopSchedulerTickTimer(sample);
+        }
+    }
+
+    // ===== Push fan-out (issue #175) =====
+
+    @Nested
+    @DisplayName("Push fan-out на мобильные устройства (#175)")
+    class PushFanOut {
+
+        @Test
+        @DisplayName("Telegram-юзер без мобильных устройств → push не вызывается")
+        void should_not_call_push_when_user_has_no_devices() {
+            // arrange — userDeviceRepository возвращает пустой список (стаб из setUp)
+            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
+            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
+                    .thenReturn(false);
+
+            // act
+            service.checkAndSendNotifications();
+
+            // assert — Telegram enqueue вызван, push — нет
+            verify(telegramSender).enqueue(any(SendMessage.class), any(SendCallbacks.class));
+            verifyNoInteractions(pushSender);
+        }
+
+        @Test
+        @DisplayName("Mobile-only юзер (без telegramChatId) получает только push")
+        void should_send_push_to_mobile_only_user_with_no_telegram() {
+            // arrange — mobile-only юзер: нет telegram chat id
+            User mobileUser = User.builder()
+                    .timezone("Asia/Almaty")           // не-UTC таймзона — проверка AC
+                    .quietHoursStart(LocalTime.of(0, 0))
+                    .quietHoursEnd(LocalTime.of(0, 0))
+                    .blocked(false)
+                    .build();
+            ReflectionTestUtils.setField(mobileUser, "id", 5L);
+
+            Plant mobilePlant = Plant.builder().user(mobileUser).name("Алоэ").build();
+            ReflectionTestUtils.setField(mobilePlant, "id", 50L);
+
+            CareSchedule mobileSchedule = CareSchedule.builder()
+                    .plant(mobilePlant)
+                    .taskType(TaskType.WATERING)
+                    .intervalDays(3)
+                    .nextDueAt(LocalDateTime.now().minusHours(1))
+                    .active(true)
+                    .build();
+            ReflectionTestUtils.setField(mobileSchedule, "id", 500L);
+
+            UserDevice device = new UserDevice(mobileUser, DevicePlatform.IOS,
+                    "apns-token-almaty", java.time.Instant.now());
+
+            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(mobileSchedule));
+            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
+                    .thenReturn(false);
+            when(userDeviceRepository.findByUserId(5L)).thenReturn(List.of(device));
+
+            // act
+            service.checkAndSendNotifications();
+
+            // assert — Telegram не вызван (нет chatId), push вызван с токеном устройства
+            verifyNoInteractions(telegramSender);
+            verify(pushSender).send("apns-token-almaty", "Plants Care", "Пора полить: Алоэ");
+        }
+
+        @Test
+        @DisplayName("Telegram-юзер с зарегистрированным устройством получает оба канала")
+        void should_send_both_telegram_and_push_for_hybrid_user() {
+            // arrange — у обычного telegram-юзера есть зарегистрированное устройство
+            UserDevice device = new UserDevice(user, DevicePlatform.ANDROID,
+                    "fcm-token-abc", java.time.Instant.now());
+
+            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
+            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
+                    .thenReturn(false);
+            when(userDeviceRepository.findByUserId(1L)).thenReturn(List.of(device));
+
+            // act
+            service.checkAndSendNotifications();
+
+            // assert — оба канала задействованы
+            verify(telegramSender).enqueue(any(SendMessage.class), any(SendCallbacks.class));
+            verify(pushSender).send("fcm-token-abc", "Plants Care", "Пора полить: Монстера");
+        }
+
+        @Test
+        @DisplayName("Ошибка push одного устройства не блокирует остальные устройства")
+        void should_continue_fan_out_when_one_device_push_fails() {
+            // arrange — два устройства; первое бросает исключение
+            UserDevice deviceBad = new UserDevice(user, DevicePlatform.ANDROID,
+                    "bad-token", java.time.Instant.now());
+            UserDevice deviceGood = new UserDevice(user, DevicePlatform.IOS,
+                    "good-token", java.time.Instant.now());
+
+            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
+            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
+                    .thenReturn(false);
+            when(userDeviceRepository.findByUserId(1L)).thenReturn(List.of(deviceBad, deviceGood));
+            org.mockito.Mockito.doThrow(new RuntimeException("Push delivery failed"))
+                    .when(pushSender).send("bad-token", "Plants Care", "Пора полить: Монстера");
+
+            // act — не должно бросить исключение
+            service.checkAndSendNotifications();
+
+            // assert — второе устройство всё равно получило push
+            verify(pushSender).send("good-token", "Plants Care", "Пора полить: Монстера");
+        }
+
+        @Test
+        @DisplayName("Тихие часы / пауза блокируют push так же как Telegram (тест с Asia/Almaty)")
+        void should_not_send_push_during_quiet_hours_non_utc_timezone() {
+            // arrange — mobile-only юзер с таймзоной Asia/Almaty (UTC+5); quiet-hours активны
+            User almaty = User.builder()
+                    .timezone("Asia/Almaty")
+                    .quietHoursStart(LocalTime.of(22, 0))
+                    .quietHoursEnd(LocalTime.of(9, 0))
+                    .blocked(false)
+                    .build();
+            ReflectionTestUtils.setField(almaty, "id", 7L);
+
+            Plant plant7 = Plant.builder().user(almaty).name("Кактус").build();
+            ReflectionTestUtils.setField(plant7, "id", 70L);
+
+            CareSchedule schedule7 = CareSchedule.builder()
+                    .plant(plant7)
+                    .taskType(TaskType.WATERING)
+                    .intervalDays(7)
+                    .nextDueAt(LocalDateTime.now().minusHours(1))
+                    .active(true)
+                    .build();
+            ReflectionTestUtils.setField(schedule7, "id", 700L);
+
+            // quiet-hours активны для этого юзера
+            when(quietHoursPolicy.isQuiet(org.mockito.ArgumentMatchers.eq(almaty), any(java.time.Instant.class)))
+                    .thenReturn(true);
+
+            when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule7));
+            when(userDeviceRepository.findByUserId(7L)).thenReturn(List.of(
+                    new UserDevice(almaty, DevicePlatform.IOS, "ios-almaty", java.time.Instant.now())));
+
+            // act
+            service.checkAndSendNotifications();
+
+            // assert — ни Telegram, ни push не вызваны (shouldSend вернул false)
+            verifyNoInteractions(telegramSender);
+            verifyNoInteractions(pushSender);
         }
     }
 


### PR DESCRIPTION
Closes #175

## Что сделано

- **PushSender port** (`core/service/PushSender.java`) — интерфейс отправки push с методом `send(token, title, body)`. Реальные FCM/APNs-провайдеры добавляются отдельной задачей.
- **PushProperties** (`@ConfigurationProperties(prefix="push")`) — конфиг глобального тумблера `push.enabled` (дефолт `false`) и будущих FCM/APNs-ключей.
- **NoopPushSender** / **PushConfig** — при `push.enabled=false` (дефолт) используется нет-оп-реализация без обращений к внешним сервисам.
- **UserDeviceRepository** — добавлен метод `findByUserId(Long)` для fan-out в шедулере.
- **NotificationSchedulerService** — исправлен null-guard для `telegramChatId` (mobile-only юзеры без Telegram), добавлен fan-out на все зарегистрированные устройства через `PushSender`; ошибка одного устройства не останавливает остальные (Sentry + warn-лог).
- **application.yml** — конфиг `push.enabled=${PUSH_ENABLED:false}` с ключами FCM/APNs из env.

## Миграции

Нет (V40 с таблицей `user_devices` уже на `develop`).

## Backward-compat риски

safe — `push.enabled=false` по умолчанию, никаких внешних вызовов не добавлено без явного включения. null-check на `telegramChatId` исправляет потенциальный NPE для mobile-only юзеров.

## Тесты

- `UserDeviceRepositoryTest` — Testcontainers + Postgres: CRUD, уникальный констрейнт, CASCADE DELETE, `touch()` (уже в develop)
- `DeviceServiceTest` — unit: idempotent upsert, hard-delete с проверкой владельца (уже в develop)
- `DevicesControllerTest` — `@WebMvcTest`: POST 201/валидация/идемпотентность, DELETE 204/404 (уже в develop)
- **`NotificationSchedulerServiceTest.PushFanOut`** (5 новых тестов):
  - mobile-only юзер с таймзоной `Asia/Almaty` получает только push (кейс с не-UTC TZ)
  - Telegram-юзер с устройством получает оба канала
  - ошибка push одного устройства не блокирует второе
  - quiet-hours блокируют push так же как Telegram
  - юзер без устройств — push не вызывается

## Чек

- [x] `mvn test` зелёный (2 pre-existing failure в PlantScheduleServiceTest/PlantServiceTest на develop не связаны с этим PR)
- [x] Reviewer прошёл (авто-ревью)