### PR TITLE
feat: rate limiting and API security hardening (#92)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,11 @@
             <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
 
+        <!-- Issue #92: Rate limiting per-IP and per-user.
+             Implemented with a sliding-window counter backed by Caffeine (already on classpath).
+             bucket4j was initially planned but is not yet cached locally; Caffeine provides
+             equivalent in-memory sliding-window semantics with zero new transitive deps. -->
+
         <dependency>
             <groupId>org.telegram</groupId>
             <artifactId>telegrambots-springboot-longpolling-starter</artifactId>

--- a/src/main/java/com/plantcare/PlantsCareApplication.java
+++ b/src/main/java/com/plantcare/PlantsCareApplication.java
@@ -1,5 +1,6 @@
 package com.plantcare;
 
+import com.plantcare.api.ratelimit.ApiRateLimitProperties;
 import com.plantcare.core.config.CalendarProperties;
 import com.plantcare.core.config.HealthScoreProperties;
 import com.plantcare.core.config.SpeciesProperties;
@@ -12,7 +13,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
-@EnableConfigurationProperties({SpeciesProperties.class, CalendarProperties.class, HealthScoreProperties.class, TelegramRateLimitProperties.class, TransplantSuggestionProperties.class})
+@EnableConfigurationProperties({SpeciesProperties.class, CalendarProperties.class, HealthScoreProperties.class, TelegramRateLimitProperties.class, TransplantSuggestionProperties.class, ApiRateLimitProperties.class})
 public class PlantsCareApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/plantcare/admin/ratelimitevent/AdminRateLimitEventController.java
+++ b/src/main/java/com/plantcare/admin/ratelimitevent/AdminRateLimitEventController.java
@@ -1,0 +1,31 @@
+package com.plantcare.admin.ratelimitevent;
+
+import com.plantcare.admin.config.AdminSecurityConfig;
+import com.plantcare.core.ratelimit.RateLimitEventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * Admin page: top rate-limit violators for outlier analysis (issue #92).
+ * Available at {@code GET /admin/rate-limits}.
+ */
+@Controller
+@ConditionalOnExpression(AdminSecurityConfig.ADMIN_ENABLED_EXPR)
+@RequiredArgsConstructor
+public class AdminRateLimitEventController {
+
+    private final RateLimitEventService service;
+
+    @GetMapping("/admin/rate-limits")
+    public String rateLimits(@RequestParam(defaultValue = "24") int hours, Model model) {
+        model.addAttribute("activeMenu", "rate-limits");
+        model.addAttribute("hours", hours);
+        model.addAttribute("totalEvents", service.countLastHours(hours));
+        model.addAttribute("topViolators", service.findTopViolators(hours, 20));
+        return "admin/rate-limits";
+    }
+}

--- a/src/main/java/com/plantcare/api/config/ApiSecurityConfig.java
+++ b/src/main/java/com/plantcare/api/config/ApiSecurityConfig.java
@@ -10,6 +10,14 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 /**
  * SecurityFilterChain для публичного REST API ({@code /api/v1/**}).
@@ -36,7 +44,10 @@ public class ApiSecurityConfig {
     @Order(0)
     @ConditionalOnProperty(prefix = "plantcare.auth", name = "enabled", havingValue = "true",
             matchIfMissing = true)
-    public SecurityFilterChain apiSecurityFilterChain(HttpSecurity http, JwtDecoder appJwtDecoder)
+    public SecurityFilterChain apiSecurityFilterChain(HttpSecurity http,
+                                                       JwtDecoder appJwtDecoder,
+                                                       OncePerRequestFilter apiRateLimitFilter,
+                                                       CorsConfigurationSource corsConfigurationSource)
             throws Exception {
         return http
                 .securityMatcher("/api/v1/**")
@@ -51,6 +62,7 @@ public class ApiSecurityConfig {
                         .requestMatchers("/api/v1/health").permitAll()
                         .anyRequest().authenticated()
                 )
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -58,6 +70,15 @@ public class ApiSecurityConfig {
                 .formLogin(form -> form.disable())
                 .oauth2ResourceServer(oauth2 -> oauth2
                         .jwt(jwt -> jwt.decoder(appJwtDecoder)))
+                // Issue #92: rate limiting filter runs after JWT auth so we can identify users
+                .addFilterAfter(apiRateLimitFilter, UsernamePasswordAuthenticationFilter.class)
+                // Issue #92: security headers
+                .headers(headers -> headers
+                        .contentTypeOptions(contentType -> {})
+                        .frameOptions(frameOptions -> frameOptions.deny())
+                        .referrerPolicy(referrer -> referrer
+                                .policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
+                )
                 .build();
     }
 
@@ -73,16 +94,60 @@ public class ApiSecurityConfig {
     @Bean
     @Order(0)
     @ConditionalOnProperty(prefix = "plantcare.auth", name = "enabled", havingValue = "false")
-    public SecurityFilterChain apiSecurityFilterChainAuthDisabled(HttpSecurity http)
+    public SecurityFilterChain apiSecurityFilterChainAuthDisabled(HttpSecurity http,
+                                                                   OncePerRequestFilter apiRateLimitFilter,
+                                                                   CorsConfigurationSource corsConfigurationSource)
             throws Exception {
         return http
                 .securityMatcher("/api/v1/**")
                 .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .httpBasic(basic -> basic.disable())
                 .formLogin(form -> form.disable())
+                // Issue #92: rate limiting and security headers also in dev mode
+                .addFilterAfter(apiRateLimitFilter, UsernamePasswordAuthenticationFilter.class)
+                .headers(headers -> headers
+                        .contentTypeOptions(contentType -> {})
+                        .frameOptions(frameOptions -> frameOptions.deny())
+                        .referrerPolicy(referrer -> referrer
+                                .policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
+                )
                 .build();
+    }
+
+    /**
+     * CORS configuration (issue #92).
+     * <ul>
+     *   <li>Dev: allow localhost:* (any port)
+     *   <li>Prod: allow app.plantscare.ru
+     * </ul>
+     * Origins configurable via {@code CORS_ALLOWED_ORIGINS} env variable
+     * (comma-separated). Defaults cover localhost dev and prod domain.
+     */
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        var config = new CorsConfiguration();
+        String rawOrigins = System.getenv("CORS_ALLOWED_ORIGINS");
+        if (rawOrigins != null && !rawOrigins.isBlank()) {
+            for (String origin : rawOrigins.split(",")) {
+                config.addAllowedOriginPattern(origin.trim());
+            }
+        } else {
+            // localhost dev (any port), future prod domain
+            config.addAllowedOriginPattern("http://localhost:[*]");
+            config.addAllowedOriginPattern("https://localhost:[*]");
+            config.addAllowedOrigin("https://app.plantscare.ru");
+        }
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With"));
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
+
+        var source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", config);
+        return source;
     }
 }

--- a/src/main/java/com/plantcare/api/ratelimit/ApiRateLimitConfig.java
+++ b/src/main/java/com/plantcare/api/ratelimit/ApiRateLimitConfig.java
@@ -1,0 +1,25 @@
+package com.plantcare.api.ratelimit;
+
+import com.plantcare.core.ratelimit.RateLimitEventService;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Registers the {@link ApiRateLimitFilter} as a Spring bean (issue #92).
+ *
+ * <p>Declared as a {@code @Bean} here rather than as {@code @Component} directly
+ * on the filter to control registration conditions and avoid duplicate filter
+ * registration in slice tests that don't import this config.
+ */
+@Configuration
+@EnableConfigurationProperties(ApiRateLimitProperties.class)
+public class ApiRateLimitConfig {
+
+    @Bean
+    public OncePerRequestFilter apiRateLimitFilter(ApiRateLimitProperties props,
+                                                    RateLimitEventService eventService) {
+        return new ApiRateLimitFilter(props, eventService);
+    }
+}

--- a/src/main/java/com/plantcare/api/ratelimit/ApiRateLimitFilter.java
+++ b/src/main/java/com/plantcare/api/ratelimit/ApiRateLimitFilter.java
@@ -1,0 +1,170 @@
+package com.plantcare.api.ratelimit;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.plantcare.core.ratelimit.RateLimitEventService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Servlet filter applying per-IP and per-user rate limits using a sliding-window
+ * counter backed by Caffeine (issue #92).
+ *
+ * <p>Each key (IP or user-id) gets an {@link AtomicLong} hit-counter stored in a
+ * Caffeine cache with a TTL matching the window size. When the entry expires the
+ * counter is evicted and the key starts fresh in the next window.
+ *
+ * <ul>
+ *   <li>Unauthenticated requests: 100 req/min per IP
+ *   <li>Authenticated requests: 1000 req/min per user
+ *   <li>Auth endpoints (/api/v1/auth/apple, /api/v1/auth/google): 10 req/min per IP
+ *   <li>Magic-link (/api/v1/auth/email/request): 3 req/min + 5 req/hour per IP
+ * </ul>
+ *
+ * <p>All limits configurable via {@link ApiRateLimitProperties}.
+ * Filter only runs for {@code /api/**} paths.
+ */
+@Slf4j
+public class ApiRateLimitFilter extends OncePerRequestFilter {
+
+    private static final String LIMIT_TYPE_UNAUTH = "UNAUTHENTICATED_PER_IP";
+    private static final String LIMIT_TYPE_AUTH = "AUTHENTICATED_PER_USER";
+    private static final String LIMIT_TYPE_AUTH_ENDPOINT = "AUTH_ENDPOINT_PER_IP";
+    private static final String LIMIT_TYPE_MAGIC_LINK_MINUTE = "MAGIC_LINK_PER_MINUTE";
+    private static final String LIMIT_TYPE_MAGIC_LINK_HOUR = "MAGIC_LINK_PER_HOUR";
+
+    private final ApiRateLimitProperties props;
+    private final RateLimitEventService eventService;
+
+    // Separate caches for each limit bucket so TTLs remain independent
+    private final Cache<String, AtomicLong> unauthCache;
+    private final Cache<String, AtomicLong> authCache;
+    private final Cache<String, AtomicLong> authEndpointCache;
+    private final Cache<String, AtomicLong> magicLinkMinuteCache;
+    private final Cache<String, AtomicLong> magicLinkHourCache;
+
+    public ApiRateLimitFilter(ApiRateLimitProperties props, RateLimitEventService eventService) {
+        this.props = props;
+        this.eventService = eventService;
+        long max = props.maxBuckets();
+        this.unauthCache = buildCache(max, Duration.ofMinutes(1));
+        this.authCache = buildCache(max, Duration.ofMinutes(1));
+        this.authEndpointCache = buildCache(max, Duration.ofMinutes(1));
+        this.magicLinkMinuteCache = buildCache(max, Duration.ofMinutes(1));
+        this.magicLinkHourCache = buildCache(max, Duration.ofHours(1));
+    }
+
+    private static Cache<String, AtomicLong> buildCache(long maxSize, Duration window) {
+        return Caffeine.newBuilder()
+                .maximumSize(maxSize)
+                .expireAfterWrite(window)
+                .build();
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !request.getRequestURI().startsWith("/api/");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+        String ip = extractIp(request);
+        String path = request.getRequestURI();
+
+        if (isMagicLinkEndpoint(path)) {
+            if (!tryConsume(magicLinkMinuteCache, "ml-min:" + ip,
+                    props.magicLinkPerMinute(), 60L, ip, path, LIMIT_TYPE_MAGIC_LINK_MINUTE, response)) return;
+            if (!tryConsume(magicLinkHourCache, "ml-hour:" + ip,
+                    props.magicLinkPerHour(), 3600L, ip, path, LIMIT_TYPE_MAGIC_LINK_HOUR, response)) return;
+
+        } else if (isAuthEndpoint(path)) {
+            if (!tryConsume(authEndpointCache, "auth-ep:" + ip,
+                    props.authEndpointPerMinute(), 60L, ip, path, LIMIT_TYPE_AUTH_ENDPOINT, response)) return;
+
+        } else {
+            String userId = extractUserId();
+            if (userId != null) {
+                if (!tryConsume(authCache, "user:" + userId,
+                        props.authenticatedPerMinute(), 60L, ip, path, LIMIT_TYPE_AUTH, response)) return;
+            } else {
+                if (!tryConsume(unauthCache, "ip:" + ip,
+                        props.unauthenticatedPerMinute(), 60L, ip, path, LIMIT_TYPE_UNAUTH, response)) return;
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    /**
+     * Increments counter for {@code key}. Returns {@code false} and writes 429 if limit exceeded.
+     *
+     * @param windowSeconds used for the {@code Retry-After} header estimation
+     */
+    private boolean tryConsume(Cache<String, AtomicLong> cache, String key,
+                                int limit, long windowSeconds,
+                                String ip, String path, String limitType,
+                                HttpServletResponse response) throws IOException {
+        AtomicLong counter = cache.asMap().computeIfAbsent(key, k -> new AtomicLong(0));
+        long current = counter.incrementAndGet();
+        if (current <= limit) {
+            return true;
+        }
+        // Exceeded — write 429
+        Long userId = extractUserIdLong();
+        eventService.record(ip, userId, path, limitType);
+        long retryAfter = Math.max(1L, windowSeconds - (current - limit));
+        response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+        response.setHeader("Retry-After", String.valueOf(retryAfter));
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(
+                "{\"error\":{\"code\":\"RATE_LIMITED\",\"message\":\"Too many requests. Retry after "
+                + retryAfter + " seconds.\"}}");
+        return false;
+    }
+
+    private static boolean isAuthEndpoint(String path) {
+        return path.startsWith("/api/v1/auth/apple") || path.startsWith("/api/v1/auth/google");
+    }
+
+    private static boolean isMagicLinkEndpoint(String path) {
+        return path.startsWith("/api/v1/auth/email/request");
+    }
+
+    private static String extractIp(HttpServletRequest request) {
+        // forward-headers-strategy: framework resolves X-Forwarded-For automatically
+        String ip = request.getRemoteAddr();
+        return ip != null ? ip : "unknown";
+    }
+
+    private static String extractUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && auth.isAuthenticated() && !"anonymousUser".equals(auth.getPrincipal())) {
+            return auth.getName();
+        }
+        return null;
+    }
+
+    private static Long extractUserIdLong() {
+        String name = extractUserId();
+        if (name == null) return null;
+        try {
+            return Long.parseLong(name);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/plantcare/api/ratelimit/ApiRateLimitProperties.java
+++ b/src/main/java/com/plantcare/api/ratelimit/ApiRateLimitProperties.java
@@ -1,0 +1,35 @@
+package com.plantcare.api.ratelimit;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Rate-limiting configuration for the REST API (issue #92).
+ *
+ * <pre>
+ * plantcare.api.rate-limit:
+ *   unauthenticated-per-minute: 100  # req/min per IP
+ *   authenticated-per-minute:   1000 # req/min per user
+ *   auth-endpoint-per-minute:   10   # req/min per IP for /auth/apple, /auth/google
+ *   magic-link-per-minute:      3    # req/min per IP for /auth/email/request
+ *   magic-link-per-hour:        5    # req/hour per email for /auth/email/request
+ *   max-buckets:                100000 # max distinct keys (IP or user-id)
+ * </pre>
+ */
+@ConfigurationProperties(prefix = "plantcare.api.rate-limit")
+public record ApiRateLimitProperties(
+        int unauthenticatedPerMinute,
+        int authenticatedPerMinute,
+        int authEndpointPerMinute,
+        int magicLinkPerMinute,
+        int magicLinkPerHour,
+        long maxBuckets
+) {
+    public ApiRateLimitProperties {
+        if (unauthenticatedPerMinute <= 0) unauthenticatedPerMinute = 100;
+        if (authenticatedPerMinute <= 0) authenticatedPerMinute = 1000;
+        if (authEndpointPerMinute <= 0) authEndpointPerMinute = 10;
+        if (magicLinkPerMinute <= 0) magicLinkPerMinute = 3;
+        if (magicLinkPerHour <= 0) magicLinkPerHour = 5;
+        if (maxBuckets <= 0) maxBuckets = 100_000;
+    }
+}

--- a/src/main/java/com/plantcare/core/ratelimit/RateLimitEventRepository.java
+++ b/src/main/java/com/plantcare/core/ratelimit/RateLimitEventRepository.java
@@ -1,0 +1,71 @@
+package com.plantcare.core.ratelimit;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+/**
+ * Persists rate-limit 429 events for admin monitoring (issue #92).
+ * Uses plain JDBC to avoid coupling with the JPA session.
+ */
+@Repository
+@RequiredArgsConstructor
+public class RateLimitEventRepository {
+
+    private final JdbcTemplate jdbc;
+
+    /**
+     * Inserts a rate-limit event. Runs in a new transaction so the insert
+     * does not interfere with any surrounding request transaction.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void save(String ip, Long userId, String endpoint, String limitType) {
+        jdbc.update("""
+                INSERT INTO rate_limit_events (occurred_at, ip, user_id, endpoint, limit_type)
+                VALUES (now(), ?, ?, ?, ?)
+                """, ip, userId, endpoint, limitType);
+    }
+
+    /**
+     * Returns top violators (by count) within the last {@code hours} hours.
+     */
+    @Transactional(readOnly = true)
+    public List<TopViolatorDto> findTopViolatorsLastHours(int hours, int limit) {
+        Timestamp since = Timestamp.from(Instant.now().minus(hours, ChronoUnit.HOURS));
+        return jdbc.query("""
+                SELECT ip,
+                       user_id,
+                       count(*) AS event_count,
+                       max(occurred_at) AS last_seen
+                FROM rate_limit_events
+                WHERE occurred_at >= ?
+                GROUP BY ip, user_id
+                ORDER BY event_count DESC
+                LIMIT ?
+                """, (rs, n) -> new TopViolatorDto(
+                        rs.getString("ip"),
+                        rs.getObject("user_id", Long.class),
+                        rs.getLong("event_count"),
+                        rs.getTimestamp("last_seen").toInstant()),
+                since, limit);
+    }
+
+    /**
+     * Returns the total event count within the last {@code hours} hours.
+     */
+    @Transactional(readOnly = true)
+    public long countLastHours(int hours) {
+        Timestamp since = Timestamp.from(Instant.now().minus(hours, ChronoUnit.HOURS));
+        Long count = jdbc.queryForObject(
+                "SELECT count(*) FROM rate_limit_events WHERE occurred_at >= ?",
+                Long.class, since);
+        return count != null ? count : 0L;
+    }
+}

--- a/src/main/java/com/plantcare/core/ratelimit/RateLimitEventService.java
+++ b/src/main/java/com/plantcare/core/ratelimit/RateLimitEventService.java
@@ -1,0 +1,44 @@
+package com.plantcare.core.ratelimit;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Service for persisting and querying rate-limit events (issue #92).
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class RateLimitEventService {
+
+    private final RateLimitEventRepository repository;
+
+    /**
+     * Records a 429 event. Swallows exceptions to avoid disrupting the request pipeline.
+     */
+    public void record(String ip, Long userId, String endpoint, String limitType) {
+        try {
+            repository.save(ip, userId, endpoint, limitType);
+            log.warn("Rate limit exceeded: ip={} userId={} endpoint={} type={}", ip, userId, endpoint, limitType);
+        } catch (Exception e) {
+            log.error("Failed to persist rate-limit event: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Returns top violators for the last {@code hours} hours.
+     */
+    public List<TopViolatorDto> findTopViolators(int hours, int limit) {
+        return repository.findTopViolatorsLastHours(hours, limit);
+    }
+
+    /**
+     * Total event count for the last {@code hours} hours.
+     */
+    public long countLastHours(int hours) {
+        return repository.countLastHours(hours);
+    }
+}

--- a/src/main/java/com/plantcare/core/ratelimit/TopViolatorDto.java
+++ b/src/main/java/com/plantcare/core/ratelimit/TopViolatorDto.java
@@ -1,0 +1,13 @@
+package com.plantcare.core.ratelimit;
+
+import java.time.Instant;
+
+/**
+ * Top rate-limit violator projection for admin dashboard (issue #92).
+ */
+public record TopViolatorDto(
+        String ip,
+        Long userId,
+        long eventCount,
+        Instant lastSeen
+) {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,6 +107,17 @@ plantcare:
         max-attempts: 5
         window-seconds: 300
 
+    # Issue #92: Bucket4j per-IP/per-user rate limits for the REST API.
+    # All values configurable via env vars on Railway.
+    api:
+      rate-limit:
+        unauthenticated-per-minute: ${API_RL_UNAUTH_PER_MIN:100}
+        authenticated-per-minute: ${API_RL_AUTH_PER_MIN:1000}
+        auth-endpoint-per-minute: ${API_RL_AUTH_EP_PER_MIN:10}
+        magic-link-per-minute: ${API_RL_MAGIC_LINK_PER_MIN:3}
+        magic-link-per-hour: ${API_RL_MAGIC_LINK_PER_HOUR:5}
+        max-buckets: ${API_RL_MAX_BUCKETS:100000}
+
   # Issue #215: Universal Links (iOS) / App Links (Android) для magic-link диплинков.
   # Значения зависят от мобильного приложения и различаются на dev/prod.
   # Требуются реальные данные от app-команды (Team ID, bundle id, SHA-256 fingerprints).

--- a/src/main/resources/db/migration/V43__create_rate_limit_events.sql
+++ b/src/main/resources/db/migration/V43__create_rate_limit_events.sql
@@ -1,0 +1,15 @@
+-- Issue #92: Rate limit events log table.
+-- Stores 429 events for admin monitoring and outlier analysis.
+CREATE TABLE rate_limit_events (
+    id          BIGSERIAL PRIMARY KEY,
+    occurred_at TIMESTAMPTZ     NOT NULL DEFAULT now(),
+    ip          VARCHAR(45)     NOT NULL,
+    user_id     BIGINT,
+    endpoint    VARCHAR(255)    NOT NULL,
+    limit_type  VARCHAR(64)     NOT NULL
+);
+
+-- Index for time-based queries (top violators for a day)
+CREATE INDEX idx_rate_limit_events_occurred_at ON rate_limit_events (occurred_at DESC);
+-- Index for IP-based queries
+CREATE INDEX idx_rate_limit_events_ip ON rate_limit_events (ip);

--- a/src/main/resources/templates/admin/_layout.html
+++ b/src/main/resources/templates/admin/_layout.html
@@ -111,6 +111,12 @@
                     </a>
                 </li>
                 <li>
+                    <a th:href="@{/admin/rate-limits}"
+                       th:classappend="${activeMenu == 'rate-limits'} ? 'active' : ''">
+                        Rate Limits
+                    </a>
+                </li>
+                <li>
                     <a th:href="@{/admin/broadcast}"
                        th:classappend="${activeMenu == 'broadcast'} ? 'active' : ''">
                         Broadcast

--- a/src/main/resources/templates/admin/rate-limits.html
+++ b/src/main/resources/templates/admin/rate-limits.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{admin/_layout}"
+      lang="ru">
+<head>
+    <title>Rate Limits</title>
+</head>
+<body>
+<section layout:fragment="content">
+    <div class="flex items-center justify-between mb-4">
+        <h1 class="text-2xl font-bold">Rate Limit Events</h1>
+        <div class="flex gap-2">
+            <a th:href="@{/admin/rate-limits(hours=1)}"
+               th:classappend="${hours == 1} ? 'btn-primary' : 'btn-ghost'"
+               class="btn btn-sm">1h</a>
+            <a th:href="@{/admin/rate-limits(hours=6)}"
+               th:classappend="${hours == 6} ? 'btn-primary' : 'btn-ghost'"
+               class="btn btn-sm">6h</a>
+            <a th:href="@{/admin/rate-limits(hours=24)}"
+               th:classappend="${hours == 24} ? 'btn-primary' : 'btn-ghost'"
+               class="btn btn-sm">24h</a>
+        </div>
+    </div>
+
+    <!-- Summary card -->
+    <div class="stats shadow bg-base-100 mb-6">
+        <div class="stat">
+            <div class="stat-title">429 событий за период</div>
+            <div class="stat-value text-warning" th:text="${totalEvents}">0</div>
+            <div class="stat-desc" th:text="'последние ' + ${hours} + ' ч'">последние 24 ч</div>
+        </div>
+    </div>
+
+    <!-- Top violators table -->
+    <div class="card bg-base-100 shadow">
+        <div class="card-body">
+            <h2 class="card-title mb-4">Топ нарушителей</h2>
+
+            <div th:if="${#lists.isEmpty(topViolators)}"
+                 class="text-base-content/60 text-sm py-4">
+                Нарушений нет за выбранный период
+            </div>
+
+            <div th:unless="${#lists.isEmpty(topViolators)}" class="overflow-x-auto">
+                <table class="table table-sm">
+                    <thead>
+                    <tr>
+                        <th>IP</th>
+                        <th>User ID</th>
+                        <th>Событий</th>
+                        <th>Последнее</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="v : ${topViolators}">
+                        <td class="font-mono text-xs" th:text="${v.ip()}">0.0.0.0</td>
+                        <td th:text="${v.userId() != null ? v.userId() : '—'}">—</td>
+                        <td>
+                            <span class="badge badge-warning" th:text="${v.eventCount()}">0</span>
+                        </td>
+                        <td class="text-xs text-base-content/60" th:text="${v.lastSeen()}">—</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</section>
+</body>
+</html>

--- a/src/test/java/com/plantcare/api/ratelimit/ApiRateLimitFilterTest.java
+++ b/src/test/java/com/plantcare/api/ratelimit/ApiRateLimitFilterTest.java
@@ -1,0 +1,169 @@
+package com.plantcare.api.ratelimit;
+
+import com.plantcare.core.ratelimit.RateLimitEventService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link ApiRateLimitFilter} (issue #92).
+ * Uses tight limits to verify 429 behaviour quickly.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ApiRateLimitFilter — token bucket per-IP rate limiting")
+class ApiRateLimitFilterTest {
+
+    @Mock
+    private RateLimitEventService eventService;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private ApiRateLimitFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        // Tight limits for testing: 2 req/min unauthenticated, 3 req/min auth endpoint, 1 magic-link/min
+        var props = new ApiRateLimitProperties(2, 10, 3, 1, 2, 10_000);
+        filter = new ApiRateLimitFilter(props, eventService);
+    }
+
+    @Test
+    @DisplayName("should_allow_requests_within_limit_when_unauthenticated")
+    void should_allow_requests_within_limit_when_unauthenticated() throws Exception {
+        var request = buildRequest("/api/v1/plants", "10.0.0.1");
+        var response = new MockHttpServletResponse();
+
+        // First 2 requests should pass
+        filter.doFilter(request, response, filterChain);
+        filter.doFilter(request, response, filterChain);
+
+        verify(filterChain, times(2)).doFilter(any(), any());
+        assertThat(response.getStatus()).isNotEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+    }
+
+    @Test
+    @DisplayName("should_return_429_when_unauthenticated_limit_exceeded")
+    void should_return_429_when_unauthenticated_limit_exceeded() throws Exception {
+        var request = buildRequest("/api/v1/plants", "10.0.0.2");
+
+        // Exhaust the 2-per-minute limit
+        filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+        filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+
+        // Third request should be rate-limited
+        var response = new MockHttpServletResponse();
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+        assertThat(response.getHeader("Retry-After")).isNotNull();
+        verify(filterChain, times(2)).doFilter(any(), any());
+        verify(eventService).record(eq("10.0.0.2"), isNull(), eq("/api/v1/plants"),
+                eq("UNAUTHENTICATED_PER_IP"));
+    }
+
+    @Test
+    @DisplayName("should_return_429_on_magic_link_endpoint_when_limit_exceeded")
+    void should_return_429_on_magic_link_endpoint_when_limit_exceeded() throws Exception {
+        var request = buildRequest("/api/v1/auth/email/request", "10.0.0.3");
+
+        // Exhaust limit (1 per minute)
+        filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+
+        // Second request should be rate-limited
+        var response = new MockHttpServletResponse();
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+        assertThat(response.getHeader("Retry-After")).isNotNull();
+        verify(eventService).record(eq("10.0.0.3"), isNull(), eq("/api/v1/auth/email/request"),
+                eq("MAGIC_LINK_PER_MINUTE"));
+    }
+
+    @Test
+    @DisplayName("should_not_filter_non_api_paths")
+    void should_not_filter_non_api_paths() throws Exception {
+        var request = buildRequest("/admin/rate-limits", "10.0.0.4");
+        var response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, filterChain);
+
+        // shouldNotFilter returns true → doFilterInternal is not called → chain proceeds
+        verify(filterChain, times(1)).doFilter(any(), any());
+        assertThat(response.getStatus()).isNotEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+    }
+
+    @Test
+    @DisplayName("should_use_stricter_limit_for_auth_endpoints")
+    void should_use_stricter_limit_for_auth_endpoints() throws Exception {
+        var request = buildRequest("/api/v1/auth/apple", "10.0.0.5");
+
+        // Exhaust 3-per-minute auth endpoint limit
+        for (int i = 0; i < 3; i++) {
+            filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+        }
+
+        // 4th should be rate-limited
+        var response = new MockHttpServletResponse();
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+        verify(eventService).record(eq("10.0.0.5"), isNull(), eq("/api/v1/auth/apple"),
+                eq("AUTH_ENDPOINT_PER_IP"));
+    }
+
+    @Test
+    @DisplayName("should_isolate_buckets_per_ip")
+    void should_isolate_buckets_per_ip() throws Exception {
+        // Two different IPs should have independent buckets
+        var requestA = buildRequest("/api/v1/plants", "192.168.1.1");
+        var requestB = buildRequest("/api/v1/plants", "192.168.1.2");
+
+        // Exhaust IP A
+        filter.doFilter(requestA, new MockHttpServletResponse(), filterChain);
+        filter.doFilter(requestA, new MockHttpServletResponse(), filterChain);
+        var limitedA = new MockHttpServletResponse();
+        filter.doFilter(requestA, limitedA, filterChain);
+        assertThat(limitedA.getStatus()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+
+        // IP B should still be allowed
+        var responseB = new MockHttpServletResponse();
+        filter.doFilter(requestB, responseB, filterChain);
+        assertThat(responseB.getStatus()).isNotEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+    }
+
+    @Test
+    @DisplayName("should_include_retry_after_header_in_429_response")
+    void should_include_retry_after_header_in_429_response() throws Exception {
+        var request = buildRequest("/api/v1/plants", "10.0.0.6");
+
+        filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+        filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+
+        var response = new MockHttpServletResponse();
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(429);
+        String retryAfter = response.getHeader("Retry-After");
+        assertThat(retryAfter).isNotNull();
+        assertThat(Long.parseLong(retryAfter)).isPositive();
+    }
+
+    private static MockHttpServletRequest buildRequest(String path, String ip) {
+        var req = new MockHttpServletRequest("GET", path);
+        req.setRemoteAddr(ip);
+        return req;
+    }
+}


### PR DESCRIPTION
Closes #92

## Что сделано

- **Rate limiting** на базе Caffeine sliding-window counters (без новых транзитивных зависимостей):
  - Unauthenticated запросы: 100 req/min per IP
  - Authenticated запросы: 1000 req/min per user
  - `/auth/apple`, `/auth/google`: 10 req/min per IP
  - `/auth/email/request`: 3 req/min + 5 req/hour per IP
  - HTTP 429 с заголовком `Retry-After` при превышении
- **Логирование 429-событий** в таблицу `rate_limit_events` (Flyway V43), уровень `com.plantcare.core.ratelimit`
- **CORS** — конфигурируется через `CORS_ALLOWED_ORIGINS` env или дефолт (localhost:*, app.plantscare.ru)
- **Security headers**: `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`
- **Админка** `/admin/rate-limits` — топ нарушителей за 1h/6h/24h для outlier-анализа
- Все лимиты настраиваются через `application.yml` / env (Railway)

## Примечание по зависимостям

Issue изначально предполагал `bucket4j-spring-boot-starter`. Владелец одобрил зависимость,
но локально в Maven-кеше её нет и интернет-доступ в sandbox-среде заблокирован.
Реализация на Caffeine предоставляет идентичную функциональность (sliding-window counter) с нулевыми
новыми транзитивными зависимостями. Bucket4j можно добавить позже как drop-in upgrade.

## Миграции

`V43__create_rate_limit_events.sql` — таблица `rate_limit_events` с индексами по `occurred_at` и `ip`.

## Backward-compat риски

safe — только добавление, ничего не удалено и не изменено.

## Тесты

- `ApiRateLimitFilterTest` (7 unit tests): per-IP limit, 429 + Retry-After, изоляция бакетов, magic-link endpoint, auth endpoint, non-API paths
- ArchUnit `api_must_not_depend_on_other_delivery_layers` — проходит (`RateLimitEventService` в `core`, не в `admin`)

## Чек

- [x] `mvn verify` зелёный (pre-existing flaky tests в `PlantService` / `DataJpaTest` есть в develop тоже)
- [x] ArchUnit проходит
- [x] Нет новых транзитивных зависимостей