### PR TITLE
feat: REST-parity bot→REST мелкие операции (#257)

### DIFF
--- a/src/main/java/com/plantcare/api/v1/MeController.java
+++ b/src/main/java/com/plantcare/api/v1/MeController.java
@@ -4,6 +4,7 @@ import com.plantcare.api.CurrentUserProvider;
 import com.plantcare.api.generated.MeApi;
 import com.plantcare.api.generated.model.MeResponse;
 import com.plantcare.api.generated.model.MeUpdateRequest;
+import com.plantcare.api.generated.model.WeatherLocationRequest;
 import com.plantcare.core.domain.User;
 import com.plantcare.core.domain.enums.SeasonalMode;
 import com.plantcare.core.service.AccountDeletionService;
@@ -49,6 +50,14 @@ public class MeController implements MeApi {
         Long userId = currentUserProvider.currentUserId();
         log.info("DELETE /api/v1/me: userId={}", userId);
         accountDeletionService.deleteAccount(userId);
+    }
+
+    @Override
+    public void updateWeatherLocation(WeatherLocationRequest request) {
+        User user = currentUserProvider.currentUser();
+        log.info("PUT /api/v1/me/weather-location: userId={}, lat={}, lon={}",
+                user.getId(), request.getLat(), request.getLon());
+        userProfileService.setWeatherLocation(user, request.getLat(), request.getLon());
     }
 
     @Override

--- a/src/main/java/com/plantcare/api/v1/PlantController.java
+++ b/src/main/java/com/plantcare/api/v1/PlantController.java
@@ -22,6 +22,7 @@ import com.plantcare.core.service.PlantDiagnosisReportService;
 import com.plantcare.core.service.PlantService;
 import com.plantcare.core.service.PlantService.ScheduleInputDto;
 import com.plantcare.core.service.UserService;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -164,6 +165,17 @@ public class PlantController implements PlantsApi {
     public void deletePlant(Long id) {
         Long userId = currentUserProvider.currentUserId();
         plantService.hardDeletePlant(userId, id);
+    }
+
+    @Override
+    public void disablePlantAcclimation(Long id) {
+        User user = userService.getByIdOrThrow(currentUserProvider.currentUserId());
+        // disable() идемпотентен: возвращает null если растение не найдено или архивировано.
+        // Бросаем 404 в этом случае — клиент должен знать, что растение не существует.
+        Plant plant = plantAcclimationService.disable(user, id);
+        if (plant == null) {
+            throw new EntityNotFoundException("Растение не найдено или архивировано: " + id);
+        }
     }
 
     @Override

--- a/src/main/java/com/plantcare/api/v1/ScheduleController.java
+++ b/src/main/java/com/plantcare/api/v1/ScheduleController.java
@@ -4,6 +4,7 @@ import com.plantcare.api.CurrentUserProvider;
 import com.plantcare.api.generated.SchedulesApi;
 import com.plantcare.api.generated.model.CareScheduleDto;
 import com.plantcare.api.generated.model.CareScheduleUpdateRequest;
+import com.plantcare.api.generated.model.SchedulePostponeRequest;
 import com.plantcare.api.generated.model.SeasonalScheduleDto;
 import com.plantcare.core.domain.enums.SeasonalOverride;
 import com.plantcare.core.domain.enums.TaskType;
@@ -60,6 +61,23 @@ public class ScheduleController implements SchedulesApi {
                 userId, id, taskType,
                 request.getEvery(), request.getAmountMl(), request.getEnabled(),
                 seasonalOverrideEnum);
+        return toDto(view);
+    }
+
+    @Override
+    public CareScheduleDto postponePlantSchedule(Long id, String type, SchedulePostponeRequest request) {
+        Long userId = currentUserProvider.currentUserId();
+
+        TaskType taskType;
+        try {
+            taskType = TaskType.valueOf(type);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Неизвестный тип задачи: " + type);
+        }
+
+        // Сдвиг «от сейчас» — аналог кнопки «Отложить на N дней» в Telegram-боте.
+        // Базовый интервал (every) не меняется, это разовый перенос.
+        ScheduleView view = plantService.postponeSchedule(userId, id, taskType, request.getDays());
         return toDto(view);
     }
 

--- a/src/main/java/com/plantcare/api/v1/ShoppingController.java
+++ b/src/main/java/com/plantcare/api/v1/ShoppingController.java
@@ -61,6 +61,17 @@ public class ShoppingController implements ShoppingApi {
     }
 
     @Override
+    public void clearCheckedShoppingItems(Boolean checked) {
+        // OpenAPI-схема гарантирует checked=true (enum [true]),
+        // но добавляем явную проверку для защиты от рефлекторного вызова с false.
+        if (!Boolean.TRUE.equals(checked)) {
+            throw new IllegalArgumentException("Параметр checked должен быть true");
+        }
+        Long userId = currentUserProvider.currentUserId();
+        shoppingListService.clearChecked(userId);
+    }
+
+    @Override
     public void deleteShoppingItem(Long id) {
         Long userId = currentUserProvider.currentUserId();
         try {

--- a/src/main/java/com/plantcare/core/service/PlantService.java
+++ b/src/main/java/com/plantcare/core/service/PlantService.java
@@ -1031,6 +1031,50 @@ public class PlantService {
         return saved;
     }
 
+    /**
+     * Разовый перенос ближайшего срабатывания расписания на {@code days} дней вперёд
+     * от текущего момента (issue #257, REST-parity bot→REST).
+     *
+     * <p>Базовый интервал ({@code every}) не меняется — это одноразовый сдвиг,
+     * аналог кнопки «Отложить на N дней» в Telegram-боте ({@code PLANT:SCHED:POSTPONE}).
+     *
+     * @return обновлённый {@link ScheduleView} для маппинга в DTO контроллером
+     */
+    @Transactional
+    public ScheduleView postponeSchedule(Long userId, Long plantId, TaskType taskType, int days) {
+        if (days < 1 || days > 365) {
+            throw new IllegalArgumentException("Количество дней должно быть от 1 до 365");
+        }
+
+        Plant plant = plantRepository.findByUserIdAndIdAndArchivedAtIsNull(userId, plantId)
+                .orElseThrow(() -> new IllegalArgumentException("Растение не найдено"));
+
+        CareSchedule schedule = careScheduleRepository
+                .findByPlantIdAndTaskType(plant.getId(), taskType)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Расписание " + taskType + " не настроено"
+                ));
+
+        LocalDateTime newNextDueAt = LocalDateTime.now(clock).plusDays(days);
+        schedule.setNextDueAt(newNextDueAt);
+        CareSchedule saved = careScheduleRepository.save(schedule);
+
+        log.info("Postponed {} for plant {} by {} days → {} (user {})",
+                taskType, plantId, days, newNextDueAt, userId);
+
+        User user = plant.getUser();
+        SeasonalInfo seasonal = buildSeasonalInfo(plant, user, saved.getIntervalDays());
+
+        return new ScheduleView(
+                taskType,
+                saved.getIntervalDays(),
+                saved.getAmountMl(),
+                saved.isActive(),
+                saved.isActive() ? saved.getNextDueAt() : null,
+                seasonal
+        );
+    }
+
     @Transactional
     public CareSchedule rescheduleSchedule(
             Long userId,

--- a/src/main/java/com/plantcare/core/service/UserProfileService.java
+++ b/src/main/java/com/plantcare/core/service/UserProfileService.java
@@ -211,6 +211,23 @@ public class UserProfileService {
         return getProfile(user);
     }
 
+    /**
+     * Устанавливает координаты погодной локации пользователя (issue #257,
+     * mobile gap: weather-location). После вызова {@link User#isWeatherUsable()}
+     * вернёт {@code true}, если у юзера ещё включён {@code weatherEnabled}.
+     *
+     * @param user аутентифицированный пользователь
+     * @param lat  широта [-90, 90]
+     * @param lon  долгота [-180, 180]
+     */
+    @Transactional
+    public void setWeatherLocation(User user, double lat, double lon) {
+        user.setWeatherLat(lat);
+        user.setWeatherLon(lon);
+        userRepository.save(user);
+        log.info("PUT /me/weather-location: userId={}, lat={}, lon={}", user.getId(), lat, lon);
+    }
+
     private static ZoneId parseZone(String timezone) {
         try {
             return ZoneId.of(timezone);

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -164,6 +164,8 @@ paths:
     $ref: './resources/plant-history.yaml#/paths/ItemHistorySummary'
   /api/v1/plants/{id}/events:
     $ref: './resources/plant-events.yaml#/paths/Collection'
+  /api/v1/plants/{id}/acclimation:
+    $ref: './resources/plants.yaml#/paths/ItemAcclimation'
   /api/v1/plants/{id}/health:
     $ref: './resources/plants.yaml#/paths/ItemHealth'
   /api/v1/plants/{id}/family:
@@ -174,6 +176,8 @@ paths:
     $ref: './resources/schedules.yaml#/paths/Collection'
   /api/v1/plants/{id}/schedules/{type}:
     $ref: './resources/schedules.yaml#/paths/Item'
+  /api/v1/plants/{id}/schedules/{type}/postpone:
+    $ref: './resources/schedules.yaml#/paths/ItemPostpone'
 
   /api/v1/locations:
     $ref: './resources/locations.yaml#/paths/Collection'
@@ -217,6 +221,8 @@ paths:
 
   /api/v1/shopping:
     $ref: './resources/shopping.yaml#/paths/Collection'
+  /api/v1/shopping/clear:
+    $ref: './resources/shopping.yaml#/paths/CollectionClear'
   /api/v1/shopping/{id}:
     $ref: './resources/shopping.yaml#/paths/Item'
 
@@ -230,6 +236,8 @@ paths:
 
   /api/v1/me:
     $ref: './resources/me.yaml#/paths/Me'
+  /api/v1/me/weather-location:
+    $ref: './resources/me.yaml#/paths/WeatherLocation'
 
   /api/v1/sharing:
     $ref: './resources/sharing.yaml#/paths/Collection'
@@ -400,6 +408,8 @@ components:
       $ref: './resources/schedules.yaml#/schemas/SeasonalScheduleDto'
     ScheduleInput:
       $ref: './resources/schedules.yaml#/schemas/ScheduleInput'
+    SchedulePostponeRequest:
+      $ref: './resources/schedules.yaml#/schemas/SchedulePostponeRequest'
 
     ShoppingItemDto:
       $ref: './resources/shopping.yaml#/schemas/ShoppingItemDto'
@@ -414,6 +424,8 @@ components:
       $ref: './resources/me.yaml#/schemas/MeResponse'
     MeUpdateRequest:
       $ref: './resources/me.yaml#/schemas/MeUpdateRequest'
+    WeatherLocationRequest:
+      $ref: './resources/me.yaml#/schemas/WeatherLocationRequest'
     NotificationDto:
       $ref: './resources/notifications.yaml#/schemas/NotificationDto'
     NotificationsResponse:

--- a/src/main/resources/openapi/resources/me.yaml
+++ b/src/main/resources/openapi/resources/me.yaml
@@ -4,6 +4,39 @@
 # в таймзоне пользователя (users.timezone).
 
 paths:
+  WeatherLocation:
+    put:
+      tags: [Me]
+      operationId: updateWeatherLocation
+      summary: Установить координаты для погодного виджета
+      description: |
+        Сохраняет широту и долготу пользователя (`weather_lat` / `weather_lon`),
+        необходимые для получения данных о влажности через
+        `GET /api/v1/weather/snapshot`.
+
+        Без координат `weatherEnabled=true` в `PATCH /me` бесполезен — погодные
+        эвристики не запустятся. После успешного вызова этого эндпоинта
+        `WeatherService.isWeatherUsable()` начнёт возвращать `true` при включённом
+        `weatherEnabled`.
+
+        Ответ `204 No Content` — нет тела, обновление применено.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/WeatherLocationRequest'
+            example:
+              lat: 55.7558
+              lon: 37.6176
+      responses:
+        '204':
+          description: Координаты сохранены.
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+
   Me:
     get:
       tags: [Me]
@@ -87,6 +120,27 @@ paths:
           $ref: '../_common/responses.yaml#/BadRequest'
 
 schemas:
+  WeatherLocationRequest:
+    type: object
+    description: |
+      Тело `PUT /api/v1/me/weather-location`. Оба поля обязательны.
+    required: [lat, lon]
+    properties:
+      lat:
+        type: number
+        format: double
+        minimum: -90
+        maximum: 90
+        description: Широта в градусах (WGS-84).
+        example: 55.7558
+      lon:
+        type: number
+        format: double
+        minimum: -180
+        maximum: 180
+        description: Долгота в градусах (WGS-84).
+        example: 37.6176
+
   MeResponse:
     type: object
     description: Профиль и настройки текущего пользователя (`GET /api/v1/me`).

--- a/src/main/resources/openapi/resources/plants.yaml
+++ b/src/main/resources/openapi/resources/plants.yaml
@@ -277,6 +277,31 @@ paths:
         '409':
           $ref: '../_common/responses.yaml#/Conflict'
 
+  ItemAcclimation:
+    delete:
+      tags: [ Plants ]
+      operationId: disablePlantAcclimation
+      summary: Выключить режим акклиматизации
+      description: |
+        Немедленно завершает режим акклиматизации растения
+        (`acclimation_until` и `acclimation_checkin_next_at` обнуляются).
+        Идемпотентно: повторный вызов на растении без акклиматизации возвращает
+        `204` без ошибки.
+
+        Доступ только к своему неархивированному растению.
+
+        * `204` — режим выключен (или уже был выключен).
+        * `404` — растение не найдено или принадлежит другому пользователю.
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - $ref: '../_common/parameters.yaml#/PlantIdPath'
+      responses:
+        '204':
+          description: Акклиматизация отключена. Тело ответа отсутствует.
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
   ItemHealth:
     get:
       tags: [ Plants ]

--- a/src/main/resources/openapi/resources/schedules.yaml
+++ b/src/main/resources/openapi/resources/schedules.yaml
@@ -73,6 +73,54 @@ paths:
         '404':
           $ref: '../_common/responses.yaml#/NotFound'
 
+  ItemPostpone:
+    post:
+      tags: [Schedules]
+      operationId: postponePlantSchedule
+      summary: Разово отложить ближайшее срабатывание расписания
+      description: |
+        Сдвигает поле `next_due_at` расписания на `days` дней вперёд от **текущего момента**,
+        не изменяя базовый интервал (`every`). Это одноразовый сдвиг —
+        следующий цикл рассчитывается по обычному интервалу.
+
+        Эквивалент кнопки «Отложить на N дней» в Telegram-боте
+        (`PLANT:SCHED:POSTPONE`).
+
+        * `200` — возвращает обновлённое расписание.
+        * `400` — неизвестный тип расписания или `days` вне диапазона.
+        * `404` — растение или расписание не найдено.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '../_common/parameters.yaml#/PlantIdPath'
+        - name: type
+          in: path
+          required: true
+          description: Тип задачи ухода.
+          schema:
+            type: string
+            enum: [WATERING, MISTING, FERTILIZING, SOIL_CHECK]
+            example: WATERING
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/SchedulePostponeRequest'
+            example:
+              days: 3
+      responses:
+        '200':
+          description: Расписание перенесено.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/CareScheduleDto'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
 schemas:
   CareScheduleDto:
     type: object
@@ -170,6 +218,19 @@ schemas:
         minimum: 1
         maximum: 60
         description: Эффективный интервал ухода в зимний период (дней).
+
+  SchedulePostponeRequest:
+    type: object
+    description: Тело `POST /plants/{id}/schedules/{type}/postpone`.
+    required: [days]
+    properties:
+      days:
+        type: integer
+        format: int32
+        minimum: 1
+        maximum: 365
+        description: На сколько дней перенести ближайшее срабатывание.
+        example: 3
 
   ScheduleInput:
     type: object

--- a/src/main/resources/openapi/resources/shopping.yaml
+++ b/src/main/resources/openapi/resources/shopping.yaml
@@ -44,6 +44,35 @@ paths:
         '400':
           $ref: '../_common/responses.yaml#/BadRequest'
 
+  CollectionClear:
+    delete:
+      tags: [Shopping]
+      operationId: clearCheckedShoppingItems
+      summary: Очистить отмеченные позиции (bulk)
+      description: |
+        Удаляет все позиции списка покупок текущего пользователя, у которых
+        `checked = true`. Позиции с `checked = false` не затрагиваются.
+
+        Вызов на пустом или полностью непроверенном списке возвращает `204`
+        (идемпотентен — ничего не делает, не ошибка).
+
+        * `204` — отмеченные позиции удалены (или список и так пуст).
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: checked
+          in: query
+          required: true
+          description: Фильтр. Единственное допустимое значение — `true` (удалить только отмеченные).
+          schema:
+            type: boolean
+            enum: [true]
+      responses:
+        '204':
+          description: Отмеченные позиции удалены.
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+
   Item:
     patch:
       tags: [Shopping]

--- a/src/test/java/com/plantcare/api/v1/PlantAcclimationControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/PlantAcclimationControllerTest.java
@@ -1,0 +1,106 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.service.HealthScoreService;
+import com.plantcare.core.service.PlantAcclimationService;
+import com.plantcare.core.service.PlantService;
+import com.plantcare.core.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Clock;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * {@code @WebMvcTest} для {@link PlantController#disablePlantAcclimation} (issue #257).
+ *
+ * <p>REST-parity gap #3: выключить акклиматизацию через REST.
+ * Раньше только бот умел отключать акклиматизацию.
+ */
+@WebMvcTest(PlantController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PlantAcclimationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PlantService plantService;
+
+    @MockitoBean
+    private PlantAcclimationService plantAcclimationService;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    @MockitoBean
+    private Clock clock;
+
+    @MockitoBean
+    private HealthScoreService healthScoreService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = mock(User.class);
+        when(user.getId()).thenReturn(1L);
+        when(currentUserProvider.currentUserId()).thenReturn(1L);
+        when(userService.getByIdOrThrow(1L)).thenReturn(user);
+    }
+
+    @Test
+    void should_return_204_when_acclimation_disabled() throws Exception {
+        // arrange
+        Plant plant = mock(Plant.class);
+        when(plantAcclimationService.disable(eq(user), eq(42L))).thenReturn(plant);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/plants/42/acclimation"))
+                .andExpect(status().isNoContent());
+
+        verify(plantAcclimationService).disable(eq(user), eq(42L));
+    }
+
+    @Test
+    void should_return_204_when_acclimation_was_already_off_idempotent() throws Exception {
+        // arrange — disable() идемпотентен: обнуляет поля, даже если они уже null
+        Plant plant = mock(Plant.class);
+        when(plantAcclimationService.disable(eq(user), eq(42L))).thenReturn(plant);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/plants/42/acclimation"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void should_return_404_when_plant_not_found() throws Exception {
+        // arrange — disable() возвращает null если растение не найдено или архивировано
+        when(plantAcclimationService.disable(eq(user), eq(999L))).thenReturn(null);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/plants/999/acclimation"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+}

--- a/src/test/java/com/plantcare/api/v1/SchedulePostponeControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/SchedulePostponeControllerTest.java
@@ -1,0 +1,156 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.service.PlantService;
+import com.plantcare.core.service.PlantService.ScheduleView;
+import com.plantcare.core.service.PlantService.SeasonalInfo;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * {@code @WebMvcTest} для {@link ScheduleController#postponePlantSchedule} (issue #257).
+ *
+ * <p>REST-parity gap #5: разовый перенос ближайшего срабатывания расписания.
+ * Аналог кнопки «Отложить на N дней» в Telegram-боте ({@code PLANT:SCHED:POSTPONE}).
+ * Базовый интервал ({@code every}) не меняется.
+ */
+@WebMvcTest(ScheduleController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class SchedulePostponeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PlantService plantService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    private static final SeasonalInfo SEASONAL_INACTIVE = new SeasonalInfo(false, 7, 7);
+
+    @BeforeEach
+    void setUp() {
+        when(currentUserProvider.currentUserId()).thenReturn(1L);
+    }
+
+    @Test
+    void should_return_updated_schedule_when_valid_postpone() throws Exception {
+        // arrange
+        ScheduleView view = new ScheduleView(
+                TaskType.WATERING, 7, 250, true,
+                LocalDateTime.of(2026, 6, 10, 9, 0),
+                SEASONAL_INACTIVE);
+
+        when(plantService.postponeSchedule(1L, 42L, TaskType.WATERING, 3)).thenReturn(view);
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/plants/42/schedules/WATERING/postpone")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"days\": 3}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.type").value("WATERING"))
+                .andExpect(jsonPath("$.every").value(7))
+                .andExpect(jsonPath("$.unit").value("DAY"))
+                .andExpect(jsonPath("$.amountMl").value(250))
+                .andExpect(jsonPath("$.enabled").value(true))
+                .andExpect(jsonPath("$.nextDueAt").exists());
+
+        verify(plantService).postponeSchedule(1L, 42L, TaskType.WATERING, 3);
+    }
+
+    @Test
+    void should_return_400_when_days_zero() throws Exception {
+        // arrange — @Min(1) на days нарушено Bean Validation
+        mockMvc.perform(post("/api/v1/plants/42/schedules/WATERING/postpone")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"days\": 0}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void should_return_400_when_days_exceeds_365() throws Exception {
+        // arrange — @Max(365) на days нарушено Bean Validation
+        mockMvc.perform(post("/api/v1/plants/42/schedules/WATERING/postpone")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"days\": 400}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void should_return_400_when_unknown_schedule_type() throws Exception {
+        // arrange — TaskType.valueOf("UNKNOWN") → IllegalArgumentException → 400
+        mockMvc.perform(post("/api/v1/plants/42/schedules/UNKNOWN/postpone")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"days\": 3}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void should_return_404_when_plant_not_found() throws Exception {
+        // arrange — сервис бросает EntityNotFoundException
+        when(plantService.postponeSchedule(1L, 999L, TaskType.WATERING, 3))
+                .thenThrow(new EntityNotFoundException("Plant not found: 999"));
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/plants/999/schedules/WATERING/postpone")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"days\": 3}"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void should_return_400_when_schedule_not_configured() throws Exception {
+        // arrange — сервис бросает IllegalArgumentException (расписание не настроено) → 400
+        when(plantService.postponeSchedule(1L, 42L, TaskType.MISTING, 5))
+                .thenThrow(new IllegalArgumentException("Расписание MISTING не настроено"));
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/plants/42/schedules/MISTING/postpone")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"days\": 5}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void should_return_nextDueAt_as_utc_when_schedule_found() throws Exception {
+        // arrange — Тест с не-UTC wall-clock time: убеждаемся что ZoneOffset.UTC применён.
+        // Это важно для корректного отображения в мобайле (все даты в UTC).
+        ScheduleView view = new ScheduleView(
+                TaskType.FERTILIZING, 14, null, true,
+                LocalDateTime.of(2026, 6, 15, 10, 30),    // wall-clock in БД (без TZ)
+                SEASONAL_INACTIVE);
+
+        when(plantService.postponeSchedule(1L, 42L, TaskType.FERTILIZING, 7))
+                .thenReturn(view);
+
+        // act + assert — nextDueAt должен отдаваться как ISO-8601 UTC
+        mockMvc.perform(post("/api/v1/plants/42/schedules/FERTILIZING/postpone")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"days\": 7}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nextDueAt").value("2026-06-15T10:30:00Z"));
+    }
+}

--- a/src/test/java/com/plantcare/api/v1/ShoppingClearControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/ShoppingClearControllerTest.java
@@ -1,0 +1,79 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.core.service.ShoppingListService;
+import com.plantcare.core.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * {@code @WebMvcTest} для {@link ShoppingController#clearCheckedShoppingItems} (issue #257).
+ *
+ * <p>REST-parity gap #4: bulk-удаление отмеченных позиций списка покупок.
+ * Раньше только бот мог очищать отмеченные позиции через {@code ShoppingListService.clearChecked}.
+ */
+@WebMvcTest(ShoppingController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ShoppingClearControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ShoppingListService shoppingListService;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    @BeforeEach
+    void setUp() {
+        when(currentUserProvider.currentUserId()).thenReturn(1L);
+    }
+
+    @Test
+    void should_return_204_when_checked_items_cleared() throws Exception {
+        // arrange
+        when(shoppingListService.clearChecked(1L)).thenReturn(3L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/shopping/clear")
+                        .param("checked", "true"))
+                .andExpect(status().isNoContent());
+
+        verify(shoppingListService).clearChecked(1L);
+    }
+
+    @Test
+    void should_return_204_when_no_checked_items_idempotent() throws Exception {
+        // arrange — clearChecked() возвращает 0 (нечего удалять), идемпотентен
+        when(shoppingListService.clearChecked(1L)).thenReturn(0L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/shopping/clear")
+                        .param("checked", "true"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void should_return_400_when_checked_param_missing() throws Exception {
+        // arrange — checked обязателен (required=true в OpenAPI-схеме)
+        mockMvc.perform(delete("/api/v1/shopping/clear"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/plantcare/api/v1/WeatherLocationControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/WeatherLocationControllerTest.java
@@ -1,0 +1,112 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.service.AccountDeletionService;
+import com.plantcare.core.service.UserProfileService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * {@code @WebMvcTest} для {@link MeController#updateWeatherLocation} (issue #257).
+ *
+ * <p>REST-parity gap #1: установка координат для погодных эвристик.
+ * {@code PATCH /me} писал только {@code weatherEnabled}, без координат
+ * погода не работала. Этот эндпоинт закрывает пробел.
+ */
+@WebMvcTest(MeController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class WeatherLocationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserProfileService userProfileService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    @MockitoBean
+    private AccountDeletionService accountDeletionService;
+
+    @BeforeEach
+    void setUp() {
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(1L);
+        when(currentUserProvider.currentUser()).thenReturn(user);
+    }
+
+    @Test
+    void should_return_204_when_valid_coordinates() throws Exception {
+        // arrange
+        doNothing().when(userProfileService)
+                .setWeatherLocation(any(User.class), anyDouble(), anyDouble());
+
+        // act + assert
+        mockMvc.perform(put("/api/v1/me/weather-location")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lat\": 55.7558, \"lon\": 37.6176}"))
+                .andExpect(status().isNoContent());
+
+        verify(userProfileService).setWeatherLocation(any(User.class), eq(55.7558), eq(37.6176));
+    }
+
+    @Test
+    void should_return_400_when_lat_missing() throws Exception {
+        // arrange — lat обязательно (@NotNull из required: true)
+        mockMvc.perform(put("/api/v1/me/weather-location")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lon\": 37.6176}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void should_return_400_when_lat_out_of_range() throws Exception {
+        // arrange — lat > 90 нарушает @DecimalMax(90) / minimum/maximum в OpenAPI
+        mockMvc.perform(put("/api/v1/me/weather-location")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lat\": 91.0, \"lon\": 37.6176}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void should_return_400_when_lon_out_of_range() throws Exception {
+        // arrange — lon < -180 нарушает @DecimalMin(-180)
+        mockMvc.perform(put("/api/v1/me/weather-location")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lat\": 55.0, \"lon\": -181.0}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void should_handle_edge_coords_north_pole() throws Exception {
+        // arrange — граничные значения lat=90, lon=180 допустимы
+        doNothing().when(userProfileService)
+                .setWeatherLocation(any(User.class), anyDouble(), anyDouble());
+
+        mockMvc.perform(put("/api/v1/me/weather-location")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lat\": 90.0, \"lon\": 180.0}"))
+                .andExpect(status().isNoContent());
+    }
+}


### PR DESCRIPTION
Closes #257

## Что сделано

- **#1 PUT /api/v1/me/weather-location** — установка lat/lon (WGS-84) для погодных эвристик. До этого `weatherEnabled=true` в `PATCH /me` включало флаг, но без координат `WeatherService.isWeatherUsable()` всегда возвращал `false`. Добавлен `UserProfileService.setWeatherLocation()`.

- **#2 (Черенки)** — уже закрыт: `parentPlantId` есть в `POST /plants` с #219 (и в OpenAPI-спеке). Дополнительный эндпоинт не нужен.

- **#3 DELETE /api/v1/plants/{id}/acclimation** — выключить режим акклиматизации через REST. Идемпотентен (повторный вызов на растении без акклиматизации → `204`). `404` если растение не найдено или архивировано.

- **#4 DELETE /api/v1/shopping/clear?checked=true** — bulk-очистка отмеченных позиций списка покупок. Делегирует `ShoppingListService.clearChecked()`. Идемпотентен: `0` удалений — не ошибка.

- **#5 POST /api/v1/plants/{id}/schedules/{type}/postpone { days }** — разовый перенос ближайшего срабатывания расписания. Базовый интервал (`every`) не меняется — это одноразовый сдвиг, аналог кнопки «Отложить на N дней» в боте (`PLANT:SCHED:POSTPONE`). Добавлен `PlantService.postponeSchedule()` с использованием инжектируемого `Clock`.

## Миграции

нет — новые операции работают поверх существующей схемы БД.

## Backward-compat риски

safe — только новые эндпоинты, старые не затронуты.

## Тесты

18 новых unit-тестов в 4 `@WebMvcTest`-классах:
- `WeatherLocationControllerTest` — happy-path, граничные lat/lon, отсутствующие поля
- `PlantAcclimationControllerTest` — happy-path, идемпотентность, 404
- `ShoppingClearControllerTest` — happy-path, пустой список, отсутствие параметра checked
- `SchedulePostponeControllerTest` — happy-path, валидация days, 400/404, UTC в ответе

## Чек

- [x] `./mvnw verify` зелёное (для unit-тестов); pre-existing flaky tests (`CareScheduleRepositoryTest`, `PlantScheduleServiceTest#non_utc_timezone`) падают на develop тоже
- [x] Логика не дублируется — все 4 операции делегируют в существующие сервисы
- [x] OpenAPI задокументировано, генерация интерфейсов прошла успешно
