### PR TITLE
feat: REST API шаблонов растений — CRUD + инстанцирование (#254)

### DIFF
--- a/src/main/java/com/plantcare/api/v1/PlantTemplateController.java
+++ b/src/main/java/com/plantcare/api/v1/PlantTemplateController.java
@@ -1,0 +1,127 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.api.generated.PlantTemplatesApi;
+import com.plantcare.api.generated.model.PlantDto;
+import com.plantcare.api.generated.model.PlantTemplateCareRuleDto;
+import com.plantcare.api.generated.model.PlantTemplateCreateRequest;
+import com.plantcare.api.generated.model.PlantTemplateDto;
+import com.plantcare.api.generated.model.PlantTemplateInstantiateRequest;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.PlantTemplate;
+import com.plantcare.core.domain.PlantTemplateCareRule;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.service.PlantTemplateService;
+import com.plantcare.core.service.UserService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.ZoneOffset;
+import java.util.List;
+
+/**
+ * REST API для управления шаблонами растений (issue #254).
+ *
+ * <p>Документация и mapping живут в сгенерированном {@link PlantTemplatesApi}
+ * из OpenAPI-спеки.
+ *
+ * <p>Форма «создать растение из шаблона»: отдельный эндпоинт
+ * {@code POST /plant-templates/{id}/instantiate} — явная операция, семантически
+ * отдельная от обычного {@code POST /plants}.
+ */
+@RestController
+@RequiredArgsConstructor
+public class PlantTemplateController implements PlantTemplatesApi {
+
+    private final PlantTemplateService plantTemplateService;
+    private final UserService userService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    public List<PlantTemplateDto> listPlantTemplates() {
+        Long userId = currentUserProvider.currentUserId();
+        return plantTemplateService.getUserTemplates(userId).stream()
+                .map(PlantTemplateController::toDto)
+                .toList();
+    }
+
+    @Override
+    public PlantTemplateDto createPlantTemplate(PlantTemplateCreateRequest request) {
+        User user = userService.getByIdOrThrow(currentUserProvider.currentUserId());
+
+        PlantTemplate template;
+        if (request.getFromPlantId() != null) {
+            template = plantTemplateService.saveFromPlant(user, request.getFromPlantId(), request.getName());
+        } else {
+            template = plantTemplateService.createEmpty(user, request.getName());
+        }
+
+        return toDto(template);
+    }
+
+    @Override
+    public void deletePlantTemplate(Long id) {
+        User user = userService.getByIdOrThrow(currentUserProvider.currentUserId());
+        // deleteTemplate throws IllegalArgumentException ("Шаблон не найден") when not found;
+        // ApiExceptionHandler maps it to 400. We rethrow as EntityNotFoundException for 404.
+        plantTemplateService.getTemplate(user.getId(), id)
+                .orElseThrow(() -> new EntityNotFoundException("Plant template not found: " + id));
+        plantTemplateService.deleteTemplate(user, id);
+    }
+
+    @Override
+    public PlantDto instantiatePlantTemplate(Long id, PlantTemplateInstantiateRequest request) {
+        User user = userService.getByIdOrThrow(currentUserProvider.currentUserId());
+        // Validate template exists and belongs to user before instantiating
+        plantTemplateService.getTemplate(user.getId(), id)
+                .orElseThrow(() -> new EntityNotFoundException("Plant template not found: " + id));
+
+        Plant plant = plantTemplateService.createPlantFromTemplate(user, id, request.getName());
+        return toPlantDto(plant);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Mappers
+    // ─────────────────────────────────────────────────────────────────
+
+    private static PlantTemplateDto toDto(PlantTemplate template) {
+        List<PlantTemplateCareRuleDto> rules = template.getCareRules().stream()
+                .map(PlantTemplateController::toCareRuleDto)
+                .toList();
+
+        PlantTemplateDto dto = new PlantTemplateDto(
+                template.getId(),
+                template.getName(),
+                rules,
+                template.getCreatedAt() != null
+                        ? template.getCreatedAt().atOffset(ZoneOffset.UTC)
+                        : null
+        );
+        return dto;
+    }
+
+    private static PlantTemplateCareRuleDto toCareRuleDto(PlantTemplateCareRule rule) {
+        return new PlantTemplateCareRuleDto(
+                PlantTemplateCareRuleDto.CareTypeEnum.fromValue(rule.getCareType().name()),
+                rule.getIntervalDays()
+        );
+    }
+
+    private static PlantDto toPlantDto(Plant plant) {
+        PlantDto dto = new PlantDto(plant.getId(), plant.getName(), plant.isArchived())
+                .notes(plant.getNotes());
+        if (plant.getLocation() != null) {
+            dto.locationId(plant.getLocation().getId())
+                    .locationName(plant.getLocation().getName());
+        }
+        if (plant.getSpecies() != null) {
+            dto.speciesId(plant.getSpecies().getId())
+                    .speciesName(plant.getSpecies().getName());
+        }
+        if (plant.getCreatedAt() != null) {
+            dto.createdAt(plant.getCreatedAt().atOffset(ZoneOffset.UTC));
+        }
+        return dto;
+    }
+}

--- a/src/main/java/com/plantcare/core/service/PlantTemplateService.java
+++ b/src/main/java/com/plantcare/core/service/PlantTemplateService.java
@@ -47,6 +47,43 @@ public class PlantTemplateService {
     private final com.plantcare.core.seasonal.service.SeasonalIntervalService seasonalIntervalService;
 
     // =================================================================
+    // createEmpty — создать пустой шаблон (без источника-растения)
+    // =================================================================
+
+    /**
+     * Создаёт шаблон без правил ухода — «чистый каркас» с именем.
+     * Используется REST API, когда {@code fromPlantId} не передан.
+     *
+     * @throws IllegalStateException    если достигнут лимит {@value #MAX_TEMPLATES_PER_USER}
+     * @throws IllegalArgumentException если имя невалидно или дублирует существующее
+     */
+    @Transactional
+    public PlantTemplate createEmpty(User user, String rawName) {
+        String name = rawName == null ? "" : rawName.trim();
+        validateName(name);
+
+        if (templateRepository.countByUserId(user.getId()) >= MAX_TEMPLATES_PER_USER) {
+            throw new IllegalStateException(
+                    "Достигнут лимит " + MAX_TEMPLATES_PER_USER + " шаблонов. " +
+                    "Удали неиспользуемые в ⚙️ Настройки → ⭐ Мои шаблоны.");
+        }
+
+        if (templateRepository.existsByUserIdAndNameIgnoreCase(user.getId(), name)) {
+            throw new IllegalArgumentException(
+                    "Шаблон с именем «" + name + "» уже существует. Выбери другое название.");
+        }
+
+        PlantTemplate template = PlantTemplate.builder()
+                .userId(user.getId())
+                .name(name)
+                .build();
+        template = templateRepository.save(template);
+
+        log.info("Created empty template '{}' (id={}) for user {}", name, template.getId(), user.getId());
+        return template;
+    }
+
+    // =================================================================
     // saveFromPlant — сохранить шаблон из существующего растения
     // =================================================================
 
@@ -72,27 +109,30 @@ public class PlantTemplateService {
                     "Шаблон с именем «" + name + "» уже существует. Выбери другое название.");
         }
 
-        PlantTemplate template = PlantTemplate.builder()
-                .userId(user.getId())
-                .name(name)
-                .build();
-        template = templateRepository.save(template);
-
         // Копируем только активные расписания — отключённые тумблером не нужны
         List<CareSchedule> activeSchedules = careScheduleRepository
                 .findAllByPlantId(plantId).stream()
                 .filter(CareSchedule::isActive)
                 .toList();
 
-        final PlantTemplate savedTemplate = template;
+        PlantTemplate template = PlantTemplate.builder()
+                .userId(user.getId())
+                .name(name)
+                .build();
+
+        // Добавляем правила до сохранения — CascadeType.ALL сохранит их вместе с шаблоном.
+        // Это гарантирует, что возвращаемый template.getCareRules() заполнен
+        // и не требует дополнительной перезагрузки из БД.
         for (CareSchedule schedule : activeSchedules) {
             PlantTemplateCareRule rule = PlantTemplateCareRule.builder()
-                    .template(savedTemplate)
+                    .template(template)
                     .careType(schedule.getTaskType())
                     .intervalDays(schedule.getIntervalDays())
                     .build();
-            careRuleRepository.save(rule);
+            template.getCareRules().add(rule);
         }
+
+        template = templateRepository.save(template);
 
         log.info("Saved template '{}' (id={}) from plant {} for user {}",
                 name, template.getId(), plantId, user.getId());

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -126,6 +126,11 @@ tags:
       мобильного приложения. Клиент передаёт `since` (серверное время из предыдущего
       ответа) и получает все сущности, изменённые после этого момента, а также
       список удалений. Server timestamp wins при конфликтах.
+  - name: PlantTemplates
+    description: |
+      Пользовательские шаблоны растений (issue #254): сохранение набора интервалов
+      ухода из существующего растения, быстрое создание нового растения по шаблону.
+      Максимум 30 шаблонов на пользователя.
 
 paths:
   /api/v1/auth/apple:
@@ -174,6 +179,13 @@ paths:
     $ref: './resources/schedules.yaml#/paths/Collection'
   /api/v1/plants/{id}/schedules/{type}:
     $ref: './resources/schedules.yaml#/paths/Item'
+
+  /api/v1/plant-templates:
+    $ref: './resources/plant-templates.yaml#/paths/Collection'
+  /api/v1/plant-templates/{id}:
+    $ref: './resources/plant-templates.yaml#/paths/Item'
+  /api/v1/plant-templates/{id}/instantiate:
+    $ref: './resources/plant-templates.yaml#/paths/Instantiate'
 
   /api/v1/locations:
     $ref: './resources/locations.yaml#/paths/Collection'
@@ -450,6 +462,15 @@ components:
       $ref: './resources/sync.yaml#/schemas/SyncCareEventDto'
     SyncDeletionDto:
       $ref: './resources/sync.yaml#/schemas/SyncDeletionDto'
+
+    PlantTemplateDto:
+      $ref: './resources/plant-templates.yaml#/schemas/PlantTemplateDto'
+    PlantTemplateCareRuleDto:
+      $ref: './resources/plant-templates.yaml#/schemas/PlantTemplateCareRuleDto'
+    PlantTemplateCreateRequest:
+      $ref: './resources/plant-templates.yaml#/schemas/PlantTemplateCreateRequest'
+    PlantTemplateInstantiateRequest:
+      $ref: './resources/plant-templates.yaml#/schemas/PlantTemplateInstantiateRequest'
 
     ApiErrorResponse:
       $ref: './_common/errors.yaml#/schemas/ApiErrorResponse'

--- a/src/main/resources/openapi/resources/plant-templates.yaml
+++ b/src/main/resources/openapi/resources/plant-templates.yaml
@@ -1,0 +1,213 @@
+# REST API: шаблоны растений (issue #254).
+#
+# Шаблон — сохранённый набор интервалов ухода, позволяющий быстро создавать
+# похожие растения. Поверх PlantTemplateService (issue #68).
+#
+# Выбранная форма «создать из шаблона»: отдельный эндпоинт
+# POST /plant-templates/{id}/instantiate — явная операция, не query-параметр
+# у POST /plants. Мотивация: семантика создания «из шаблона» отличается от
+# обычного создания растения; query-параметр у другого ресурса нарушает SRP.
+
+paths:
+  Collection:
+    get:
+      tags: [PlantTemplates]
+      operationId: listPlantTemplates
+      summary: Список шаблонов пользователя
+      description: |
+        Возвращает все шаблоны растений, созданные текущим пользователем,
+        отсортированные по дате создания (новые первыми).
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Список шаблонов.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/schemas/PlantTemplateDto'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+
+    post:
+      tags: [PlantTemplates]
+      operationId: createPlantTemplate
+      summary: Создать шаблон
+      description: |
+        Создаёт шаблон растения для текущего пользователя.
+
+        Если передан `fromPlantId`, копирует активные расписания ухода
+        (WATERING, MISTING, FERTILIZING) из существующего растения пользователя.
+
+        Ограничения:
+        - Максимум 30 шаблонов на пользователя.
+        - Имя 1–40 символов, без дублей (case-insensitive) в пределах пользователя.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/PlantTemplateCreateRequest'
+            examples:
+              fromPlant:
+                summary: Шаблон из существующего растения
+                value:
+                  name: "Монстера 7д"
+                  fromPlantId: 42
+              custom:
+                summary: Шаблон без источника
+                value:
+                  name: "Кактус 14д"
+      responses:
+        '201':
+          description: Шаблон создан.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/PlantTemplateDto'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+        '409':
+          $ref: '../_common/responses.yaml#/Conflict'
+
+  Item:
+    delete:
+      tags: [PlantTemplates]
+      operationId: deletePlantTemplate
+      summary: Удалить шаблон
+      description: |
+        Удаляет шаблон пользователя. Растения, созданные из этого шаблона,
+        не затрагиваются (связи FK на plants нет).
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/parameters/PlantTemplateIdPath'
+      responses:
+        '204':
+          description: Шаблон удалён.
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+  Instantiate:
+    post:
+      tags: [PlantTemplates]
+      operationId: instantiatePlantTemplate
+      summary: Создать растение из шаблона
+      description: |
+        Создаёт новое растение, копируя интервалы ухода из указанного шаблона.
+        Сезонная корректировка применяется согласно глобальной настройке
+        пользователя (`seasonal_mode`). Локация — дефолтная для пользователя.
+
+        Расписания (WATERING + другие из шаблона) получают статус active.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/parameters/PlantTemplateIdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/PlantTemplateInstantiateRequest'
+            example:
+              name: "Монстера 2"
+      responses:
+        '201':
+          description: Растение создано.
+          content:
+            application/json:
+              schema:
+                $ref: './plants.yaml#/schemas/PlantDto'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+parameters:
+  PlantTemplateIdPath:
+    name: id
+    in: path
+    required: true
+    description: ID шаблона растения.
+    schema:
+      type: integer
+      format: int64
+      example: 1
+
+schemas:
+  PlantTemplateDto:
+    type: object
+    description: Шаблон растения пользователя.
+    required: [id, name, careRules, createdAt]
+    properties:
+      id:
+        type: integer
+        format: int64
+        example: 1
+      name:
+        type: string
+        maxLength: 40
+        example: "Монстера 7д"
+      careRules:
+        type: array
+        description: Правила ухода, сохранённые в шаблоне.
+        items:
+          $ref: '#/schemas/PlantTemplateCareRuleDto'
+      createdAt:
+        type: string
+        format: date-time
+        example: "2024-01-15T10:30:00Z"
+
+  PlantTemplateCareRuleDto:
+    type: object
+    description: Одно правило ухода в шаблоне.
+    required: [careType, intervalDays]
+    properties:
+      careType:
+        type: string
+        enum: [WATERING, MISTING, FERTILIZING, SOIL_CHECK]
+        example: WATERING
+      intervalDays:
+        type: integer
+        minimum: 1
+        example: 7
+
+  PlantTemplateCreateRequest:
+    type: object
+    required: [name]
+    properties:
+      name:
+        type: string
+        minLength: 1
+        maxLength: 40
+        example: "Монстера 7д"
+      fromPlantId:
+        type: integer
+        format: int64
+        nullable: true
+        description: |
+          ID существующего растения пользователя, из которого копировать
+          активные расписания ухода. Если не указан — шаблон создаётся
+          без правил (пустой каркас).
+        example: 42
+
+  PlantTemplateInstantiateRequest:
+    type: object
+    required: [name]
+    properties:
+      name:
+        type: string
+        minLength: 1
+        maxLength: 100
+        description: Имя нового растения.
+        example: "Монстера 2"

--- a/src/test/java/com/plantcare/api/v1/PlantTemplateControllerIT.java
+++ b/src/test/java/com/plantcare/api/v1/PlantTemplateControllerIT.java
@@ -1,0 +1,407 @@
+package com.plantcare.api.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.plantcare.bot.support.IntegrationTestBase;
+import com.plantcare.core.domain.CareSchedule;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.PlantTemplate;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.repository.CareScheduleRepository;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.PlantTemplateCareRuleRepository;
+import com.plantcare.core.repository.PlantTemplateRepository;
+import com.plantcare.core.repository.UserRepository;
+import com.plantcare.core.service.PlantService;
+import com.plantcare.core.service.PlantTemplateService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Интеграционные тесты REST API шаблонов растений (issue #254).
+ *
+ * <p>Покрывает AC:
+ * - GET /plant-templates — список шаблонов
+ * - POST /plant-templates с fromPlantId — создание из растения
+ * - POST /plant-templates без fromPlantId — создание пустого шаблона
+ * - DELETE /plant-templates/{id} — удаление
+ * - POST /plant-templates/{id}/instantiate — создание растения из шаблона
+ *
+ * <p>Таймзонный кейс: пользователь с Asia/Almaty.
+ */
+@AutoConfigureMockMvc
+class PlantTemplateControllerIT extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PlantRepository plantRepository;
+
+    @Autowired
+    private PlantTemplateRepository templateRepository;
+
+    @Autowired
+    private PlantTemplateCareRuleRepository careRuleRepository;
+
+    @Autowired
+    private CareScheduleRepository careScheduleRepository;
+
+    @Autowired
+    private PlantService plantService;
+
+    @Autowired
+    private PlantTemplateService plantTemplateService;
+
+    private User user;
+    private Plant plant;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(User.builder()
+                .telegramChatId(9_254_001L)
+                .username("template_api_test_user")
+                .timezone("Europe/Moscow")
+                .build());
+
+        plant = plantService.createPlantWithWateringSchedule(
+                user, null, "Тестовая монстера", 7,
+                LocalDateTime.now().plusDays(7));
+
+        // Добавляем расписание опрыскивания — шаблон будет содержать 2 правила
+        plantService.addCareSchedule(plant, TaskType.MISTING, 3,
+                LocalDateTime.now().plusDays(3));
+    }
+
+    @AfterEach
+    void cleanup() {
+        // Delete in FK-safe order: care_rules (cascade from templates), templates,
+        // care_schedules, plants, then locations (cascade from users) and users last.
+        // Use deleteAll() for whole-table cleanup to avoid orphan constraint issues.
+        careRuleRepository.deleteAll();
+        templateRepository.deleteAll();
+        careScheduleRepository.deleteAll();
+        plantRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ================================================================
+    // GET /api/v1/plant-templates — список шаблонов
+    // ================================================================
+
+    @Test
+    void should_return_empty_list_when_user_has_no_templates() throws Exception {
+        // act + assert
+        mockMvc.perform(get("/api/v1/plant-templates")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void should_return_templates_for_current_user() throws Exception {
+        // arrange
+        plantTemplateService.saveFromPlant(user, plant.getId(), "Монстера шаблон");
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plant-templates")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].name").value("Монстера шаблон"))
+                .andExpect(jsonPath("$[0].id").isNumber())
+                .andExpect(jsonPath("$[0].careRules").isArray());
+    }
+
+    @Test
+    void should_not_return_other_users_templates() throws Exception {
+        // arrange — template for a different user
+        User otherUser = userRepository.save(User.builder()
+                .telegramChatId(9_254_002L)
+                .timezone("UTC")
+                .build());
+
+        Plant otherPlant = plantService.createPlantWithWateringSchedule(
+                otherUser, null, "Чужое растение", 5,
+                LocalDateTime.now().plusDays(5));
+
+        plantTemplateService.saveFromPlant(otherUser, otherPlant.getId(), "Чужой шаблон");
+
+        // act — request as our user
+        mockMvc.perform(get("/api/v1/plant-templates")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    // ================================================================
+    // POST /api/v1/plant-templates — создание шаблона из растения
+    // ================================================================
+
+    @Test
+    void should_create_template_from_plant_and_copy_active_schedules() throws Exception {
+        // act
+        String body = """
+                {
+                  "name": "Монстера 7д",
+                  "fromPlantId": %d
+                }
+                """.formatted(plant.getId());
+
+        MvcResult result = mockMvc.perform(post("/api/v1/plant-templates")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId()))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Монстера 7д"))
+                .andExpect(jsonPath("$.id").isNumber())
+                .andExpect(jsonPath("$.careRules").isArray())
+                .andReturn();
+
+        // assert — care rules copied (WATERING + MISTING)
+        JsonNode json = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(json.get("careRules").size()).isEqualTo(2);
+
+        long templateId = json.get("id").asLong();
+        var rules = careRuleRepository.findAllByTemplateId(templateId);
+        assertThat(rules).extracting(r -> r.getCareType().name())
+                .containsExactlyInAnyOrder("WATERING", "MISTING");
+    }
+
+    @Test
+    void should_create_empty_template_when_fromPlantId_not_provided() throws Exception {
+        // act
+        String body = """
+                {"name": "Пустой шаблон"}
+                """;
+
+        MvcResult result = mockMvc.perform(post("/api/v1/plant-templates")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId()))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Пустой шаблон"))
+                .andReturn();
+
+        // assert — no care rules
+        JsonNode json = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(json.get("careRules").size()).isEqualTo(0);
+    }
+
+    @Test
+    void should_return_409_when_template_name_is_duplicate() throws Exception {
+        // arrange — create first template
+        plantTemplateService.saveFromPlant(user, plant.getId(), "Дубль");
+
+        // act — try to create template with same name (case-insensitive)
+        String body = """
+                {"name": "дубль", "fromPlantId": %d}
+                """.formatted(plant.getId());
+
+        mockMvc.perform(post("/api/v1/plant-templates")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId()))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void should_return_400_when_template_name_is_blank() throws Exception {
+        // act
+        String body = """
+                {"name": "   "}
+                """;
+
+        mockMvc.perform(post("/api/v1/plant-templates")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId()))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ================================================================
+    // DELETE /api/v1/plant-templates/{id}
+    // ================================================================
+
+    @Test
+    void should_delete_template_and_not_affect_plants() throws Exception {
+        // arrange
+        PlantTemplate template = plantTemplateService.saveFromPlant(
+                user, plant.getId(), "Удаляемый шаблон");
+        Plant fromTemplate = plantTemplateService.createPlantFromTemplate(
+                user, template.getId(), "Растение из шаблона");
+
+        // act
+        mockMvc.perform(delete("/api/v1/plant-templates/" + template.getId())
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isNoContent());
+
+        // assert — template deleted, plant untouched
+        assertThat(templateRepository.findById(template.getId())).isEmpty();
+        assertThat(plantRepository.findById(fromTemplate.getId())).isPresent();
+    }
+
+    @Test
+    void should_return_404_when_deleting_nonexistent_template() throws Exception {
+        // act + assert
+        mockMvc.perform(delete("/api/v1/plant-templates/9999999")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void should_return_404_when_deleting_other_users_template() throws Exception {
+        // arrange — template owned by a different user
+        User otherUser = userRepository.save(User.builder()
+                .telegramChatId(9_254_003L)
+                .timezone("UTC")
+                .build());
+
+        Plant otherPlant = plantService.createPlantWithWateringSchedule(
+                otherUser, null, "Чужое", 7, LocalDateTime.now().plusDays(7));
+
+        PlantTemplate otherTemplate = plantTemplateService.saveFromPlant(
+                otherUser, otherPlant.getId(), "Чужой шаблон");
+
+        // act — try to delete as our user
+        mockMvc.perform(delete("/api/v1/plant-templates/" + otherTemplate.getId())
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId())))))
+                .andExpect(status().isNotFound());
+    }
+
+    // ================================================================
+    // POST /api/v1/plant-templates/{id}/instantiate — создание растения
+    // ================================================================
+
+    @Test
+    void should_create_plant_from_template_with_correct_schedules() throws Exception {
+        // arrange
+        PlantTemplate template = plantTemplateService.saveFromPlant(
+                user, plant.getId(), "Шаблон для инстанцирования");
+
+        String body = """
+                {"name": "Монстера 2"}
+                """;
+
+        // act
+        MvcResult result = mockMvc.perform(
+                        post("/api/v1/plant-templates/" + template.getId() + "/instantiate")
+                                .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId()))))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Монстера 2"))
+                .andExpect(jsonPath("$.id").isNumber())
+                .andReturn();
+
+        // assert — new plant has schedules from template
+        JsonNode json = objectMapper.readTree(result.getResponse().getContentAsString());
+        long newPlantId = json.get("id").asLong();
+
+        List<CareSchedule> schedules = careScheduleRepository.findAllByPlantId(newPlantId);
+        assertThat(schedules).extracting(s -> s.getTaskType().name())
+                .contains("WATERING", "MISTING");
+
+        // Watering interval should match template (7 days)
+        schedules.stream()
+                .filter(s -> s.getTaskType() == TaskType.WATERING)
+                .findFirst()
+                .ifPresent(s -> assertThat(s.getIntervalDays()).isEqualTo(7));
+    }
+
+    @Test
+    void should_create_plant_from_template_for_non_utc_user_timezone() throws Exception {
+        // arrange — user with Asia/Almaty (UTC+5)
+        User almaty = userRepository.save(User.builder()
+                .telegramChatId(9_254_004L)
+                .username("almaty_template_user")
+                .timezone("Asia/Almaty")
+                .build());
+
+        Plant almatyPlant = plantService.createPlantWithWateringSchedule(
+                almaty, null, "Алма-атинская монстера", 7,
+                LocalDateTime.now().plusDays(7));
+
+        PlantTemplate template = plantTemplateService.saveFromPlant(
+                almaty, almatyPlant.getId(), "Шаблон Алматы");
+
+        String body = """
+                {"name": "Алмаатинская 2"}
+                """;
+
+        // act
+        MvcResult result = mockMvc.perform(
+                        post("/api/v1/plant-templates/" + template.getId() + "/instantiate")
+                                .with(jwt().jwt(j -> j.claim("sub", String.valueOf(almaty.getId()))))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        // assert — plant created with positive nextDueAt
+        JsonNode json = objectMapper.readTree(result.getResponse().getContentAsString());
+        long newPlantId = json.get("id").asLong();
+
+        List<CareSchedule> schedules = careScheduleRepository.findAllByPlantId(newPlantId);
+        assertThat(schedules.stream().filter(s -> s.getTaskType() == TaskType.WATERING).findFirst())
+                .isPresent()
+                .hasValueSatisfying(s -> assertThat(s.getNextDueAt()).isAfter(LocalDateTime.now()));
+    }
+
+    @Test
+    void should_return_404_when_instantiating_nonexistent_template() throws Exception {
+        // act + assert
+        String body = """
+                {"name": "Растение без шаблона"}
+                """;
+
+        mockMvc.perform(post("/api/v1/plant-templates/9999999/instantiate")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId()))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void should_return_400_when_plant_name_is_blank_on_instantiate() throws Exception {
+        // arrange
+        PlantTemplate template = plantTemplateService.saveFromPlant(
+                user, plant.getId(), "Шаблон для проверки имени");
+
+        String body = """
+                {"name": ""}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/plant-templates/" + template.getId() + "/instantiate")
+                        .with(jwt().jwt(j -> j.claim("sub", String.valueOf(user.getId()))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
Closes #254

## Что сделано

- Добавлен REST API шаблонов растений поверх существующего `PlantTemplateService` (issue #68):
  - `GET /api/v1/plant-templates` — список шаблонов пользователя
  - `POST /api/v1/plant-templates` — создать шаблон (с `fromPlantId` — копирует активные расписания из растения; без — пустой шаблон)
  - `DELETE /api/v1/plant-templates/{id}` — удалить шаблон
  - `POST /api/v1/plant-templates/{id}/instantiate` — создать растение из шаблона
- Выбранная форма «создать из шаблона»: **отдельный эндпоинт `/instantiate`** (не query-параметр у `POST /plants`). Мотивация: семантика создания из шаблона отличается от обычного создания растения.
- Новый файл OpenAPI-спеки `resources/plant-templates.yaml` с tag `PlantTemplates`, зарегистрирован в `openapi.yaml`. Эндпоинты задокументированы в `/v3/api-docs`.
- `PlantTemplateService`: добавлен метод `createEmpty()` для кейса без `fromPlantId`; рефакторинг `saveFromPlant()` — care rules теперь добавляются в коллекцию до `save()` (использует `CascadeType.ALL`), возвращаемый объект содержит заполненный `careRules`.
- 14 интеграционных тестов в `PlantTemplateControllerIT`: happy path, edge cases, таймзонный кейс (Asia/Almaty), изоляция по пользователям.

## Миграции

нет — схема БД (`plant_templates` + `plant_template_care_rules`) создана в issue #68.

## Backward-compat риски

safe — только новые эндпоинты, существующие не затронуты.

## Тесты

- `PlantTemplateControllerIT` (14 тестов):
  - GET: пустой список, список пользователя, изоляция от чужих шаблонов
  - POST с fromPlantId: создание шаблона с копированием расписаний (WATERING + MISTING)
  - POST без fromPlantId: создание пустого шаблона
  - POST: дубль имени (case-insensitive) → 400/409, пустое имя → 400
  - DELETE: удаление + проверка что растения не удалены, 404 для чужого/несуществующего
  - POST /instantiate: создание растения с расписаниями, таймзона Asia/Almaty, 404 для несуществующего, 400 для пустого имени
- `PlantTemplateServiceTest` (12 тестов, pre-existing) — все зелёные

## Чек

- [x] `mvn verify` зелёное (5 pre-existing failures на develop, не связаны с этим PR — verified)
- [x] reviewer прошёл (или указаны принятые SHOULD-FIX)
