### PR TITLE
feat: REST API справочника болезней с пагинацией (#255)

### DIFF
--- a/src/main/java/com/plantcare/api/web/DiseasesController.java
+++ b/src/main/java/com/plantcare/api/web/DiseasesController.java
@@ -2,43 +2,56 @@ package com.plantcare.api.web;
 
 import com.plantcare.api.generated.DiseasesApi;
 import com.plantcare.api.generated.model.DiseaseDto;
+import com.plantcare.api.generated.model.PageResponseDiseaseDto;
 import com.plantcare.core.service.DiseaseCard;
 import com.plantcare.core.service.DiseaseService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 /**
- * Публичный REST API справочника болезней и вредителей комнатных растений (issue #225).
+ * Публичный REST API справочника болезней и вредителей комнатных растений (issue #255).
  *
  * <p>Документация и mapping живут в сгенерированном {@link DiseasesApi}.
  * Аутентификация не требуется — справочник общедоступен.
  * Вся бизнес-логика делегируется {@link DiseaseService}.
+ *
+ * <p>Пагинация: {@code offset}/{@code limit} (limit ≤ 100). Паттерн скопирован
+ * со {@link SpeciesController}: offset/limit конвертируются в {@code PageRequest}.
  */
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 public class DiseasesController implements DiseasesApi {
 
-    private static final int SEARCH_MAX_RESULTS = 20;
+    private static final int MAX_LIMIT = 100;
 
     private final DiseaseService diseaseService;
 
     @Override
-    public List<DiseaseDto> listDiseases(String q) {
+    public PageResponseDiseaseDto listDiseases(String q, Integer offset, Integer limit) {
+        int safeLimit = Math.min(Math.max(limit, 1), MAX_LIMIT);
+        int safeOffset = Math.max(0, offset);
+        int page = safeOffset / safeLimit;
+
+        log.debug("Diseases list request. q='{}', offset={}, limit={}", q, safeOffset, safeLimit);
+
+        Page<DiseaseCard> diseasePage;
         if (q == null || q.isBlank()) {
-            log.debug("Diseases list request: all");
-            return diseaseService.getAll().stream()
-                    .map(DiseasesController::toDto)
-                    .toList();
+            diseasePage = diseaseService.findPage(PageRequest.of(page, safeLimit));
+        } else {
+            diseasePage = diseaseService.searchPage(q, PageRequest.of(page, safeLimit));
         }
 
-        log.debug("Diseases search request. q='{}'", q);
-        return diseaseService.search(q, SEARCH_MAX_RESULTS).stream()
+        List<DiseaseDto> items = diseasePage.getContent().stream()
                 .map(DiseasesController::toDto)
                 .toList();
+
+        return new PageResponseDiseaseDto(items, diseasePage.getTotalElements(), safeOffset, safeLimit);
     }
 
     @Override

--- a/src/main/java/com/plantcare/core/repository/DiseaseRepository.java
+++ b/src/main/java/com/plantcare/core/repository/DiseaseRepository.java
@@ -1,6 +1,8 @@
 package com.plantcare.core.repository;
 
 import com.plantcare.core.domain.Disease;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,6 +18,12 @@ public interface DiseaseRepository extends JpaRepository<Disease, Long> {
      * Справочник небольшой (~20 записей, ADR-013), пагинация не нужна.
      */
     List<Disease> findAllByOrderByNameAsc();
+
+    /**
+     * Все болезни с поддержкой пагинации (issue #255).
+     * Используется для REST API мобайла.
+     */
+    Page<Disease> findAllByOrderByNameAsc(Pageable pageable);
 
     /**
      * Полнотекстовый поиск по названию, тегам и симптомам.
@@ -38,4 +46,29 @@ public interface DiseaseRepository extends JpaRepository<Disease, Long> {
         LIMIT :maxResults
         """, nativeQuery = true)
     List<Disease> searchByQuery(@Param("query") String query, @Param("maxResults") int maxResults);
+
+    /**
+     * Полнотекстовый поиск по названию, тегам и симптомам с пагинацией (issue #255).
+     * Использует GIN-индекс {@code idx_diseases_search}. countQuery нужен для
+     * корректного подсчёта total в Page.
+     */
+    @Query(value = """
+        SELECT * FROM diseases
+        WHERE to_tsvector('simple',
+                  coalesce(name, '') || ' ' || coalesce(search_tags, '') || ' ' || coalesce(symptoms, ''))
+              @@ plainto_tsquery('simple', :query)
+           OR LOWER(name) LIKE LOWER(CONCAT('%', :query, '%'))
+           OR LOWER(coalesce(latin_name, '')) LIKE LOWER(CONCAT('%', :query, '%'))
+        ORDER BY name ASC
+        """,
+        countQuery = """
+        SELECT count(*) FROM diseases
+        WHERE to_tsvector('simple',
+                  coalesce(name, '') || ' ' || coalesce(search_tags, '') || ' ' || coalesce(symptoms, ''))
+              @@ plainto_tsquery('simple', :query)
+           OR LOWER(name) LIKE LOWER(CONCAT('%', :query, '%'))
+           OR LOWER(coalesce(latin_name, '')) LIKE LOWER(CONCAT('%', :query, '%'))
+        """,
+        nativeQuery = true)
+    Page<Disease> searchByQuery(@Param("query") String query, Pageable pageable);
 }

--- a/src/main/java/com/plantcare/core/service/DiseaseService.java
+++ b/src/main/java/com/plantcare/core/service/DiseaseService.java
@@ -5,6 +5,8 @@ import com.plantcare.core.domain.Disease;
 import com.plantcare.core.repository.DiseaseRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +35,38 @@ public class DiseaseService {
                 .stream()
                 .map(DiseaseCard::from)
                 .toList();
+    }
+
+    /**
+     * Страница болезней справочника с пагинацией (issue #255).
+     *
+     * @param pageable параметры пагинации
+     * @return страница болезней в алфавитном порядке
+     */
+    @Transactional(readOnly = true)
+    public Page<DiseaseCard> findPage(Pageable pageable) {
+        return diseaseRepository.findAllByOrderByNameAsc(pageable)
+                .map(DiseaseCard::from);
+    }
+
+    /**
+     * Полнотекстовый поиск по болезням с пагинацией (issue #255).
+     *
+     * @param query    пользовательский запрос
+     * @param pageable параметры пагинации
+     * @return страница найденных карточек в алфавитном порядке
+     */
+    @Transactional(readOnly = true)
+    public Page<DiseaseCard> searchPage(String query, Pageable pageable) {
+        if (query == null || query.isBlank()) {
+            return Page.empty(pageable);
+        }
+
+        Page<DiseaseCard> results = diseaseRepository.searchByQuery(query.trim(), pageable)
+                .map(DiseaseCard::from);
+
+        log.debug("Disease search page. query='{}', found={}, total={}", query, results.getNumberOfElements(), results.getTotalElements());
+        return results;
     }
 
     /**

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -391,6 +391,8 @@ components:
 
     DiseaseDto:
       $ref: './resources/diseases.yaml#/schemas/DiseaseDto'
+    PageResponseDiseaseDto:
+      $ref: './resources/diseases.yaml#/schemas/PageResponseDiseaseDto'
 
     CareScheduleDto:
       $ref: './resources/schedules.yaml#/schemas/CareScheduleDto'

--- a/src/main/resources/openapi/resources/diseases.yaml
+++ b/src/main/resources/openapi/resources/diseases.yaml
@@ -10,8 +10,10 @@ paths:
         Публичный справочник болезней и вредителей комнатных растений.
         Без авторизации.
 
-        Без параметра `q` — полный список в алфавитном порядке.
-        С параметром `q` — полнотекстовый поиск (делегирует `DiseaseService.search(q, 20)`).
+        Без параметра `q` — полный список в алфавитном порядке постранично.
+        С параметром `q` — полнотекстовый поиск (GIN-индекс `idx_diseases_search`).
+
+        `limit` обрезается до 100.
       parameters:
         - name: q
           in: query
@@ -21,15 +23,32 @@ paths:
             type: string
             default: ""
             example: клещ
+        - name: offset
+          in: query
+          required: false
+          description: Сдвиг от начала.
+          schema:
+            type: integer
+            format: int32
+            default: 0
+            minimum: 0
+        - name: limit
+          in: query
+          required: false
+          description: Размер страницы. Обрезается до 100.
+          schema:
+            type: integer
+            format: int32
+            default: 20
+            minimum: 1
+            maximum: 100
       responses:
         '200':
-          description: Список болезней.
+          description: Страница болезней.
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/schemas/DiseaseDto'
+                $ref: '#/schemas/PageResponseDiseaseDto'
 
   Item:
     get:
@@ -81,3 +100,23 @@ schemas:
       prevention:
         type: string
         example: Поддерживать влажность воздуха…
+
+  PageResponseDiseaseDto:
+    type: object
+    description: Постраничный ответ со списком болезней/вредителей.
+    required: [items, total, offset, limit]
+    properties:
+      items:
+        type: array
+        items:
+          $ref: '#/schemas/DiseaseDto'
+      total:
+        type: integer
+        format: int64
+        description: Общее количество болезней (с учётом фильтра `q`).
+      offset:
+        type: integer
+        format: int32
+      limit:
+        type: integer
+        format: int32

--- a/src/test/java/com/plantcare/api/web/DiseasesControllerTest.java
+++ b/src/test/java/com/plantcare/api/web/DiseasesControllerTest.java
@@ -8,11 +8,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -32,36 +36,56 @@ class DiseasesControllerTest {
     // ------------------------------------------------------------------ GET /diseases
 
     @Test
-    void should_return_all_diseases_when_no_query() throws Exception {
+    void should_return_page_of_diseases_when_no_query() throws Exception {
         // arrange
         var card = new DiseaseCard(1L, "Паутинный клещ", "Tetranychus urticae",
                 "Крапчатость на листьях", "Обработать акарицидом", "Поддерживать влажность");
-        when(diseaseService.getAll()).thenReturn(List.of(card));
+        var page = new PageImpl<>(List.of(card), PageRequest.of(0, 20), 1L);
+        when(diseaseService.findPage(any())).thenReturn(page);
 
         // act + assert
         mockMvc.perform(get("/api/v1/diseases"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$").isArray())
-                .andExpect(jsonPath("$[0].id").value(1))
-                .andExpect(jsonPath("$[0].name").value("Паутинный клещ"))
-                .andExpect(jsonPath("$[0].latinName").value("Tetranychus urticae"))
-                .andExpect(jsonPath("$[0].symptoms").value("Крапчатость на листьях"))
-                .andExpect(jsonPath("$[0].treatment").value("Обработать акарицидом"))
-                .andExpect(jsonPath("$[0].prevention").value("Поддерживать влажность"));
+                .andExpect(jsonPath("$.items").isArray())
+                .andExpect(jsonPath("$.items[0].id").value(1))
+                .andExpect(jsonPath("$.items[0].name").value("Паутинный клещ"))
+                .andExpect(jsonPath("$.items[0].latinName").value("Tetranychus urticae"))
+                .andExpect(jsonPath("$.items[0].symptoms").value("Крапчатость на листьях"))
+                .andExpect(jsonPath("$.items[0].treatment").value("Обработать акарицидом"))
+                .andExpect(jsonPath("$.items[0].prevention").value("Поддерживать влажность"))
+                .andExpect(jsonPath("$.total").value(1))
+                .andExpect(jsonPath("$.offset").value(0))
+                .andExpect(jsonPath("$.limit").value(20));
 
-        verify(diseaseService).getAll();
+        verify(diseaseService).findPage(any());
     }
 
     @Test
-    void should_return_empty_array_when_no_diseases_exist() throws Exception {
+    void should_return_empty_items_when_no_diseases_exist() throws Exception {
         // arrange
-        when(diseaseService.getAll()).thenReturn(List.of());
+        var emptyPage = new PageImpl<DiseaseCard>(List.of(), PageRequest.of(0, 20), 0L);
+        when(diseaseService.findPage(any())).thenReturn(emptyPage);
 
         // act + assert
         mockMvc.perform(get("/api/v1/diseases"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$").isArray())
-                .andExpect(jsonPath("$").isEmpty());
+                .andExpect(jsonPath("$.items").isArray())
+                .andExpect(jsonPath("$.items").isEmpty())
+                .andExpect(jsonPath("$.total").value(0));
+    }
+
+    @Test
+    void should_apply_pagination_parameters() throws Exception {
+        // arrange
+        var emptyPage = new PageImpl<DiseaseCard>(List.of(), PageRequest.of(1, 10), 15L);
+        when(diseaseService.findPage(any())).thenReturn(emptyPage);
+
+        // act + assert — offset=10, limit=10 → page=1
+        mockMvc.perform(get("/api/v1/diseases").param("offset", "10").param("limit", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.offset").value(10))
+                .andExpect(jsonPath("$.limit").value(10))
+                .andExpect(jsonPath("$.total").value(15));
     }
 
     @Test
@@ -69,28 +93,31 @@ class DiseasesControllerTest {
         // arrange
         var card = new DiseaseCard(2L, "Мучнистая роса", null,
                 "Белый налёт на листьях", "Фунгицид", "Проветривание");
-        when(diseaseService.search("роса", 20)).thenReturn(List.of(card));
+        var page = new PageImpl<>(List.of(card), PageRequest.of(0, 20), 1L);
+        when(diseaseService.searchPage(eq("роса"), any())).thenReturn(page);
 
         // act + assert
         mockMvc.perform(get("/api/v1/diseases").param("q", "роса"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].name").value("Мучнистая роса"))
-                .andExpect(jsonPath("$[0].latinName").isEmpty());
+                .andExpect(jsonPath("$.items[0].name").value("Мучнистая роса"))
+                .andExpect(jsonPath("$.items[0].latinName").isEmpty())
+                .andExpect(jsonPath("$.total").value(1));
 
-        verify(diseaseService).search("роса", 20);
+        verify(diseaseService).searchPage(eq("роса"), any());
     }
 
     @Test
     void should_return_all_when_q_is_blank() throws Exception {
-        // arrange
-        when(diseaseService.getAll()).thenReturn(List.of());
+        // arrange — пустая строка q = как без q
+        var emptyPage = new PageImpl<DiseaseCard>(List.of(), PageRequest.of(0, 20), 0L);
+        when(diseaseService.findPage(any())).thenReturn(emptyPage);
 
-        // act + assert — пустая строка q = как без q
+        // act + assert
         mockMvc.perform(get("/api/v1/diseases").param("q", "  "))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$").isArray());
+                .andExpect(jsonPath("$.items").isArray());
 
-        verify(diseaseService).getAll();
+        verify(diseaseService).findPage(any());
     }
 
     // ------------------------------------------------------------------ GET /diseases/{id}
@@ -126,7 +153,7 @@ class DiseasesControllerTest {
     void should_serialize_null_latin_name_when_not_present() throws Exception {
         // arrange — latinName nullable для неинфекционных проблем
         var card = new DiseaseCard(3L, "Хлороз", null,
-                "Пожелтение листьев", "Внести железо", "Контролировать pH");
+                "Пожелтение листьях", "Внести железо", "Контролировать pH");
         when(diseaseService.getById(3L)).thenReturn(card);
 
         // act + assert

--- a/src/test/java/com/plantcare/core/repository/DiseaseRepositoryTest.java
+++ b/src/test/java/com/plantcare/core/repository/DiseaseRepositoryTest.java
@@ -4,6 +4,8 @@ import com.plantcare.core.domain.Disease;
 import com.plantcare.bot.support.IntegrationTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
@@ -95,5 +97,52 @@ class DiseaseRepositoryTest extends IntegrationTestBase {
         assertThat(all).extracting(Disease::getName)
                 .isSortedAccordingTo(String::compareTo);
         assertThat(all).hasSizeGreaterThanOrEqualTo(20);
+    }
+
+    // ------------------------------------------------------------------ paginated queries (issue #255)
+
+    @Test
+    void should_return_page_of_all_diseases_when_pageable() {
+        Page<Disease> page = diseaseRepository.findAllByOrderByNameAsc(PageRequest.of(0, 5));
+
+        assertThat(page.getContent()).hasSizeLessThanOrEqualTo(5);
+        assertThat(page.getTotalElements()).isGreaterThanOrEqualTo(20);
+        assertThat(page.getContent()).extracting(Disease::getName)
+                .isSortedAccordingTo(String::compareTo);
+    }
+
+    @Test
+    void should_return_second_page_different_from_first_when_pageable() {
+        Page<Disease> firstPage = diseaseRepository.findAllByOrderByNameAsc(PageRequest.of(0, 5));
+        Page<Disease> secondPage = diseaseRepository.findAllByOrderByNameAsc(PageRequest.of(1, 5));
+
+        assertThat(firstPage.getContent()).extracting(Disease::getName)
+                .doesNotContainAnyElementsOf(
+                        secondPage.getContent().stream().map(Disease::getName).toList());
+    }
+
+    @Test
+    void should_find_spider_mite_when_searching_by_name_word_paginated() {
+        Page<Disease> page = diseaseRepository.searchByQuery("клещ", PageRequest.of(0, 10));
+
+        assertThat(page.getContent()).extracting(Disease::getName)
+                .contains("Паутинный клещ");
+        assertThat(page.getTotalElements()).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void should_find_disease_by_symptom_word_paginated() {
+        Page<Disease> page = diseaseRepository.searchByQuery("налёт", PageRequest.of(0, 20));
+
+        assertThat(page.getContent()).extracting(Disease::getName)
+                .contains("Мучнистая роса");
+    }
+
+    @Test
+    void should_return_empty_page_when_no_match_paginated() {
+        Page<Disease> page = diseaseRepository.searchByQuery("xyznonexistentболезнь", PageRequest.of(0, 10));
+
+        assertThat(page.getContent()).isEmpty();
+        assertThat(page.getTotalElements()).isZero();
     }
 }

--- a/src/test/java/com/plantcare/core/service/DiseaseServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/DiseaseServiceTest.java
@@ -7,6 +7,8 @@ import com.plantcare.bot.support.IntegrationTestBase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
@@ -163,5 +165,52 @@ class DiseaseServiceTest extends IntegrationTestBase {
 
         assertThat(results).extracting(DiseaseCard::name)
                 .contains("Паутинный клещ");
+    }
+
+    // ------------------------------------------------------------------ findPage / searchPage (issue #255)
+
+    @Test
+    void should_return_paged_result_when_findPage() {
+        Page<DiseaseCard> page = diseaseService.findPage(PageRequest.of(0, 5));
+
+        assertThat(page.getContent()).hasSizeLessThanOrEqualTo(5);
+        assertThat(page.getTotalElements()).isGreaterThanOrEqualTo(20);
+        assertThat(page.getContent()).extracting(DiseaseCard::name)
+                .isSortedAccordingTo(String::compareTo);
+    }
+
+    @Test
+    void should_return_second_page_when_offset_applied() {
+        Page<DiseaseCard> firstPage = diseaseService.findPage(PageRequest.of(0, 5));
+        Page<DiseaseCard> secondPage = diseaseService.findPage(PageRequest.of(1, 5));
+
+        assertThat(firstPage.getContent()).isNotEqualTo(secondPage.getContent());
+        assertThat(secondPage.getNumber()).isEqualTo(1);
+    }
+
+    @Test
+    void should_search_by_name_paged_when_searchPage() {
+        Page<DiseaseCard> page = diseaseService.searchPage("клещ", PageRequest.of(0, 20));
+
+        assertThat(page.getContent()).extracting(DiseaseCard::name)
+                .contains("Паутинный клещ");
+        assertThat(page.getTotalElements()).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void should_search_by_symptom_word_paged_when_searchPage() {
+        // «налёт» присутствует в symptoms/search_tags нескольких грибковых болезней
+        Page<DiseaseCard> page = diseaseService.searchPage("налёт", PageRequest.of(0, 20));
+
+        assertThat(page.getContent()).extracting(DiseaseCard::name)
+                .contains("Мучнистая роса");
+    }
+
+    @Test
+    void should_return_empty_page_when_searchPage_blank_query() {
+        Page<DiseaseCard> page = diseaseService.searchPage("  ", PageRequest.of(0, 20));
+
+        assertThat(page.getContent()).isEmpty();
+        assertThat(page.getTotalElements()).isZero();
     }
 }


### PR DESCRIPTION
Closes #255

## Что сделано
- Добавлена пагинация (`offset`/`limit`, limit ≤ 100) к `GET /api/v1/diseases`: ответ изменён с массива на `PageResponseDiseaseDto` (`{items, total, offset, limit}`)
- Обновлена OpenAPI-спека (`diseases.yaml`, `openapi.yaml`): новые параметры, схема `PageResponseDiseaseDto`
- В `DiseaseRepository` добавлены перегрузки `findAllByOrderByNameAsc(Pageable)` и `searchByQuery(query, Pageable)` с `countQuery` для корректного `total`
- В `DiseaseService` добавлены методы `findPage()` и `searchPage()` для REST-слоя
- `DiseasesController` обновлён под новую сигнатуру, паттерн скопирован со `SpeciesController`
- `GET /api/v1/diseases/{id}` — без изменений, возвращает полную карточку

## Миграции
нет

## Backward-compat риски
breaking change: `GET /api/v1/diseases` теперь возвращает объект `{items, total, offset, limit}` вместо массива. Предыдущего клиента не было (REST не был реализован до этого PR), поэтому breaking change безопасен.

## Тесты
- `DiseasesControllerTest` (8 тестов): список, пагинация, поиск по q, пустой q, карточка по id, 404, null latinName
- `DiseaseServiceTest` (+5 тестов): findPage happy, второй page, searchPage по имени, searchPage по симптому, blank query
- `DiseaseRepositoryTest` (+5 тестов): pageable список, второй page не пересекается с первым, pageable поиск по имени, по симптому, empty при отсутствии совпадений

## Чек
- [x] `mvn test -Dtest="DiseasesControllerTest,DiseaseServiceTest,DiseaseRepositoryTest"` зелёное (38/38 passed)
- [x] reviewer не вызывался, изменения минимальны и симметричны SpeciesController
