### PR TITLE
ci: guard против дублей версий Flyway-миграций

### DIFF
--- a/.github/workflows/migration-guard.yml
+++ b/.github/workflows/migration-guard.yml
@@ -1,0 +1,32 @@
+name: Flyway migration guard
+
+# Ловит дубли версий Flyway-миграций ДО мержа (история коллизий V38/41/43/44 —
+# параллельный auto-merge двух PR с одной версией ронял develop и сломал бы прод-деплой).
+# Лёгкая проверка без Maven — секунды.
+
+on:
+  pull_request:
+  push:
+    branches: [ develop, main ]
+
+jobs:
+  flyway-dup-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Проверка на дубли версий миграций
+        run: |
+          dir="src/main/resources/db/migration"
+          # извлекаем версию из имени Vxxx__...sql (поддержка V1.1-стиля)
+          dups=$(ls "$dir" | sed -nE 's/^(V[0-9]+(\.[0-9]+)*)__.*\.sql$/\1/p' | sort | uniq -d)
+          if [ -n "$dups" ]; then
+            echo "::error::Найдены дубли версий Flyway-миграций:"
+            for v in $dups; do
+              echo "  Версия $v:"
+              ls "$dir" | grep -E "^${v}__" | sed 's/^/    - /'
+            done
+            echo ""
+            echo "Развести: переименовать НЕ применённую на деве миграцию на следующий свободный номер."
+            exit 1
+          fi
+          echo "OK: дублей версий миграций нет."


### PR DESCRIPTION
## Зачем
Параллельный auto-merge не раз приводил к **дублю версий миграций** (V38/41/43/44): Flyway падал на старте (`more than one migration with version N`), `develop` краснел каскадом из сотен ошибок `@SpringBootTest`, а на проде это **сломало бы деплой**. Чинили постфактум (#248/#259/#261).

## Что
Лёгкий workflow `Flyway migration guard` (без Maven, секунды): на каждый PR и push в `develop`/`main` проверяет уникальность версий в `src/main/resources/db/migration`. При дубле падает с понятным сообщением — какие файлы конфликтуют и что делать.

Это ловит проблему **до** мержа, а не после покраснения develop.

## Проверено
- На текущем `develop` (`c211c8a`) — дублей нет, guard зелёный.
- Позитивный тест: синтетический дубль `V44` корректно детектится (exit 1).

Мерж — за человеком.

🤖 Generated with [Claude Code](https://claude.com/claude-code)