### PR TITLE
feat: REST API per-season seasonal settings /me/seasonal (#256)

### DIFF
--- a/src/main/java/com/plantcare/api/v1/MeController.java
+++ b/src/main/java/com/plantcare/api/v1/MeController.java
@@ -4,8 +4,15 @@ import com.plantcare.api.CurrentUserProvider;
 import com.plantcare.api.generated.MeApi;
 import com.plantcare.api.generated.model.MeResponse;
 import com.plantcare.api.generated.model.MeUpdateRequest;
+import com.plantcare.api.generated.model.Season;
+import com.plantcare.api.generated.model.SeasonSettings;
+import com.plantcare.api.generated.model.SeasonalSettingsResponse;
+import com.plantcare.api.generated.model.SeasonalSettingsUpdateRequest;
 import com.plantcare.core.domain.User;
 import com.plantcare.core.domain.enums.SeasonalMode;
+import com.plantcare.core.seasonal.service.SeasonalSettingsService;
+import com.plantcare.core.seasonal.service.SeasonalSettingsService.SeasonSetting;
+import com.plantcare.core.seasonal.service.SeasonalSettingsService.SeasonalSettings;
 import com.plantcare.core.service.AccountDeletionService;
 import com.plantcare.core.service.UserProfileService;
 import com.plantcare.core.service.UserProfileService.Profile;
@@ -14,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.math.BigDecimal;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
@@ -33,6 +41,7 @@ public class MeController implements MeApi {
     private final UserProfileService userProfileService;
     private final CurrentUserProvider currentUserProvider;
     private final AccountDeletionService accountDeletionService;
+    private final SeasonalSettingsService seasonalSettingsService;
 
     @Override
     public MeResponse getMe() {
@@ -67,6 +76,62 @@ public class MeController implements MeApi {
         );
 
         return toResponse(userProfileService.updateProfile(user, update));
+    }
+
+    // ===================================================================
+    // Per-season настройки (issue #256): /api/v1/me/seasonal
+    // ===================================================================
+
+    @Override
+    public SeasonalSettingsResponse getSeasonalSettings() {
+        User user = currentUserProvider.currentUser();
+        log.info("GET /api/v1/me/seasonal: userId={}", user.getId());
+
+        return toSeasonalResponse(seasonalSettingsService.getSettings(user));
+    }
+
+    @Override
+    public SeasonalSettingsResponse updateSeasonalSettings(SeasonalSettingsUpdateRequest request) {
+        User user = currentUserProvider.currentUser();
+        log.info("PATCH /api/v1/me/seasonal: userId={}, season={}", user.getId(), request.getSeason());
+
+        SeasonalSettings settings = seasonalSettingsService.updateSeason(
+                user,
+                toDomainSeason(request.getSeason()),
+                toMultiplier(request.getMultiplier()),
+                request.getIntervalDays());
+        return toSeasonalResponse(settings);
+    }
+
+    @Override
+    public SeasonalSettingsResponse clearSeasonalInterval(Season season) {
+        User user = currentUserProvider.currentUser();
+        log.info("DELETE /api/v1/me/seasonal/{}: userId={}", season, user.getId());
+
+        return toSeasonalResponse(seasonalSettingsService.clearInterval(user, toDomainSeason(season)));
+    }
+
+    private static SeasonalSettingsResponse toSeasonalResponse(SeasonalSettings settings) {
+        return new SeasonalSettingsResponse(
+                settings.enabled(),
+                SeasonalSettingsResponse.ModeEnum.fromValue(settings.mode().name()),
+                settings.seasons().stream().map(MeController::toSeasonSettings).toList());
+    }
+
+    private static SeasonSettings toSeasonSettings(SeasonSetting setting) {
+        // multiplier обязателен в схеме (NUMERIC NOT NULL в БД); intervalDays опционален.
+        return new SeasonSettings(
+                Season.fromValue(setting.season().name()),
+                setting.multiplier().doubleValue())
+                .intervalDays(setting.intervalDays());
+    }
+
+    private static com.plantcare.core.domain.enums.Season toDomainSeason(Season season) {
+        return com.plantcare.core.domain.enums.Season.valueOf(season.getValue());
+    }
+
+    private static BigDecimal toMultiplier(Double value) {
+        return value == null ? null : BigDecimal.valueOf(value);
     }
 
     private static MeResponse toResponse(Profile profile) {

--- a/src/main/java/com/plantcare/core/seasonal/service/SeasonalSettingsService.java
+++ b/src/main/java/com/plantcare/core/seasonal/service/SeasonalSettingsService.java
@@ -1,0 +1,144 @@
+package com.plantcare.core.seasonal.service;
+
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.Season;
+import com.plantcare.core.domain.enums.SeasonalMode;
+import com.plantcare.core.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+/**
+ * Per-season настройки сезонности для REST API ({@code /api/v1/me/seasonal}, issue #256).
+ *
+ * <p>Паритет с ботом ({@link com.plantcare.bot.seasonal.service.SeasonalMenuService}):
+ * на стороне бота те же поля {@code summerMultiplier}/{@code winterMultiplier} и
+ * {@code summerIntervalOverrideDays}/{@code winterIntervalOverrideDays} меняются через
+ * inline-кнопки. Здесь — тот же набор операций, но через явные значения от мобильного
+ * клиента, а не циклический перебор шагов.
+ *
+ * <p>Глобальный флаг {@code seasonalEnabled} и {@code seasonalMode} здесь только читаются
+ * (для контекста ответа); меняются они через {@code PATCH /api/v1/me}
+ * ({@link com.plantcare.core.service.UserProfileService}).
+ *
+ * <p>Реально применяемое значение к расчёту {@code next_due_at} считает
+ * {@link SeasonalIntervalService}; этот сервис только хранит per-season настройки.
+ * Внешних вызовов (Telegram) внутри транзакции нет — только чтение/запись БД.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SeasonalSettingsService {
+
+    /** Границы множителя совпадают с UI бота (шаги 0.50..1.50). */
+    static final BigDecimal MIN_MULTIPLIER = new BigDecimal("0.50");
+    static final BigDecimal MAX_MULTIPLIER = new BigDecimal("1.50");
+
+    private final UserRepository userRepository;
+
+    /** Per-season настройки одного сезона (множитель + опциональный fixed-интервал). */
+    public record SeasonSetting(Season season, BigDecimal multiplier, Integer intervalDays) {
+    }
+
+    /** Снимок настроек сезонности пользователя для {@code GET /api/v1/me/seasonal}. */
+    public record SeasonalSettings(boolean enabled, SeasonalMode mode, List<SeasonSetting> seasons) {
+    }
+
+    /** Текущие per-season настройки пользователя по обоим сезонам. */
+    @Transactional(readOnly = true)
+    public SeasonalSettings getSettings(User user) {
+        return new SeasonalSettings(
+                user.isSeasonalEnabled(),
+                user.getSeasonalMode(),
+                List.of(
+                        toSetting(user, Season.SUMMER),
+                        toSetting(user, Season.WINTER)
+                )
+        );
+    }
+
+    /**
+     * Задаёт множитель и/или fixed-интервал для одного сезона. {@code null}-поле = «не менять».
+     * Множитель clamp'ится в [{@link #MIN_MULTIPLIER}..{@link #MAX_MULTIPLIER}] и округляется до
+     * сотых; интервал — в [{@value SeasonalIntervalService#MIN_INTERVAL_DAYS}..{@value
+     * SeasonalIntervalService#MAX_INTERVAL_DAYS}], как в боте.
+     */
+    @Transactional
+    public SeasonalSettings updateSeason(User user, Season season,
+                                         BigDecimal multiplier, Integer intervalDays) {
+        if (multiplier == null && intervalDays == null) {
+            throw new IllegalArgumentException(
+                    "At least one of multiplier/intervalDays must be provided");
+        }
+        if (multiplier != null) {
+            BigDecimal value = normalizeMultiplier(multiplier);
+            if (season.isSummer()) {
+                user.setSummerMultiplier(value);
+            } else {
+                user.setWinterMultiplier(value);
+            }
+        }
+        if (intervalDays != null) {
+            int value = clampInterval(intervalDays);
+            if (season.isSummer()) {
+                user.setSummerIntervalOverrideDays(value);
+            } else {
+                user.setWinterIntervalOverrideDays(value);
+            }
+        }
+        userRepository.save(user);
+        log.info("Seasonal settings updated via REST: userId={}, season={}, multiplierSet={}, intervalSet={}",
+                user.getId(), season, multiplier != null, intervalDays != null);
+
+        return getSettings(user);
+    }
+
+    /**
+     * Сбрасывает fixed-интервал сезона в {@code null} — сезон возвращается к дефолту
+     * (в режиме FIXED используется базовый интервал растения). Идемпотентно.
+     */
+    @Transactional
+    public SeasonalSettings clearInterval(User user, Season season) {
+        if (season.isSummer()) {
+            user.setSummerIntervalOverrideDays(null);
+        } else {
+            user.setWinterIntervalOverrideDays(null);
+        }
+        userRepository.save(user);
+        log.info("Seasonal interval cleared via REST: userId={}, season={}", user.getId(), season);
+
+        return getSettings(user);
+    }
+
+    private static SeasonSetting toSetting(User user, Season season) {
+        BigDecimal multiplier = season.isSummer()
+                ? user.getSummerMultiplier()
+                : user.getWinterMultiplier();
+        Integer intervalDays = season.isSummer()
+                ? user.getSummerIntervalOverrideDays()
+                : user.getWinterIntervalOverrideDays();
+        return new SeasonSetting(season, multiplier, intervalDays);
+    }
+
+    private static BigDecimal normalizeMultiplier(BigDecimal multiplier) {
+        BigDecimal scaled = multiplier.setScale(2, RoundingMode.HALF_UP);
+        if (scaled.compareTo(MIN_MULTIPLIER) < 0) return MIN_MULTIPLIER;
+        if (scaled.compareTo(MAX_MULTIPLIER) > 0) return MAX_MULTIPLIER;
+        return scaled;
+    }
+
+    private static int clampInterval(int days) {
+        if (days < SeasonalIntervalService.MIN_INTERVAL_DAYS) {
+            return SeasonalIntervalService.MIN_INTERVAL_DAYS;
+        }
+        if (days > SeasonalIntervalService.MAX_INTERVAL_DAYS) {
+            return SeasonalIntervalService.MAX_INTERVAL_DAYS;
+        }
+        return days;
+    }
+}

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -230,6 +230,10 @@ paths:
 
   /api/v1/me:
     $ref: './resources/me.yaml#/paths/Me'
+  /api/v1/me/seasonal:
+    $ref: './resources/me.yaml#/paths/Seasonal'
+  /api/v1/me/seasonal/{season}:
+    $ref: './resources/me.yaml#/paths/SeasonalItem'
 
   /api/v1/sharing:
     $ref: './resources/sharing.yaml#/paths/Collection'

--- a/src/main/resources/openapi/resources/me.yaml
+++ b/src/main/resources/openapi/resources/me.yaml
@@ -86,6 +86,105 @@ paths:
         '400':
           $ref: '../_common/responses.yaml#/BadRequest'
 
+  Seasonal:
+    get:
+      tags: [Me]
+      operationId: getSeasonalSettings
+      summary: Per-season настройки сезонности
+      description: |
+        Возвращает тонкие per-season настройки сезонности текущего пользователя:
+        множитель (`multiplier`) и фиксированный интервал (`intervalDays`) для
+        каждого сезона (`SUMMER`, `WINTER`), а также глобальный флаг `enabled`
+        и `mode`.
+
+        Какое поле реально применяется к расчёту — зависит от `mode`:
+        в режиме `MULTIPLIER` используется `multiplier`, в режиме `FIXED` —
+        `intervalDays` (а если он `null`, fallback на базовый интервал растения).
+
+        Глобальный флаг включения (`seasonalEnabled`) и режим (`seasonalMode`)
+        меняются через `PATCH /api/v1/me`; здесь они отдаются только для контекста.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Per-season настройки сезонности.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/SeasonalSettingsResponse'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+    patch:
+      tags: [Me]
+      operationId: updateSeasonalSettings
+      summary: Задать множитель/интервал для сезона
+      description: |
+        Устанавливает множитель и/или фиксированный интервал для одного сезона.
+        `season` обязателен. Переданные поля (`multiplier`, `intervalDays`)
+        применяются, отсутствующие (`null`) остаются без изменений.
+
+        - `multiplier` — коэффициент к базовому интервалу (диапазон `0.50..1.50`,
+          округляется до сотых). Используется в режиме `MULTIPLIER`.
+        - `intervalDays` — фиксированный интервал в днях (`1..60`). Используется
+          в режиме `FIXED`. Чтобы вернуть сезон к дефолту (использовать базовый
+          интервал растения), используйте `DELETE /api/v1/me/seasonal/{season}`.
+
+        Изменение влияет на ленивый пересчёт `next_due_at` так же, как в боте.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/SeasonalSettingsUpdateRequest'
+            example:
+              season: SUMMER
+              multiplier: 0.7
+      responses:
+        '200':
+          description: Настройки сезона обновлены.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/SeasonalSettingsResponse'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+
+  SeasonalItem:
+    delete:
+      tags: [Me]
+      operationId: clearSeasonalInterval
+      summary: Очистить фиксированный интервал сезона
+      description: |
+        Сбрасывает фиксированный интервал (`intervalDays`) указанного сезона в
+        `null` — сезон возвращается к дефолтному поведению (в режиме `FIXED`
+        используется базовый интервал растения). Множитель сезона не затрагивается.
+
+        Идемпотентно: повторный вызов для уже очищенного сезона тоже вернёт `200`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: season
+          in: path
+          required: true
+          description: Сезон, чей фиксированный интервал нужно очистить.
+          schema:
+            $ref: '#/schemas/Season'
+      responses:
+        '200':
+          description: Интервал сезона очищен; возвращены актуальные настройки.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/SeasonalSettingsResponse'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+
 schemas:
   MeResponse:
     type: object
@@ -290,3 +389,94 @@ schemas:
         nullable: true
         description: Учитывать погоду в рекомендациях.
         example: true
+
+  Season:
+    type: string
+    enum: [SUMMER, WINTER]
+    description: |
+      Сезон. Первая итерация сезонности оперирует только летом и зимой
+      (всё, что не лето — зима); границы настраиваются отдельно.
+
+  SeasonSettings:
+    type: object
+    description: Настройки одного сезона (множитель и фиксированный интервал).
+    required:
+      - season
+      - multiplier
+    properties:
+      season:
+        $ref: '#/schemas/Season'
+      multiplier:
+        type: number
+        format: double
+        minimum: 0.5
+        maximum: 1.5
+        description: |
+          Коэффициент к базовому интервалу растения. Применяется в режиме
+          `MULTIPLIER`. Например, базовый 10 дней × 0.8 = полив каждые 8 дней.
+        example: 0.8
+      intervalDays:
+        type: integer
+        format: int32
+        minimum: 1
+        maximum: 60
+        nullable: true
+        description: |
+          Фиксированный интервал в днях для этого сезона. Применяется в режиме
+          `FIXED`. `null` — интервал не задан, используется базовый интервал
+          растения.
+        example: 5
+
+  SeasonalSettingsResponse:
+    type: object
+    description: |
+      Per-season настройки сезонности пользователя (`GET /api/v1/me/seasonal`).
+      `enabled`/`mode` отдаются для контекста; меняются через `PATCH /api/v1/me`.
+    required:
+      - enabled
+      - mode
+      - seasons
+    properties:
+      enabled:
+        type: boolean
+        description: Глобальный флаг учёта сезонов (зеркало `seasonalEnabled`).
+        example: true
+      mode:
+        type: string
+        enum: [MULTIPLIER, FIXED]
+        description: Активный режим сезонности (зеркало `seasonalMode`).
+        example: MULTIPLIER
+      seasons:
+        type: array
+        description: Настройки по каждому сезону (`SUMMER`, `WINTER`).
+        items:
+          $ref: '#/schemas/SeasonSettings'
+
+  SeasonalSettingsUpdateRequest:
+    type: object
+    description: |
+      Задать множитель и/или фиксированный интервал одного сезона. `season`
+      обязателен; `multiplier`/`intervalDays` опциональны (отсутствующие не меняются).
+    required:
+      - season
+    properties:
+      season:
+        $ref: '#/schemas/Season'
+      multiplier:
+        type: number
+        format: double
+        minimum: 0.5
+        maximum: 1.5
+        nullable: true
+        description: Коэффициент к базовому интервалу (`0.50..1.50`).
+        example: 0.7
+      intervalDays:
+        type: integer
+        format: int32
+        minimum: 1
+        maximum: 60
+        nullable: true
+        description: |
+          Фиксированный интервал в днях (`1..60`). Для сброса в дефолт используйте
+          `DELETE /api/v1/me/seasonal/{season}`.
+        example: 5

--- a/src/test/java/com/plantcare/api/v1/MeControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/MeControllerTest.java
@@ -73,6 +73,9 @@ class MeControllerTest {
     @MockitoBean
     private CurrentUserProvider currentUserProvider;
 
+    @MockitoBean
+    private com.plantcare.core.seasonal.service.SeasonalSettingsService seasonalSettingsService;
+
     @BeforeEach
     void stubCurrentUser() {
         User user = mock(User.class);

--- a/src/test/java/com/plantcare/api/v1/MeSeasonalIT.java
+++ b/src/test/java/com/plantcare/api/v1/MeSeasonalIT.java
@@ -1,0 +1,297 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.bot.support.IntegrationTestBase;
+import com.plantcare.core.domain.Location;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.SeasonalMode;
+import com.plantcare.core.domain.enums.SeasonalOverride;
+import com.plantcare.core.repository.CareScheduleRepository;
+import com.plantcare.core.repository.LocationRepository;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for per-season seasonal settings REST API (issue #256):
+ * GET/PATCH /api/v1/me/seasonal and DELETE /api/v1/me/seasonal/{season}.
+ *
+ * <p>Covers the full stack (controller → SeasonalSettingsService → repository →
+ * Postgres 16 via Testcontainers) and the AC: set multiplier, set interval, clear,
+ * and influence on schedule recalculation (verified through the seasonal projection
+ * of GET /api/v1/plants/{id}/schedules).
+ */
+@AutoConfigureMockMvc
+class MeSeasonalIT extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PlantRepository plantRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @Autowired
+    private CareScheduleRepository careScheduleRepository;
+
+    @AfterEach
+    void cleanup() {
+        careScheduleRepository.deleteAll();
+        plantRepository.deleteAll();
+        locationRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // -----------------------------------------------------------------------
+    // GET — read current per-season settings
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_return_per_season_settings_when_get_seasonal() throws Exception {
+        // arrange
+        User user = userRepository.save(User.builder()
+                .telegramChatId(9_001L)
+                .timezone("Europe/Moscow")
+                .seasonalEnabled(true)
+                .seasonalMode(SeasonalMode.MULTIPLIER)
+                .summerMultiplier(new BigDecimal("0.80"))
+                .winterMultiplier(new BigDecimal("1.20"))
+                .build());
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/me/seasonal")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.enabled").value(true))
+                .andExpect(jsonPath("$.mode").value("MULTIPLIER"))
+                .andExpect(jsonPath("$.seasons[0].season").value("SUMMER"))
+                .andExpect(jsonPath("$.seasons[0].multiplier").value(0.8))
+                .andExpect(jsonPath("$.seasons[1].season").value("WINTER"))
+                .andExpect(jsonPath("$.seasons[1].multiplier").value(1.2));
+    }
+
+    // -----------------------------------------------------------------------
+    // PATCH — set multiplier for a season
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_set_multiplier_for_season_when_patch_seasonal() throws Exception {
+        // arrange
+        User user = userRepository.save(User.builder()
+                .telegramChatId(9_002L)
+                .timezone("Europe/Moscow")
+                .seasonalEnabled(true)
+                .seasonalMode(SeasonalMode.MULTIPLIER)
+                .summerMultiplier(new BigDecimal("0.80"))
+                .build());
+
+        String body = """
+                {"season": "SUMMER", "multiplier": 0.6}
+                """;
+
+        // act
+        mockMvc.perform(patch("/api/v1/me/seasonal")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId()))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.seasons[0].season").value("SUMMER"))
+                .andExpect(jsonPath("$.seasons[0].multiplier").value(0.6));
+
+        // assert — persisted
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        org.assertj.core.api.Assertions.assertThat(reloaded.getSummerMultiplier())
+                .isEqualByComparingTo(new BigDecimal("0.60"));
+    }
+
+    // -----------------------------------------------------------------------
+    // PATCH — set fixed interval for a season
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_set_interval_for_season_when_patch_seasonal() throws Exception {
+        // arrange
+        User user = userRepository.save(User.builder()
+                .telegramChatId(9_003L)
+                .timezone("Europe/Moscow")
+                .seasonalEnabled(true)
+                .seasonalMode(SeasonalMode.FIXED)
+                .build());
+
+        String body = """
+                {"season": "WINTER", "intervalDays": 14}
+                """;
+
+        // act
+        mockMvc.perform(patch("/api/v1/me/seasonal")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId()))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.seasons[1].season").value("WINTER"))
+                .andExpect(jsonPath("$.seasons[1].intervalDays").value(14));
+
+        // assert — persisted
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        org.assertj.core.api.Assertions.assertThat(reloaded.getWinterIntervalOverrideDays())
+                .isEqualTo(14);
+    }
+
+    // -----------------------------------------------------------------------
+    // DELETE — clear interval returns season to default
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_clear_interval_when_delete_seasonal_season() throws Exception {
+        // arrange — season has a fixed interval that we will clear
+        User user = userRepository.save(User.builder()
+                .telegramChatId(9_004L)
+                .timezone("Europe/Moscow")
+                .seasonalEnabled(true)
+                .seasonalMode(SeasonalMode.FIXED)
+                .summerIntervalOverrideDays(5)
+                .build());
+
+        // act
+        mockMvc.perform(delete("/api/v1/me/seasonal/SUMMER")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.seasons[0].season").value("SUMMER"))
+                .andExpect(jsonPath("$.seasons[0].intervalDays").doesNotExist());
+
+        // assert — interval reset to null (default behaviour)
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        org.assertj.core.api.Assertions.assertThat(reloaded.getSummerIntervalOverrideDays())
+                .isNull();
+    }
+
+    @Test
+    void should_be_idempotent_when_delete_already_cleared_interval() throws Exception {
+        // arrange — no interval set
+        User user = userRepository.save(User.builder()
+                .telegramChatId(9_005L)
+                .timezone("Europe/Moscow")
+                .seasonalEnabled(true)
+                .seasonalMode(SeasonalMode.FIXED)
+                .build());
+
+        // act + assert — repeated DELETE still 200
+        mockMvc.perform(delete("/api/v1/me/seasonal/WINTER")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk());
+        mockMvc.perform(delete("/api/v1/me/seasonal/WINTER")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.seasons[1].intervalDays").doesNotExist());
+    }
+
+    // -----------------------------------------------------------------------
+    // Influence on schedule — setting a multiplier changes the seasonal projection
+    // of GET /api/v1/plants/{id}/schedules (same recalculation as the bot).
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_affect_schedule_recalculation_when_multiplier_changed_via_rest() throws Exception {
+        // arrange — base interval 10, summer × 0.8 default = 8
+        User user = userRepository.save(User.builder()
+                .telegramChatId(9_006L)
+                .timezone("Asia/Almaty")
+                .seasonalEnabled(true)
+                .seasonalMode(SeasonalMode.MULTIPLIER)
+                .summerMultiplier(new BigDecimal("0.80"))
+                .winterMultiplier(new BigDecimal("1.20"))
+                .build());
+        long plantId = givenPlantWithWateringSchedule(user, 10).getId();
+
+        // sanity — summer projection is 8 before the change
+        mockMvc.perform(get("/api/v1/plants/" + plantId + "/schedules")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].seasonal.summerIntervalDays").value(8));
+
+        // act — change summer multiplier to 0.5 via REST
+        mockMvc.perform(patch("/api/v1/me/seasonal")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId()))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"season\": \"SUMMER\", \"multiplier\": 0.5}"))
+                .andExpect(status().isOk());
+
+        // assert — schedule projection now reflects 10 × 0.5 = 5
+        mockMvc.perform(get("/api/v1/plants/" + plantId + "/schedules")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].seasonal.active").value(true))
+                .andExpect(jsonPath("$[0].seasonal.summerIntervalDays").value(5))
+                .andExpect(jsonPath("$[0].seasonal.winterIntervalDays").value(12));
+    }
+
+    // -----------------------------------------------------------------------
+    // Validation — out-of-range value rejected with 400
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_reject_out_of_range_multiplier_with_400() throws Exception {
+        // arrange
+        User user = userRepository.save(User.builder()
+                .telegramChatId(9_007L)
+                .timezone("Europe/Moscow")
+                .seasonalEnabled(true)
+                .build());
+
+        // act + assert — multiplier 5.0 exceeds maximum 1.5
+        mockMvc.perform(patch("/api/v1/me/seasonal")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId()))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"season\": \"SUMMER\", \"multiplier\": 5.0}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // -----------------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------------
+
+    private Plant givenPlantWithWateringSchedule(User user, int baseIntervalDays) {
+        Location location = locationRepository.save(Location.builder()
+                .user(user)
+                .name("Test Location")
+                .defaultLocation(true)
+                .build());
+
+        Plant plant = plantRepository.save(Plant.builder()
+                .user(user)
+                .location(location)
+                .name("Test Plant")
+                .seasonalOverride(SeasonalOverride.INHERIT)
+                .build());
+
+        careScheduleRepository.save(com.plantcare.core.domain.CareSchedule.builder()
+                .plant(plant)
+                .taskType(com.plantcare.core.domain.enums.TaskType.WATERING)
+                .intervalDays(baseIntervalDays)
+                .nextDueAt(LocalDateTime.now().plusDays(baseIntervalDays))
+                .active(true)
+                .build());
+
+        return plant;
+    }
+}

--- a/src/test/java/com/plantcare/core/seasonal/service/SeasonalSettingsServiceTest.java
+++ b/src/test/java/com/plantcare/core/seasonal/service/SeasonalSettingsServiceTest.java
@@ -1,0 +1,100 @@
+package com.plantcare.core.seasonal.service;
+
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.Season;
+import com.plantcare.core.domain.enums.SeasonalMode;
+import com.plantcare.core.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link SeasonalSettingsService} — per-season setting mutation,
+ * clamping and clearing logic (issue #256). Repository is mocked; the service
+ * itself has no persistence side effects beyond {@code save}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SeasonalSettingsServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private SeasonalSettingsService service;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .seasonalEnabled(true)
+                .seasonalMode(SeasonalMode.MULTIPLIER)
+                .summerMultiplier(new BigDecimal("0.80"))
+                .winterMultiplier(new BigDecimal("1.20"))
+                .build();
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Test
+    void should_set_multiplier_rounded_to_two_decimals_when_update_multiplier() {
+        service.updateSeason(user, Season.SUMMER, new BigDecimal("0.666"), null);
+
+        assertThat(user.getSummerMultiplier()).isEqualByComparingTo(new BigDecimal("0.67"));
+    }
+
+    @Test
+    void should_clamp_multiplier_to_max_when_above_range() {
+        service.updateSeason(user, Season.WINTER, new BigDecimal("9.99"), null);
+
+        assertThat(user.getWinterMultiplier())
+                .isEqualByComparingTo(SeasonalSettingsService.MAX_MULTIPLIER);
+    }
+
+    @Test
+    void should_clamp_interval_to_bounds_when_above_max() {
+        service.updateSeason(user, Season.SUMMER, null, 999);
+
+        assertThat(user.getSummerIntervalOverrideDays())
+                .isEqualTo(SeasonalIntervalService.MAX_INTERVAL_DAYS);
+    }
+
+    @Test
+    void should_clear_interval_to_null_when_clear_called() {
+        user.setSummerIntervalOverrideDays(7);
+
+        service.clearInterval(user, Season.SUMMER);
+
+        assertThat(user.getSummerIntervalOverrideDays()).isNull();
+    }
+
+    @Test
+    void should_reject_update_when_no_field_provided() {
+        assertThatThrownBy(() -> service.updateSeason(user, Season.SUMMER, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_return_both_seasons_when_get_settings() {
+        var settings = service.getSettings(user);
+
+        assertThat(settings.enabled()).isTrue();
+        assertThat(settings.mode()).isEqualTo(SeasonalMode.MULTIPLIER);
+        List<Season> seasons = settings.seasons().stream()
+                .map(SeasonalSettingsService.SeasonSetting::season).toList();
+        assertThat(seasons).containsExactly(Season.SUMMER, Season.WINTER);
+    }
+}


### PR DESCRIPTION
Closes #256

## Что сделано
- REST API для per-season настроек сезонности (паритет бот↔REST), поверх тех же полей `User`, что использует бот:
  - `GET /api/v1/me/seasonal` — текущие множители/интервалы по сезонам (`SUMMER`, `WINTER`) + `enabled`/`mode` для контекста.
  - `PATCH /api/v1/me/seasonal` — задать множитель и/или фиксированный интервал одного сезона (`season` обязателен; переданные поля применяются, отсутствующие не меняются).
  - `DELETE /api/v1/me/seasonal/{season}` — очистить фиксированный интервал сезона (вернуть к дефолту: базовый интервал растения). Идемпотентно.
- Глобальный `seasonalEnabled`/`seasonalMode` остаётся в `PATCH /api/v1/me` (как и требует issue).
- Новый `SeasonalSettingsService` (core) — чтение/изменение/очистка per-season настроек с clamp множителя (0.50..1.50) и интервала (1..60), как в боте. Контроллер тонкий, поверх `MeApi`.
- Изменения влияют на пересчёт расписаний так же, как в боте: видно в seasonal-проекции `GET /api/v1/plants/{id}/schedules` (через `SeasonalIntervalService`).
- Спека contract-first обновлена в `src/main/resources/openapi/resources/me.yaml` (paths `Seasonal`/`SeasonalItem`, схемы `Season`/`SeasonSettings`/`SeasonalSettingsResponse`/`SeasonalSettingsUpdateRequest`) и зарегистрирована в корневом `openapi.yaml`. Операции попадают в `/v3/api-docs` (springdoc отражает сгенерированный `MeApi`).

Форма ресурса зафиксирована как под `/me/seasonal` (per issue: «под `/me/seasonal` vs отдельный `/seasonal`»).

## Миграции
нет (используются уже существующие колонки `users.summer_*`/`winter_*` из issue #67).

## Backward-compat риски
safe — только новые эндпоинты и новые схемы в спеке, существующее поведение `PATCH /me` не тронуто, схема БД не меняется.

## Тесты
- `MeSeasonalIT` (full stack, Testcontainers): GET настроек, PATCH множителя, PATCH интервала, DELETE (очистка + идемпотентность), влияние на пересчёт расписания (через seasonal-проекцию `/plants/{id}/schedules`, TZ `Asia/Almaty`), валидация диапазона (400).
- `SeasonalSettingsServiceTest` (unit): округление/clamp множителя, clamp интервала, очистка в null, отказ при пустом апдейте, чтение обоих сезонов.
- `MeControllerTest`: добавлен mock нового сервиса в @WebMvcTest-слайс.

Эти три набора зелёные: `MeSeasonalIT` 7/7, `SeasonalSettingsServiceTest` 6/6, `MeControllerTest` 20/20.

## Чек
- [ ] `mvn verify` полностью зелёное — **нет**, см. ниже.
- [x] Изменённый код и его тесты зелёные.

## Примечания по сборке
- В чекауте отсутствует Maven wrapper (`./mvnw`/`.mvn/`), поэтому сборка гонялась системным `mvn` (другого варианта в дереве нет). Это стоит вернуть отдельной задачей — не относится к #256.
- Полный `mvn verify` падает на тестах, **не связанных с этим PR**: `SpeciesSeedTest.allSpeciesSeeded`, `SpeciesRepositoryTest.topPopularReturnsInCorrectOrder`, `PlantServiceTest` (popularity ordering / markCareDone), `CareScheduleRepositoryTest...` — все из-за загрязнённой shared-БД переиспользуемого Testcontainer (`duplicate key value violates unique constraint "species_name_key"`). Эти же тесты падают на **нетронутом `develop`** (проверено запуском `SpeciesSeedTest` на чистой базовой ветке без изменений #256). Мой диф не добавляет видов, миграций и не трогает эти файлы. Сбросить общий контейнер не стал, чтобы не сломать БД параллельным агентам пула.
