### PR TITLE
feat: гостевой вход POST /auth/guest + POST /auth/guest/convert (#227)

### DIFF
--- a/src/main/java/com/plantcare/api/ApiExceptionHandler.java
+++ b/src/main/java/com/plantcare/api/ApiExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.plantcare.api;
 
 import com.plantcare.api.auth.exception.AuthTokenException;
+import com.plantcare.api.auth.exception.GuestConvertException;
 import com.plantcare.api.auth.exception.RateLimitExceededException;
 import com.plantcare.api.dto.ApiErrorResponse;
 import com.plantcare.api.dto.FieldError;
@@ -87,6 +88,16 @@ public class ApiExceptionHandler {
     @ExceptionHandler(AuthTokenException.class)
     public ResponseEntity<ApiErrorResponse> handleAuthToken(AuthTokenException e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiErrorResponse.of(e.getCode().name(), e.getMessage()));
+    }
+
+    @ExceptionHandler(GuestConvertException.class)
+    public ResponseEntity<ApiErrorResponse> handleGuestConvert(GuestConvertException e) {
+        HttpStatus status = switch (e.getCode()) {
+            case NOT_A_GUEST -> HttpStatus.FORBIDDEN;
+            case IDENTITY_ALREADY_TAKEN -> HttpStatus.CONFLICT;
+        };
+        return ResponseEntity.status(status)
                 .body(ApiErrorResponse.of(e.getCode().name(), e.getMessage()));
     }
 

--- a/src/main/java/com/plantcare/api/auth/exception/GuestConvertException.java
+++ b/src/main/java/com/plantcare/api/auth/exception/GuestConvertException.java
@@ -1,0 +1,31 @@
+package com.plantcare.api.auth.exception;
+
+import lombok.Getter;
+
+/**
+ * Бросается при ошибках конвертации гостевого аккаунта (issue #227).
+ * Маппится через {@link com.plantcare.api.ApiExceptionHandler}.
+ */
+@Getter
+public class GuestConvertException extends RuntimeException {
+
+    public enum Code {
+        NOT_A_GUEST,
+        IDENTITY_ALREADY_TAKEN
+    }
+
+    private final Code code;
+
+    public GuestConvertException(Code code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    public static GuestConvertException notAGuest(String message) {
+        return new GuestConvertException(Code.NOT_A_GUEST, message);
+    }
+
+    public static GuestConvertException identityAlreadyTaken(String message) {
+        return new GuestConvertException(Code.IDENTITY_ALREADY_TAKEN, message);
+    }
+}

--- a/src/main/java/com/plantcare/api/auth/ratelimit/GuestRateLimiter.java
+++ b/src/main/java/com/plantcare/api/auth/ratelimit/GuestRateLimiter.java
@@ -1,0 +1,55 @@
+package com.plantcare.api.auth.ratelimit;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * In-memory rate limiter для {@code POST /api/v1/auth/guest} (issue #227).
+ * Не более 3 новых гостей с одного IP за час. Caffeine со sliding-window
+ * через expireAfterWrite (аналогично {@link MagicLinkRateLimiter}).
+ */
+@Component
+public class GuestRateLimiter {
+
+    private final Cache<String, AtomicInteger> attempts;
+    private final int maxNew;
+    private final long windowSeconds;
+
+    public GuestRateLimiter(
+            @Value("${plantcare.auth.guest.rate-limit.max-new:3}") int maxNew,
+            @Value("${plantcare.auth.guest.rate-limit.window-seconds:3600}") long windowSeconds) {
+        this.maxNew = maxNew;
+        this.windowSeconds = windowSeconds;
+        this.attempts = Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofSeconds(windowSeconds))
+                .maximumSize(50_000)
+                .build();
+    }
+
+    /**
+     * Проверяет, превышен ли лимит создания новых гостей для ключа (IP).
+     * Не учитывает restore-сценарий — только реальное создание нового гостя.
+     */
+    public boolean isBlocked(String key) {
+        AtomicInteger c = attempts.getIfPresent(key);
+        return c != null && c.get() >= maxNew;
+    }
+
+    /**
+     * Записывает факт создания нового гостя от ключа.
+     */
+    public void recordNew(String key) {
+        attempts.asMap()
+                .computeIfAbsent(key, k -> new AtomicInteger(0))
+                .incrementAndGet();
+    }
+
+    public long getWindowSeconds() {
+        return windowSeconds;
+    }
+}

--- a/src/main/java/com/plantcare/api/auth/service/GuestAuthService.java
+++ b/src/main/java/com/plantcare/api/auth/service/GuestAuthService.java
@@ -1,0 +1,193 @@
+package com.plantcare.api.auth.service;
+
+import com.plantcare.api.auth.exception.GuestConvertException;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * Гостевой вход и конвертация гостя в реальный аккаунт (issue #227).
+ *
+ * <p>Правила гостевого флоу:
+ * <ul>
+ *   <li>{@code POST /auth/guest} — создаёт нового гостя или восстанавливает сессию
+ *       по {@code deviceId}.</li>
+ *   <li>{@code POST /auth/guest/convert} — переводит гостевой аккаунт в реальный
+ *       (привязывает email/Apple/Google), данные сохраняются.</li>
+ * </ul>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GuestAuthService {
+
+    private final UserRepository userRepository;
+    private final TokenService tokenService;
+    private final MagicLinkService magicLinkService;
+    private final AuthService authService;
+
+    /**
+     * Результат гостевого входа.
+     *
+     * @param pair      пара токенов
+     * @param isNewUser {@code true} если создан новый пользователь, {@code false} — восстановление
+     */
+    public record GuestLoginResult(TokenPair pair, boolean isNewUser) {
+    }
+
+    /**
+     * Гостевой вход по {@code deviceId}. Идемпотентен: повторный вызов с тем же
+     * {@code deviceId} восстанавливает сессию, не создаёт дубль.
+     *
+     * @param deviceId клиентский UUID4 устройства (валидация формата — на уровне контроллера)
+     * @return пара токенов + признак нового пользователя
+     */
+    @Transactional
+    public GuestLoginResult loginOrRestore(String deviceId) {
+        Optional<User> existing = userRepository.findByDeviceId(deviceId);
+        if (existing.isPresent()) {
+            User user = existing.get();
+            log.info("Guest restore: userId={}, deviceId={}", user.getId(), deviceId);
+            return new GuestLoginResult(tokenService.issuePair(user), false);
+        }
+
+        User guest = new User();
+        guest.setGuest(true);
+        guest.setDeviceId(deviceId);
+        try {
+            User saved = userRepository.saveAndFlush(guest);
+            log.info("Guest created: userId={}, deviceId={}", saved.getId(), deviceId);
+            return new GuestLoginResult(tokenService.issuePair(saved), true);
+        } catch (DataIntegrityViolationException e) {
+            // Гонка: параллельный запрос успел создать гостя с тем же deviceId.
+            User race = userRepository.findByDeviceId(deviceId)
+                    .orElseThrow(() -> e);
+            log.info("Guest concurrent create, re-resolved: userId={}", race.getId());
+            return new GuestLoginResult(tokenService.issuePair(race), false);
+        }
+    }
+
+    /**
+     * Конвертирует гостевой аккаунт в реальный через email (magic-link flow).
+     * После вызова отправляется письмо с magic-link; финальные токены будут выданы
+     * при верификации через {@code POST /auth/email/verify}.
+     *
+     * @param guest  текущий пользователь (должен быть гостем)
+     * @param email  email для привязки
+     */
+    @Transactional
+    public void convertViaEmail(User guest, String email) {
+        ensureGuest(guest);
+
+        String normalizedEmail = email.trim().toLowerCase();
+        checkEmailNotTaken(normalizedEmail, guest.getId());
+
+        // Привязываем email, снимаем признак гостя, чистим deviceId.
+        guest.setEmail(normalizedEmail);
+        guest.setEmailVerified(false); // подтвердится после клика по magic-link
+        guest.setGuest(false);
+        guest.setDeviceId(null);
+        userRepository.save(guest);
+
+        log.info("Guest converted via EMAIL: userId={}, email={}", guest.getId(), normalizedEmail);
+        magicLinkService.request(normalizedEmail);
+    }
+
+    /**
+     * Конвертирует гостевой аккаунт через Google id-token.
+     *
+     * @param guest    текущий пользователь (должен быть гостем)
+     * @param email    email из верифицированного Google-токена
+     * @param subject  Google sub
+     * @return новая пара токенов
+     */
+    @Transactional
+    public TokenPair convertViaGoogle(User guest, String email, String subject) {
+        ensureGuest(guest);
+
+        String normalizedEmail = email.trim().toLowerCase();
+        checkEmailNotTaken(normalizedEmail, guest.getId());
+        checkGoogleSubjectNotTaken(subject, guest.getId());
+
+        guest.setEmail(normalizedEmail);
+        guest.setEmailVerified(true);
+        guest.setGoogleSubject(subject);
+        guest.setGuest(false);
+        guest.setDeviceId(null);
+        userRepository.save(guest);
+
+        log.info("Guest converted via GOOGLE: userId={}", guest.getId());
+        return tokenService.issuePair(guest);
+    }
+
+    /**
+     * Конвертирует гостевой аккаунт через Apple id-token.
+     *
+     * @param guest    текущий пользователь (должен быть гостем)
+     * @param email    email (может быть null при private relay)
+     * @param subject  Apple sub
+     * @return новая пара токенов
+     */
+    @Transactional
+    public TokenPair convertViaApple(User guest, String email, String subject) {
+        ensureGuest(guest);
+
+        if (email != null && !email.isBlank()) {
+            String normalizedEmail = email.trim().toLowerCase();
+            checkEmailNotTaken(normalizedEmail, guest.getId());
+            guest.setEmail(normalizedEmail);
+            guest.setEmailVerified(true);
+        }
+        checkAppleSubjectNotTaken(subject, guest.getId());
+
+        guest.setAppleSubject(subject);
+        guest.setGuest(false);
+        guest.setDeviceId(null);
+        userRepository.save(guest);
+
+        log.info("Guest converted via APPLE: userId={}", guest.getId());
+        return tokenService.issuePair(guest);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private void ensureGuest(User user) {
+        if (!user.isGuest()) {
+            throw GuestConvertException.notAGuest(
+                    "User is not a guest account and cannot be converted");
+        }
+    }
+
+    private void checkEmailNotTaken(String normalizedEmail, Long currentUserId) {
+        userRepository.findByEmail(normalizedEmail)
+                .filter(u -> !u.getId().equals(currentUserId))
+                .ifPresent(u -> {
+                    throw GuestConvertException.identityAlreadyTaken(
+                            "Email is already associated with another account");
+                });
+    }
+
+    private void checkGoogleSubjectNotTaken(String subject, Long currentUserId) {
+        userRepository.findByGoogleSubject(subject)
+                .filter(u -> !u.getId().equals(currentUserId))
+                .ifPresent(u -> {
+                    throw GuestConvertException.identityAlreadyTaken(
+                            "Google account is already associated with another account");
+                });
+    }
+
+    private void checkAppleSubjectNotTaken(String subject, Long currentUserId) {
+        userRepository.findByAppleSubject(subject)
+                .filter(u -> !u.getId().equals(currentUserId))
+                .ifPresent(u -> {
+                    throw GuestConvertException.identityAlreadyTaken(
+                            "Apple account is already associated with another account");
+                });
+    }
+}

--- a/src/main/java/com/plantcare/api/v1/AuthController.java
+++ b/src/main/java/com/plantcare/api/v1/AuthController.java
@@ -4,14 +4,20 @@ import com.plantcare.api.generated.AuthApi;
 import com.plantcare.api.generated.model.AppleAuthRequest;
 import com.plantcare.api.generated.model.EmailRequest;
 import com.plantcare.api.generated.model.GoogleAuthRequest;
+import com.plantcare.api.generated.model.GuestConvertRequest;
+import com.plantcare.api.generated.model.GuestConvertResponse;
+import com.plantcare.api.generated.model.GuestLoginRequest;
+import com.plantcare.api.generated.model.GuestLoginResponse;
 import com.plantcare.api.generated.model.LogoutRequest;
 import com.plantcare.api.generated.model.MagicLinkVerifyRequest;
 import com.plantcare.api.generated.model.RefreshRequest;
 import com.plantcare.api.generated.model.TokenPairResponse;
 import com.plantcare.api.CurrentUserProvider;
 import com.plantcare.api.auth.exception.RateLimitExceededException;
+import com.plantcare.api.auth.ratelimit.GuestRateLimiter;
 import com.plantcare.api.auth.ratelimit.MagicLinkRateLimiter;
 import com.plantcare.api.auth.service.AuthService;
+import com.plantcare.api.auth.service.GuestAuthService;
 import com.plantcare.api.auth.service.LogoutService;
 import com.plantcare.api.auth.service.MagicLinkService;
 import com.plantcare.api.auth.service.RefreshService;
@@ -44,8 +50,10 @@ public class AuthController implements AuthApi {
     private final RefreshService refreshService;
     private final MagicLinkService magicLinkService;
     private final LogoutService logoutService;
+    private final GuestAuthService guestAuthService;
     private final CurrentUserProvider currentUserProvider;
     private final MagicLinkRateLimiter rateLimiter;
+    private final GuestRateLimiter guestRateLimiter;
     private final HttpServletRequest httpRequest;
 
     @Override
@@ -99,6 +107,73 @@ public class AuthController implements AuthApi {
         logoutService.logoutAll(currentUserProvider.currentUserId());
     }
 
+    // ===== Guest auth (issue #227) =====
+
+    @Override
+    public GuestLoginResponse guestLogin(GuestLoginRequest request) {
+        String deviceId = request.getDeviceId();
+        String ip = httpRequest.getRemoteAddr();
+
+        // Rate-limit применяется ко ВСЕМ запросам с этого IP (не только к созданиям).
+        // Это консервативный подход: restore-запрос тоже считается, что не позволяет
+        // злоупотреблять эндпоинтом даже при повторе одного deviceId.
+        if (guestRateLimiter.isBlocked(ip)) {
+            log.warn("Guest rate-limit triggered for ip={}", ip);
+            throw new RateLimitExceededException(
+                    "Too many guest auth requests from this IP", guestRateLimiter.getWindowSeconds());
+        }
+
+        var result = guestAuthService.loginOrRestore(deviceId);
+
+        if (result.isNewUser()) {
+            guestRateLimiter.recordNew(ip);
+        }
+        log.info("Guest login: isNewUser={}", result.isNewUser());
+
+        var pair = result.pair();
+        return new GuestLoginResponse(
+                pair.accessToken(),
+                pair.refreshToken(),
+                pair.expiresIn(),
+                TokenPair.TOKEN_TYPE,
+                result.isNewUser()
+        );
+    }
+
+    @Override
+    public GuestConvertResponse guestConvert(GuestConvertRequest request) {
+        User guest = currentUserProvider.currentUser();
+        var provider = request.getProvider();
+
+        return switch (provider) {
+            case EMAIL -> {
+                if (request.getEmail() == null || request.getEmail().isBlank()) {
+                    throw new IllegalArgumentException("email is required for provider=EMAIL");
+                }
+                guestAuthService.convertViaEmail(guest, request.getEmail());
+                yield new GuestConvertResponse(GuestConvertResponse.StatusEnum.EMAIL_SENT);
+            }
+            case GOOGLE -> {
+                if (request.getIdToken() == null || request.getIdToken().isBlank()) {
+                    throw new IllegalArgumentException("idToken is required for provider=GOOGLE");
+                }
+                ExternalIdentity identity = googleTokenVerifier.verify(request.getIdToken());
+                TokenPair pair = guestAuthService.convertViaGoogle(
+                        guest, identity.email(), identity.subject());
+                yield toConvertResponse(pair);
+            }
+            case APPLE -> {
+                if (request.getIdToken() == null || request.getIdToken().isBlank()) {
+                    throw new IllegalArgumentException("idToken is required for provider=APPLE");
+                }
+                ExternalIdentity identity = appleTokenVerifier.verify(request.getIdToken());
+                TokenPair pair = guestAuthService.convertViaApple(
+                        guest, identity.email(), identity.subject());
+                yield toConvertResponse(pair);
+            }
+        };
+    }
+
     private void enforceRateLimit(String key) {
         if (rateLimiter.isBlocked(key)) {
             log.warn("Magic link rate-limit triggered");
@@ -114,5 +189,13 @@ public class AuthController implements AuthApi {
                 pair.refreshToken(),
                 pair.expiresIn(),
                 TokenPair.TOKEN_TYPE);
+    }
+
+    private static GuestConvertResponse toConvertResponse(TokenPair pair) {
+        return new GuestConvertResponse(GuestConvertResponse.StatusEnum.CONVERTED)
+                .accessToken(pair.accessToken())
+                .refreshToken(pair.refreshToken())
+                .expiresIn(pair.expiresIn())
+                .tokenType(TokenPair.TOKEN_TYPE);
     }
 }

--- a/src/main/java/com/plantcare/api/v1/MeController.java
+++ b/src/main/java/com/plantcare/api/v1/MeController.java
@@ -90,7 +90,8 @@ public class MeController implements MeApi {
                 profile.appleLinked(),
                 profile.googleLinked(),
                 profile.emailLinked(),
-                profile.telegramLinked()
+                profile.telegramLinked(),
+                profile.isGuest()
         )
                 .email(profile.email())
                 .avatar(profile.avatar())

--- a/src/main/java/com/plantcare/core/domain/User.java
+++ b/src/main/java/com/plantcare/core/domain/User.java
@@ -115,6 +115,17 @@ public class User extends BaseEntity {
     @Builder.Default
     private Map<String, Object> featureFlags = new HashMap<>();
 
+    // ===== Guest auth (issue #227) =====
+
+    /** TRUE для гостевых аккаунтов без email/social. */
+    @Column(name = "is_guest", nullable = false)
+    @Builder.Default
+    private boolean guest = false;
+
+    /** UUID устройства для идентификации гостя. NULL для обычных юзеров. */
+    @Column(name = "device_id", length = 64, unique = true)
+    private String deviceId;
+
     @Column(name = "is_blocked", nullable = false)
     @Builder.Default
     private boolean blocked = false;

--- a/src/main/java/com/plantcare/core/repository/UserRepository.java
+++ b/src/main/java/com/plantcare/core/repository/UserRepository.java
@@ -29,6 +29,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByGoogleSubject(String googleSubject);
 
+    // ===== Guest auth (issue #227) =====
+
+    /** Поиск гостевого пользователя по deviceId устройства. */
+    Optional<User> findByDeviceId(String deviceId);
+
     /**
      * Issue #79: pessimistic SELECT FOR UPDATE used during lazy calendar-token
      * generation, чтобы два параллельных нажатия на кнопку «Экспорт» не

--- a/src/main/java/com/plantcare/core/service/UserProfileService.java
+++ b/src/main/java/com/plantcare/core/service/UserProfileService.java
@@ -77,6 +77,7 @@ public class UserProfileService {
             boolean googleLinked,
             boolean emailLinked,
             boolean telegramLinked,
+            boolean isGuest,
             String calendarSubscriptionUrl
     ) {
     }
@@ -150,6 +151,7 @@ public class UserProfileService {
                 user.getGoogleSubject() != null,
                 user.getEmail() != null,
                 user.getTelegramChatId() != null,
+                user.isGuest(),
                 calendarSubscriptionUrl
         );
     }

--- a/src/main/resources/db/migration/V44__add_guest_support.sql
+++ b/src/main/resources/db/migration/V44__add_guest_support.sql
@@ -1,0 +1,11 @@
+-- Issue #227: гостевой вход (POST /auth/guest + POST /auth/guest/convert).
+-- Оба поля nullable — backward-compatible для rolling deploy.
+
+ALTER TABLE users
+    ADD COLUMN is_guest  BOOLEAN     NOT NULL DEFAULT FALSE,
+    ADD COLUMN device_id VARCHAR(64) UNIQUE;
+
+COMMENT ON COLUMN users.is_guest  IS 'TRUE для гостевых аккаунтов без email/social.';
+COMMENT ON COLUMN users.device_id IS 'UUID устройства для идентификации гостя. NULL для обычных юзеров.';
+
+CREATE INDEX idx_users_device_id ON users(device_id) WHERE device_id IS NOT NULL;

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -142,6 +142,10 @@ paths:
     $ref: './resources/auth.yaml#/paths/Logout'
   /api/v1/auth/logout-all:
     $ref: './resources/auth.yaml#/paths/LogoutAll'
+  /api/v1/auth/guest:
+    $ref: './resources/guest.yaml#/paths/GuestLogin'
+  /api/v1/auth/guest/convert:
+    $ref: './resources/guest.yaml#/paths/GuestConvert'
 
   /api/v1/health:
     $ref: './resources/health.yaml#/paths/Health'
@@ -294,6 +298,14 @@ components:
       $ref: './resources/auth.yaml#/schemas/LogoutRequest'
     TokenPairResponse:
       $ref: './resources/auth.yaml#/schemas/TokenPairResponse'
+    GuestLoginRequest:
+      $ref: './resources/guest.yaml#/schemas/GuestLoginRequest'
+    GuestLoginResponse:
+      $ref: './resources/guest.yaml#/schemas/GuestLoginResponse'
+    GuestConvertRequest:
+      $ref: './resources/guest.yaml#/schemas/GuestConvertRequest'
+    GuestConvertResponse:
+      $ref: './resources/guest.yaml#/schemas/GuestConvertResponse'
 
     HealthResponse:
       $ref: './resources/health.yaml#/schemas/HealthResponse'

--- a/src/main/resources/openapi/resources/guest.yaml
+++ b/src/main/resources/openapi/resources/guest.yaml
@@ -1,0 +1,166 @@
+# Гостевой вход и конвертация (issue #227).
+# POST /auth/guest — создать/восстановить гостевую сессию по deviceId.
+# POST /auth/guest/convert — конвертировать гостя в реальный аккаунт.
+
+paths:
+  GuestLogin:
+    post:
+      tags: [Auth]
+      operationId: guestLogin
+      summary: Гостевой вход / восстановление сессии
+      description: |
+        Принимает `deviceId` (UUID4, генерируется устройством один раз).
+        - Если гость с таким `deviceId` уже существует — восстанавливает сессию
+          (`isNewUser: false`).
+        - Иначе — создаёт нового гостевого пользователя (`isNewUser: true`).
+
+        Гость получает стандартную пару access+refresh токенов и имеет полный
+        доступ ко всем REST-эндпоинтам (в V1 ограничений нет).
+
+        Rate-limit: не более 3 **новых** гостей с одного IP за час.
+        Restore (существующий deviceId) от лимита не зависит.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/GuestLoginRequest'
+      responses:
+        '200':
+          description: Пара токенов выдана (новый гость или восстановление).
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/GuestLoginResponse'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '429':
+          $ref: '../_common/responses.yaml#/TooManyRequests'
+
+  GuestConvert:
+    post:
+      tags: [Auth]
+      operationId: guestConvert
+      summary: Конвертировать гостевой аккаунт в реальный
+      description: |
+        Привязывает email/Apple/Google к гостевому аккаунту. Данные пользователя
+        (растения, история) сохраняются. Требует валидный bearer-токен гостя.
+
+        Поддерживаемые провайдеры:
+        - `EMAIL` — отправляет magic-link на указанный email. `status="EMAIL_SENT"`;
+          токены обновятся после верификации через `POST /auth/email/verify`.
+          `accessToken`/`refreshToken` в ответе — `null`.
+        - `GOOGLE` — привязывает Google-аккаунт. `status="CONVERTED"`, новая пара
+          токенов в ответе.
+        - `APPLE` — привязывает Apple-аккаунт. `status="CONVERTED"`, новая пара
+          токенов в ответе.
+
+        После конвертации `deviceId` очищается, `isGuest` становится `false`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/GuestConvertRequest'
+      responses:
+        '200':
+          description: Конвертация запущена или завершена.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/GuestConvertResponse'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+        '403':
+          $ref: '../_common/responses.yaml#/Forbidden'
+        '409':
+          $ref: '../_common/responses.yaml#/Conflict'
+
+schemas:
+  GuestLoginRequest:
+    type: object
+    description: Тело POST /api/v1/auth/guest.
+    required: [deviceId]
+    properties:
+      deviceId:
+        type: string
+        pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        description: UUID4 устройства (lowercase). Генерируется клиентом один раз и не меняется.
+        example: '550e8400-e29b-41d4-a716-446655440000'
+
+  GuestLoginResponse:
+    type: object
+    description: Ответ на гостевой вход (issue #227).
+    required: [accessToken, refreshToken, expiresIn, tokenType, isNewUser]
+    properties:
+      accessToken:
+        type: string
+        description: Access-JWT для авторизации запросов.
+      refreshToken:
+        type: string
+        description: Refresh-JWT для получения новой пары.
+      expiresIn:
+        type: integer
+        format: int64
+        description: Время жизни access-токена в секундах.
+        example: 3600
+      tokenType:
+        type: string
+        description: Тип токена.
+        example: Bearer
+      isNewUser:
+        type: boolean
+        description: '`true` — создан новый гость; `false` — восстановление по deviceId.'
+
+  GuestConvertRequest:
+    type: object
+    description: Тело POST /api/v1/auth/guest/convert.
+    required: [provider]
+    properties:
+      provider:
+        type: string
+        enum: [EMAIL, GOOGLE, APPLE]
+        description: Провайдер для конвертации.
+      email:
+        type: string
+        format: email
+        maxLength: 320
+        description: Обязателен для `provider=EMAIL`.
+        example: user@example.com
+      idToken:
+        type: string
+        description: Google или Apple id-token. Обязателен для `provider=GOOGLE`/`APPLE`.
+
+  GuestConvertResponse:
+    type: object
+    description: Ответ на конвертацию гостевого аккаунта.
+    required: [status]
+    properties:
+      status:
+        type: string
+        enum: [CONVERTED, EMAIL_SENT]
+        description: |
+          `CONVERTED` — аккаунт конвертирован немедленно (GOOGLE/APPLE), токены в ответе.
+          `EMAIL_SENT` — magic-link отправлен (EMAIL), токены обновятся после верификации.
+      accessToken:
+        type: string
+        nullable: true
+        description: Новый access-JWT. Только при `status=CONVERTED`.
+      refreshToken:
+        type: string
+        nullable: true
+        description: Новый refresh-JWT. Только при `status=CONVERTED`.
+      expiresIn:
+        type: integer
+        format: int64
+        nullable: true
+        description: Время жизни access-токена в секундах. Только при `status=CONVERTED`.
+      tokenType:
+        type: string
+        nullable: true
+        description: Тип токена. Только при `status=CONVERTED`.
+        example: Bearer

--- a/src/main/resources/openapi/resources/me.yaml
+++ b/src/main/resources/openapi/resources/me.yaml
@@ -111,6 +111,7 @@ schemas:
       - googleLinked
       - emailLinked
       - telegramLinked
+      - isGuest
     properties:
       id:
         type: integer
@@ -229,6 +230,12 @@ schemas:
         type: boolean
         description: Привязан ли Telegram-аккаунт.
         example: true
+      isGuest:
+        type: boolean
+        description: |
+          `true` для гостевых аккаунтов (зарегистрированных через `POST /auth/guest`).
+          Мобилка использует это поле для показа баннера «Сохраните данные» (issue #227).
+        example: false
       calendarSubscriptionUrl:
         type: string
         nullable: true

--- a/src/test/java/com/plantcare/api/auth/service/GuestAuthServiceTest.java
+++ b/src/test/java/com/plantcare/api/auth/service/GuestAuthServiceTest.java
@@ -1,0 +1,243 @@
+package com.plantcare.api.auth.service;
+
+import com.plantcare.api.auth.exception.GuestConvertException;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit-тесты {@link GuestAuthService} (issue #227).
+ */
+@ExtendWith(MockitoExtension.class)
+class GuestAuthServiceTest {
+
+    private static final String DEVICE_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private TokenService tokenService;
+    @Mock
+    private MagicLinkService magicLinkService;
+    // AuthService is a dependency of GuestAuthService via constructor injection
+    @Mock
+    private AuthService authService;
+
+    @InjectMocks
+    private GuestAuthService guestAuthService;
+
+    private User guestUser;
+    private TokenPair tokenPair;
+
+    @BeforeEach
+    void setUp() {
+        guestUser = new User();
+        guestUser.setGuest(true);
+        guestUser.setDeviceId(DEVICE_ID);
+        ReflectionTestUtils.setField(guestUser, "id", 1L);
+
+        tokenPair = new TokenPair("access", "refresh", 3600L);
+    }
+
+    // ─── loginOrRestore — создание нового гостя ───────────────────────────────
+
+    @Test
+    void should_create_new_guest_and_return_is_new_user_true_when_device_id_unknown() {
+        // arrange
+        when(userRepository.findByDeviceId(DEVICE_ID)).thenReturn(Optional.empty());
+        when(userRepository.saveAndFlush(any())).thenReturn(guestUser);
+        when(tokenService.issuePair(guestUser)).thenReturn(tokenPair);
+
+        // act
+        var result = guestAuthService.loginOrRestore(DEVICE_ID);
+
+        // assert
+        assertThat(result.isNewUser()).isTrue();
+        assertThat(result.pair()).isEqualTo(tokenPair);
+        verify(userRepository).saveAndFlush(any());
+    }
+
+    @Test
+    void should_restore_session_and_return_is_new_user_false_when_device_id_exists() {
+        // arrange
+        when(userRepository.findByDeviceId(DEVICE_ID)).thenReturn(Optional.of(guestUser));
+        when(tokenService.issuePair(guestUser)).thenReturn(tokenPair);
+
+        // act
+        var result = guestAuthService.loginOrRestore(DEVICE_ID);
+
+        // assert
+        assertThat(result.isNewUser()).isFalse();
+        assertThat(result.pair()).isEqualTo(tokenPair);
+        verify(userRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void should_resolve_concurrent_guest_creation_when_integrity_violation_occurs() {
+        // arrange — race: параллельный запрос уже вставил пользователя
+        when(userRepository.findByDeviceId(DEVICE_ID))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(guestUser));
+        when(userRepository.saveAndFlush(any()))
+                .thenThrow(new DataIntegrityViolationException("unique constraint"));
+        when(tokenService.issuePair(guestUser)).thenReturn(tokenPair);
+
+        // act
+        var result = guestAuthService.loginOrRestore(DEVICE_ID);
+
+        // assert — re-resolve, isNewUser=false (уже создан другим запросом)
+        assertThat(result.isNewUser()).isFalse();
+        verify(userRepository, times(2)).findByDeviceId(DEVICE_ID);
+    }
+
+    // ─── convertViaEmail ─────────────────────────────────────────────────────
+
+    @Test
+    void should_attach_email_and_send_magic_link_when_converting_guest_via_email() {
+        // arrange
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.empty());
+        when(userRepository.save(guestUser)).thenReturn(guestUser);
+        doNothing().when(magicLinkService).request("user@example.com");
+
+        // act
+        guestAuthService.convertViaEmail(guestUser, "user@example.com");
+
+        // assert — email привязан, isGuest сброшен, deviceId очищен
+        assertThat(guestUser.getEmail()).isEqualTo("user@example.com");
+        assertThat(guestUser.isGuest()).isFalse();
+        assertThat(guestUser.getDeviceId()).isNull();
+        verify(magicLinkService).request("user@example.com");
+    }
+
+    @Test
+    void should_normalise_email_to_lowercase_when_converting_via_email() {
+        // arrange
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.empty());
+        when(userRepository.save(any())).thenReturn(guestUser);
+
+        // act
+        guestAuthService.convertViaEmail(guestUser, "  User@Example.COM  ");
+
+        // assert — email нормализован
+        assertThat(guestUser.getEmail()).isEqualTo("user@example.com");
+    }
+
+    @Test
+    void should_throw_not_a_guest_when_converting_real_user() {
+        // arrange
+        User realUser = new User();
+        realUser.setGuest(false);
+        realUser.setEmail("existing@example.com");
+
+        // act + assert
+        assertThatThrownBy(() -> guestAuthService.convertViaEmail(realUser, "other@example.com"))
+                .isInstanceOf(GuestConvertException.class)
+                .extracting(e -> ((GuestConvertException) e).getCode())
+                .isEqualTo(GuestConvertException.Code.NOT_A_GUEST);
+    }
+
+    @Test
+    void should_throw_identity_already_taken_when_email_occupied_by_another_user() {
+        // arrange — email уже занят другим аккаунтом
+        User other = new User();
+        ReflectionTestUtils.setField(other, "id", 99L); // different from guestUser.id=1L
+        when(userRepository.findByEmail(eq("taken@example.com"))).thenReturn(Optional.of(other));
+
+        // act + assert
+        assertThatThrownBy(() -> guestAuthService.convertViaEmail(guestUser, "taken@example.com"))
+                .isInstanceOf(GuestConvertException.class)
+                .extracting(e -> ((GuestConvertException) e).getCode())
+                .isEqualTo(GuestConvertException.Code.IDENTITY_ALREADY_TAKEN);
+
+        verify(magicLinkService, never()).request(any());
+    }
+
+    // ─── convertViaGoogle ────────────────────────────────────────────────────
+
+    @Test
+    void should_convert_guest_to_google_user_and_return_tokens() {
+        // arrange
+        when(userRepository.findByEmail("g@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findByGoogleSubject("google-sub")).thenReturn(Optional.empty());
+        when(userRepository.save(guestUser)).thenReturn(guestUser);
+        when(tokenService.issuePair(guestUser)).thenReturn(tokenPair);
+
+        // act
+        TokenPair result = guestAuthService.convertViaGoogle(guestUser, "g@example.com", "google-sub");
+
+        // assert
+        assertThat(result).isEqualTo(tokenPair);
+        assertThat(guestUser.getGoogleSubject()).isEqualTo("google-sub");
+        assertThat(guestUser.isGuest()).isFalse();
+        assertThat(guestUser.getDeviceId()).isNull();
+    }
+
+    @Test
+    void should_throw_identity_already_taken_when_google_subject_occupied() {
+        // arrange
+        User other = new User();
+        ReflectionTestUtils.setField(other, "id", 99L); // different from guestUser.id=1L
+        when(userRepository.findByEmail("g@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findByGoogleSubject("taken-sub")).thenReturn(Optional.of(other));
+
+        // act + assert
+        assertThatThrownBy(() -> guestAuthService.convertViaGoogle(guestUser, "g@example.com", "taken-sub"))
+                .isInstanceOf(GuestConvertException.class)
+                .extracting(e -> ((GuestConvertException) e).getCode())
+                .isEqualTo(GuestConvertException.Code.IDENTITY_ALREADY_TAKEN);
+    }
+
+    // ─── convertViaApple ─────────────────────────────────────────────────────
+
+    @Test
+    void should_convert_guest_to_apple_user_with_null_email_when_private_relay() {
+        // arrange — Apple private relay: email = null
+        when(userRepository.findByAppleSubject("apple-sub")).thenReturn(Optional.empty());
+        when(userRepository.save(guestUser)).thenReturn(guestUser);
+        when(tokenService.issuePair(guestUser)).thenReturn(tokenPair);
+
+        // act
+        TokenPair result = guestAuthService.convertViaApple(guestUser, null, "apple-sub");
+
+        // assert — email остался null, subject привязан
+        assertThat(result).isEqualTo(tokenPair);
+        assertThat(guestUser.getAppleSubject()).isEqualTo("apple-sub");
+        assertThat(guestUser.getEmail()).isNull();
+        assertThat(guestUser.isGuest()).isFalse();
+    }
+
+    @Test
+    void should_convert_guest_to_apple_user_with_email_when_provided() {
+        // arrange
+        when(userRepository.findByEmail("a@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findByAppleSubject("apple-sub")).thenReturn(Optional.empty());
+        when(userRepository.save(guestUser)).thenReturn(guestUser);
+        when(tokenService.issuePair(guestUser)).thenReturn(tokenPair);
+
+        // act
+        guestAuthService.convertViaApple(guestUser, "a@example.com", "apple-sub");
+
+        // assert
+        assertThat(guestUser.getEmail()).isEqualTo("a@example.com");
+        assertThat(guestUser.isEmailVerified()).isTrue();
+    }
+}

--- a/src/test/java/com/plantcare/api/v1/AuthControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/AuthControllerTest.java
@@ -1,9 +1,12 @@
 package com.plantcare.api.v1;
 
 import com.plantcare.api.auth.exception.AuthTokenException;
+import com.plantcare.api.auth.exception.GuestConvertException;
 import com.plantcare.api.auth.exception.RateLimitExceededException;
+import com.plantcare.api.auth.ratelimit.GuestRateLimiter;
 import com.plantcare.api.auth.ratelimit.MagicLinkRateLimiter;
 import com.plantcare.api.auth.service.AuthService;
+import com.plantcare.api.auth.service.GuestAuthService;
 import com.plantcare.api.auth.service.LogoutService;
 import com.plantcare.api.auth.service.MagicLinkService;
 import com.plantcare.api.auth.service.RefreshService;
@@ -27,6 +30,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -78,6 +82,12 @@ class AuthControllerTest {
 
     @MockitoBean
     private MagicLinkRateLimiter rateLimiter;
+
+    @MockitoBean
+    private GuestAuthService guestAuthService;
+
+    @MockitoBean
+    private GuestRateLimiter guestRateLimiter;
 
     private static User userMock(long id) {
         User user = mock(User.class);
@@ -374,5 +384,134 @@ class AuthControllerTest {
                 .andExpect(status().isNoContent());
 
         verify(logoutService).logoutAll(99L);
+    }
+
+    // ===================== POST /auth/guest (issue #227) =====================
+
+    @Test
+    void should_return_200_with_token_pair_and_is_new_user_true_when_new_guest_created() throws Exception {
+        // arrange
+        when(guestRateLimiter.isBlocked(anyString())).thenReturn(false);
+        var result = new GuestAuthService.GuestLoginResult(pair(), true);
+        when(guestAuthService.loginOrRestore("550e8400-e29b-41d4-a716-446655440000")).thenReturn(result);
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/auth/guest")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"deviceId\": \"550e8400-e29b-41d4-a716-446655440000\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("access-jwt"))
+                .andExpect(jsonPath("$.refreshToken").value("refresh-jwt"))
+                .andExpect(jsonPath("$.isNewUser").value(true));
+
+        verify(guestRateLimiter).recordNew(anyString());
+    }
+
+    @Test
+    void should_return_200_with_is_new_user_false_when_existing_device_id() throws Exception {
+        // arrange
+        when(guestRateLimiter.isBlocked(anyString())).thenReturn(false);
+        var result = new GuestAuthService.GuestLoginResult(pair(), false);
+        when(guestAuthService.loginOrRestore("550e8400-e29b-41d4-a716-446655440000")).thenReturn(result);
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/auth/guest")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"deviceId\": \"550e8400-e29b-41d4-a716-446655440000\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isNewUser").value(false));
+
+        // restore не фиксируется в rate-limiter
+        verify(guestRateLimiter, never()).recordNew(anyString());
+    }
+
+    @Test
+    void should_return_429_when_guest_rate_limit_exceeded() throws Exception {
+        // arrange — IP заблокирован
+        when(guestRateLimiter.isBlocked(anyString())).thenReturn(true);
+        when(guestRateLimiter.getWindowSeconds()).thenReturn(3600L);
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/auth/guest")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"deviceId\": \"550e8400-e29b-41d4-a716-446655440000\"}"))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(jsonPath("$.error.code").value("RATE_LIMITED"));
+
+        verify(guestAuthService, never()).loginOrRestore(anyString());
+    }
+
+    @Test
+    void should_return_400_when_device_id_is_invalid_uuid() throws Exception {
+        // act + assert — невалидный UUID4 → Bean Validation → 400
+        mockMvc.perform(post("/api/v1/auth/guest")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"deviceId\": \"not-a-uuid\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    // ===================== POST /auth/guest/convert (issue #227) =====================
+
+    @Test
+    void should_return_200_with_email_sent_status_when_converting_via_email() throws Exception {
+        // arrange
+        User guest = userMock(10L);
+        when(guest.isGuest()).thenReturn(true);
+        when(currentUserProvider.currentUser()).thenReturn(guest);
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/auth/guest/convert")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"provider\": \"EMAIL\", \"email\": \"new@example.com\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("EMAIL_SENT"));
+
+        verify(guestAuthService).convertViaEmail(guest, "new@example.com");
+    }
+
+    @Test
+    void should_return_403_when_converting_non_guest_account() throws Exception {
+        // arrange — токен реального юзера
+        User real = userMock(20L);
+        when(currentUserProvider.currentUser()).thenReturn(real);
+        doThrow(GuestConvertException.notAGuest("User is not a guest"))
+                .when(guestAuthService).convertViaEmail(any(), anyString());
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/auth/guest/convert")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"provider\": \"EMAIL\", \"email\": \"other@example.com\"}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("NOT_A_GUEST"));
+    }
+
+    @Test
+    void should_return_409_when_identity_already_taken_during_convert() throws Exception {
+        // arrange — email уже занят другим аккаунтом
+        User guest = userMock(30L);
+        when(currentUserProvider.currentUser()).thenReturn(guest);
+        doThrow(GuestConvertException.identityAlreadyTaken("Email already taken"))
+                .when(guestAuthService).convertViaEmail(any(), anyString());
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/auth/guest/convert")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"provider\": \"EMAIL\", \"email\": \"taken@example.com\"}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("IDENTITY_ALREADY_TAKEN"));
+    }
+
+    @Test
+    void should_return_400_when_email_missing_for_email_provider() throws Exception {
+        // arrange
+        User guest = userMock(40L);
+        when(currentUserProvider.currentUser()).thenReturn(guest);
+
+        // act + assert — email обязателен для provider=EMAIL
+        mockMvc.perform(post("/api/v1/auth/guest/convert")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"provider\": \"EMAIL\"}"))
+                .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/plantcare/api/v1/MeControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/MeControllerTest.java
@@ -95,6 +95,7 @@ class MeControllerTest {
                 true, SeasonalMode.FIXED, true,
                 Map.of("sharing", "true"),
                 true, false, true, true,
+                false,
                 "https://plants-care.example.com/calendar/abc123.ics");
         when(userProfileService.getProfile(any(User.class))).thenReturn(profile);
 
@@ -138,6 +139,7 @@ class MeControllerTest {
                 false, SeasonalMode.MULTIPLIER, false,
                 Map.of(),
                 false, false, true, true,
+                false,
                 null);
         when(userProfileService.getProfile(any(User.class))).thenReturn(profile);
 
@@ -161,6 +163,7 @@ class MeControllerTest {
                 false, SeasonalMode.MULTIPLIER, false,
                 Map.of(),
                 true, false, true, true,
+                false,
                 null);
         when(userProfileService.getProfile(any(User.class))).thenReturn(profile);
 
@@ -190,6 +193,7 @@ class MeControllerTest {
                 false, SeasonalMode.MULTIPLIER, false,
                 Map.of(),
                 false, false, false, true,
+                false,
                 null);
         when(userProfileService.getProfile(any(User.class))).thenReturn(profile);
 
@@ -278,6 +282,7 @@ class MeControllerTest {
                 true, SeasonalMode.FIXED, true,
                 Map.of(),
                 false, false, true, true,
+                false,
                 null);
         when(userProfileService.updateProfile(any(User.class), any(ProfileUpdate.class)))
                 .thenReturn(updated);
@@ -341,6 +346,7 @@ class MeControllerTest {
                 false, SeasonalMode.MULTIPLIER, false,
                 Map.of(),
                 false, false, true, true,
+                false,
                 null);
         when(userProfileService.updateProfile(any(User.class), any(ProfileUpdate.class)))
                 .thenReturn(updated);
@@ -543,6 +549,7 @@ class MeControllerTest {
                 false, SeasonalMode.MULTIPLIER, false,
                 Map.of(),
                 false, false, true, true,
+                false,
                 null);
     }
 


### PR DESCRIPTION
## Summary

- **V44 migration**: добавлены `is_guest BOOLEAN NOT NULL DEFAULT FALSE` и `device_id VARCHAR(64) UNIQUE` в таблицу `users`; создан partial index `idx_users_device_id`
- **GuestAuthService**: `loginOrRestore(deviceId)` — идемпотентный гостевой вход с защитой от race condition через `DataIntegrityViolationException`; `convertViaEmail/Google/Apple()` — конвертация гостя в реальный аккаунт
- **GuestRateLimiter**: Caffeine, до 3 новых гостей с одного IP за час (настраивается через `plantcare.auth.guest.rate-limit.*`)
- **GuestConvertException**: `NOT_A_GUEST → 403`, `IDENTITY_ALREADY_TAKEN → 409`
- **OpenAPI**: `guest.yaml` (GuestLoginRequest/Response, GuestConvertRequest/Response), пути добавлены в `openapi.yaml`
- **MeResponse**: поле `isGuest: bool` добавлено в схему и сериализацию
- **Тесты**: 11 unit-тестов `GuestAuthServiceTest`, 8 новых тестов в `AuthControllerTest`, исправлен `MeControllerTest`

## Test plan

- [ ] `POST /auth/guest` с новым `deviceId` → `201`, `isNewUser=true`, токены
- [ ] `POST /auth/guest` с известным `deviceId` → `200`, `isNewUser=false`, токены (restore)
- [ ] `POST /auth/guest` с одного IP > 3 раза подряд → `429 Too Many Requests`
- [ ] `POST /auth/guest/convert` `provider=EMAIL` → `200`, `status=EMAIL_SENT`; magic-link приходит на почту
- [ ] `POST /auth/guest/convert` `provider=GOOGLE` с валидным `idToken` → `200`, `status=CONVERTED`, токены
- [ ] `POST /auth/guest/convert` `provider=APPLE` → `200`, `status=CONVERTED`, токены
- [ ] `POST /auth/guest/convert` от не-гостевого юзера → `403`
- [ ] `POST /auth/guest/convert` на занятый email/subject → `409`
- [ ] `GET /api/v1/me` возвращает `isGuest: true` для гостя

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)