### PR TITLE
feat: REST API шеринг локаций — совместный уход (#251)

### DIFF
--- a/src/main/java/com/plantcare/api/ApiExceptionHandler.java
+++ b/src/main/java/com/plantcare/api/ApiExceptionHandler.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * Глобальный обработчик ошибок REST API ({@code /api/**}).
@@ -124,6 +125,18 @@ public class ApiExceptionHandler {
     public ResponseEntity<ApiErrorResponse> handleConflict(IllegalStateException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(ApiErrorResponse.of("CONFLICT", e.getMessage()));
+    }
+
+    /**
+     * {@link ResponseStatusException} — используется для HTTP-статусов без стандартного
+     * исключения (например, 410 Gone для просроченного/использованного инвайта).
+     * Пробрасывает статус из исключения, формат ответа — единый ApiErrorResponse.
+     */
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ApiErrorResponse> handleResponseStatus(ResponseStatusException e) {
+        String code = e.getStatusCode().value() == 410 ? "GONE" : e.getStatusCode().toString();
+        return ResponseEntity.status(e.getStatusCode())
+                .body(ApiErrorResponse.of(code, e.getReason() != null ? e.getReason() : e.getMessage()));
     }
 
     @ExceptionHandler(RuntimeException.class)

--- a/src/main/java/com/plantcare/api/v1/LocationSharingController.java
+++ b/src/main/java/com/plantcare/api/v1/LocationSharingController.java
@@ -1,0 +1,141 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.api.generated.LocationSharingApi;
+import com.plantcare.api.generated.model.AcceptInviteResponse;
+import com.plantcare.api.generated.model.LocationAccessRole;
+import com.plantcare.api.generated.model.LocationInviteResponse;
+import com.plantcare.api.generated.model.LocationMemberDto;
+import com.plantcare.api.generated.model.LocationMembersResponse;
+import com.plantcare.api.generated.model.SharedLocationDto;
+import com.plantcare.api.generated.model.SharedLocationsResponse;
+import com.plantcare.core.domain.LocationInvite;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.AccessRole;
+import com.plantcare.core.service.LocationSharingService;
+import com.plantcare.core.service.LocationSharingService.AcceptResult;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.ZoneOffset;
+import java.util.List;
+
+/**
+ * REST API совместного ухода по локации (issue #251).
+ *
+ * <p>Документация и mapping живут в сгенерированном {@link LocationSharingApi}
+ * (см. openapi/resources/location-sharing.yaml).
+ *
+ * <p>Поток:
+ * <ol>
+ *   <li>OWNER → POST /locations/{id}/invites → получает одноразовый токен.</li>
+ *   <li>Приглашённый → POST /invites/{token}/accept → становится CARETAKER.</li>
+ *   <li>GET /locations/{id}/members → список участников.</li>
+ *   <li>DELETE /locations/{id}/members/{userId} → отзыв доступа (только OWNER).</li>
+ *   <li>GET /shared-locations → локации, где я CARETAKER.</li>
+ * </ol>
+ */
+@RestController
+@RequiredArgsConstructor
+public class LocationSharingController implements LocationSharingApi {
+
+    private final LocationSharingService locationSharingService;
+    private final CurrentUserProvider currentUserProvider;
+
+    /**
+     * POST /api/v1/locations/{id}/invites — создать одноразовый инвайт (только OWNER).
+     * Возвращает токен и время истечения.
+     */
+    @Override
+    public LocationInviteResponse createLocationInvite(Long id) {
+        Long userId = currentUserProvider.currentUserId();
+        LocationInvite invite;
+        try {
+            invite = locationSharingService.createInvite(userId, id);
+        } catch (IllegalArgumentException e) {
+            throw new EntityNotFoundException(e.getMessage());
+        }
+        return new LocationInviteResponse()
+                .token(invite.getToken())
+                .expiresAt(invite.getExpiresAt().atOffset(ZoneOffset.UTC));
+    }
+
+    /**
+     * POST /api/v1/invites/{token}/accept — принять приглашение.
+     * Идемпотентно: повторный accept тем же пользователем → 200 (ALREADY_USED трактуется
+     * как «у тебя уже есть доступ»). Протухший/использованный другим → 410.
+     */
+    @Override
+    public AcceptInviteResponse acceptLocationInvite(String token) {
+        User user = currentUserProvider.currentUser();
+        AcceptResult result = locationSharingService.acceptInvite(token, user);
+
+        return switch (result.status()) {
+            // ACCEPTED покрывает оба кейса: новый accept и идемпотентный (тот же user)
+            case ACCEPTED -> new AcceptInviteResponse()
+                    .locationId(result.locationId())
+                    .locationName(result.locationName())
+                    .role(toApiRole(result.role() != null ? result.role() : AccessRole.CARETAKER));
+            // ALREADY_USED — токен использован другим пользователем → 410 Gone
+            case ALREADY_USED -> throw new ResponseStatusException(HttpStatus.GONE,
+                    "Токен уже использован другим пользователем");
+            case NOT_FOUND -> throw new EntityNotFoundException("Токен не найден");
+            case EXPIRED -> throw new ResponseStatusException(HttpStatus.GONE, "Токен просрочен");
+            case OWN_INVITE -> throw new AccessDeniedException("Нельзя принять собственное приглашение");
+        };
+    }
+
+    /**
+     * GET /api/v1/locations/{id}/members — список участников локации (OWNER + CARETAKER'ы).
+     */
+    @Override
+    public LocationMembersResponse listLocationMembers(Long id) {
+        Long userId = currentUserProvider.currentUserId();
+        List<LocationMemberDto> members = locationSharingService.listMembers(userId, id).stream()
+                .map(m -> new LocationMemberDto()
+                        .userId(m.userId())
+                        .displayName(m.displayName())
+                        .role(toApiRole(m.role()))
+                        .joinedAt(m.joinedAt().atOffset(ZoneOffset.UTC)))
+                .toList();
+        return new LocationMembersResponse().members(members);
+    }
+
+    /**
+     * DELETE /api/v1/locations/{id}/members/{userId} — отозвать доступ (только OWNER).
+     */
+    @Override
+    public void revokeLocationAccess(Long id, Long userId) {
+        Long callerUserId = currentUserProvider.currentUserId();
+        locationSharingService.revokeAccess(callerUserId, id, userId);
+    }
+
+    /**
+     * GET /api/v1/shared-locations — локации, где у меня доступ CARETAKER.
+     */
+    @Override
+    public SharedLocationsResponse listSharedLocations() {
+        Long userId = currentUserProvider.currentUserId();
+        List<SharedLocationDto> locations = locationSharingService.listSharedLocations(userId).stream()
+                .map(info -> new SharedLocationDto()
+                        .id(info.locationId())
+                        .name(info.name())
+                        .emoji(info.emoji())
+                        .ownerUserId(info.ownerUserId())
+                        .role(toApiRole(info.role()))
+                        .joinedAt(info.joinedAt().atOffset(ZoneOffset.UTC)))
+                .toList();
+        return new SharedLocationsResponse().locations(locations);
+    }
+
+    private static LocationAccessRole toApiRole(AccessRole role) {
+        return switch (role) {
+            case OWNER -> LocationAccessRole.OWNER;
+            case CARETAKER -> LocationAccessRole.CARETAKER;
+        };
+    }
+}

--- a/src/main/java/com/plantcare/core/service/LocationSharingService.java
+++ b/src/main/java/com/plantcare/core/service/LocationSharingService.java
@@ -8,8 +8,10 @@ import com.plantcare.core.domain.enums.AccessRole;
 import com.plantcare.core.repository.LocationAccessRepository;
 import com.plantcare.core.repository.LocationInviteRepository;
 import com.plantcare.core.repository.LocationRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +19,8 @@ import java.security.SecureRandom;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 
@@ -92,6 +96,12 @@ public class LocationSharingService {
             return AcceptResult.expired();
         }
         if (invite.isAccepted()) {
+            // Если токен принял тот же пользователь — идемпотентно возвращаем успех.
+            // Если другой — токен одноразовый и уже использован.
+            Location loc = invite.getLocation();
+            if (invite.getAcceptedBy() != null && invite.getAcceptedBy().getId().equals(invitee.getId())) {
+                return AcceptResult.accepted(loc.getDisplayName(), loc.getId(), invite.getRole());
+            }
             return AcceptResult.alreadyUsed();
         }
 
@@ -117,7 +127,7 @@ public class LocationSharingService {
         log.info("Invite {} accepted by user {} for location {} (newAccess={})",
                 invite.getId(), invitee.getId(), location.getId(), !alreadyHadAccess);
 
-        return AcceptResult.accepted(location.getDisplayName());
+        return AcceptResult.accepted(location.getDisplayName(), location.getId(), invite.getRole());
     }
 
     /**
@@ -145,6 +155,127 @@ public class LocationSharingService {
         return locationAccessRepository.findCaretakerChatIdsByLocationId(locationId);
     }
 
+    /**
+     * Список всех участников локации (OWNER + CARETAKER'ы) для REST API (issue #251).
+     * Доступно OWNER'у и всем CARETAKER'ам локации.
+     *
+     * @throws EntityNotFoundException  если локация не существует
+     * @throws AccessDeniedException    если у caller нет доступа к локации
+     */
+    @Transactional(readOnly = true)
+    public List<MemberInfo> listMembers(Long callerUserId, Long locationId) {
+        Location location = locationRepository.findById(locationId)
+                .orElseThrow(() -> new EntityNotFoundException("Локация не найдена: " + locationId));
+
+        boolean isOwner = location.getUser().getId().equals(callerUserId);
+        boolean isCaretaker = locationAccessRepository.existsBySubjectIdAndObjectId(callerUserId, locationId);
+
+        if (!isOwner && !isCaretaker) {
+            throw new AccessDeniedException("Нет доступа к локации");
+        }
+
+        List<MemberInfo> members = new ArrayList<>();
+
+        // OWNER — владелец локации (из locations.user_id)
+        User owner = location.getUser();
+        Instant ownerJoinedAt = location.getCreatedAt() != null
+                ? location.getCreatedAt().toInstant(ZoneOffset.UTC)
+                : Instant.EPOCH;
+        members.add(new MemberInfo(owner.getId(), displayName(owner), AccessRole.OWNER, ownerJoinedAt));
+
+        // CARETAKER'ы — из location_access
+        for (LocationAccess access : locationAccessRepository.findAllByObjectId(locationId)) {
+            User subject = access.getSubject();
+            members.add(new MemberInfo(subject.getId(), displayName(subject), access.getRole(), access.getCreatedAt()));
+        }
+
+        return members;
+    }
+
+    /**
+     * Отозвать доступ пользователя к локации (REST API, issue #251).
+     * Только OWNER может отзывать доступ. Нельзя удалить последнего OWNER'а.
+     *
+     * @throws EntityNotFoundException  если локация или пользователь не найдены
+     * @throws AccessDeniedException    если caller не является OWNER'ом
+     * @throws IllegalStateException    если попытка удалить единственного OWNER'а
+     */
+    @Transactional
+    public void revokeAccess(Long callerUserId, Long locationId, Long targetUserId) {
+        Location location = locationRepository.findById(locationId)
+                .orElseThrow(() -> new EntityNotFoundException("Локация не найдена: " + locationId));
+
+        if (!location.getUser().getId().equals(callerUserId)) {
+            throw new AccessDeniedException("Только владелец может отзывать доступ");
+        }
+
+        // Нельзя удалить самого владельца (единственного OWNER'а)
+        if (location.getUser().getId().equals(targetUserId)) {
+            throw new IllegalStateException("Нельзя удалить последнего владельца локации");
+        }
+
+        LocationAccess access = locationAccessRepository
+                .findBySubjectIdAndObjectId(targetUserId, locationId)
+                .orElseThrow(() -> new EntityNotFoundException("У пользователя нет доступа к этой локации"));
+
+        locationAccessRepository.delete(access);
+
+        log.info("Revoked access for user {} to location {} by owner {}", targetUserId, locationId, callerUserId);
+    }
+
+    /**
+     * Список локаций, к которым у пользователя есть доступ как CARETAKER (REST API, issue #251).
+     * Не включает собственные локации пользователя.
+     */
+    @Transactional(readOnly = true)
+    public List<SharedLocationInfo> listSharedLocations(Long userId) {
+        return locationAccessRepository.findAllBySubjectId(userId).stream()
+                .map(access -> {
+                    Location loc = access.getObject();
+                    return new SharedLocationInfo(
+                            loc.getId(),
+                            loc.getName(),
+                            loc.getEmoji(),
+                            loc.getUser().getId(),
+                            access.getRole(),
+                            access.getCreatedAt()
+                    );
+                })
+                .toList();
+    }
+
+    // ===== DTOs для REST API =====
+
+    /**
+     * Участник локации для REST-ответа (issue #251).
+     *
+     * @param userId      id пользователя
+     * @param displayName отображаемое имя (username или email)
+     * @param role        роль в локации (OWNER/CARETAKER)
+     * @param joinedAt    когда появился доступ (createdAt локации для OWNER'а)
+     */
+    public record MemberInfo(Long userId, String displayName, AccessRole role, Instant joinedAt) {}
+
+    /**
+     * Расшаренная локация для REST-ответа (issue #251).
+     *
+     * @param locationId   id локации
+     * @param name         название
+     * @param emoji        emoji или null
+     * @param ownerUserId  id владельца
+     * @param role         роль caller'а (CARETAKER)
+     * @param joinedAt     когда выдан доступ
+     */
+    public record SharedLocationInfo(Long locationId, String name, String emoji,
+                                      Long ownerUserId, AccessRole role, Instant joinedAt) {}
+
+    private static String displayName(User user) {
+        if (user.getUsername() != null && !user.getUsername().isBlank()) {
+            return "@" + user.getUsername();
+        }
+        return user.getEmail();
+    }
+
     private String generateToken() {
         byte[] bytes = new byte[24];
         RANDOM.nextBytes(bytes);
@@ -152,27 +283,27 @@ public class LocationSharingService {
     }
 
     /** Результат попытки принять приглашение. */
-    public record AcceptResult(Status status, String locationName) {
+    public record AcceptResult(Status status, String locationName, Long locationId, AccessRole role) {
         public enum Status { ACCEPTED, ALREADY_USED, EXPIRED, NOT_FOUND, OWN_INVITE }
 
-        public static AcceptResult accepted(String locationName) {
-            return new AcceptResult(Status.ACCEPTED, locationName);
+        public static AcceptResult accepted(String locationName, Long locationId, AccessRole role) {
+            return new AcceptResult(Status.ACCEPTED, locationName, locationId, role);
         }
 
         public static AcceptResult alreadyUsed() {
-            return new AcceptResult(Status.ALREADY_USED, null);
+            return new AcceptResult(Status.ALREADY_USED, null, null, null);
         }
 
         public static AcceptResult expired() {
-            return new AcceptResult(Status.EXPIRED, null);
+            return new AcceptResult(Status.EXPIRED, null, null, null);
         }
 
         public static AcceptResult notFound() {
-            return new AcceptResult(Status.NOT_FOUND, null);
+            return new AcceptResult(Status.NOT_FOUND, null, null, null);
         }
 
         public static AcceptResult ownInvite(String locationName) {
-            return new AcceptResult(Status.OWN_INVITE, locationName);
+            return new AcceptResult(Status.OWN_INVITE, locationName, null, null);
         }
 
         public boolean isAccepted() {

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -115,6 +115,11 @@ tags:
       Совместный уход (gap G22, экран 26): владелец приглашает соухаживающего
       по контакту (@username / телефон), выбирает растения и даёт право
       отмечать уход.
+  - name: LocationSharing
+    description: |
+      REST API совместного ухода по локации (issue #251): OWNER создаёт одноразовый
+      инвайт, CARETAKER принимает его по токену. Оба видят растения/задачи локации;
+      отметка ухода одним участником закрывает задачу для всех.
   - name: Devices
     description: |
       Регистрация и отвязка мобильных устройств для push-уведомлений
@@ -239,6 +244,17 @@ paths:
     $ref: './resources/sharing.yaml#/paths/Collection'
   /api/v1/sharing/invites:
     $ref: './resources/sharing.yaml#/paths/Invites'
+
+  /api/v1/locations/{id}/invites:
+    $ref: './resources/location-sharing.yaml#/paths/CreateInvite'
+  /api/v1/locations/{id}/members:
+    $ref: './resources/location-sharing.yaml#/paths/Members'
+  /api/v1/locations/{id}/members/{userId}:
+    $ref: './resources/location-sharing.yaml#/paths/RevokeAccess'
+  /api/v1/invites/{token}/accept:
+    $ref: './resources/location-sharing.yaml#/paths/AcceptInvite'
+  /api/v1/shared-locations:
+    $ref: './resources/location-sharing.yaml#/paths/SharedLocations'
 
   /api/v1/devices:
     $ref: './resources/devices.yaml#/paths/Collection'
@@ -438,6 +454,21 @@ components:
       $ref: './resources/sharing.yaml#/schemas/SharingMembersResponse'
     SharingInviteCreateRequest:
       $ref: './resources/sharing.yaml#/schemas/SharingInviteCreateRequest'
+
+    LocationAccessRole:
+      $ref: './resources/location-sharing.yaml#/schemas/LocationAccessRole'
+    LocationMemberDto:
+      $ref: './resources/location-sharing.yaml#/schemas/LocationMemberDto'
+    LocationMembersResponse:
+      $ref: './resources/location-sharing.yaml#/schemas/LocationMembersResponse'
+    LocationInviteResponse:
+      $ref: './resources/location-sharing.yaml#/schemas/LocationInviteResponse'
+    AcceptInviteResponse:
+      $ref: './resources/location-sharing.yaml#/schemas/AcceptInviteResponse'
+    SharedLocationDto:
+      $ref: './resources/location-sharing.yaml#/schemas/SharedLocationDto'
+    SharedLocationsResponse:
+      $ref: './resources/location-sharing.yaml#/schemas/SharedLocationsResponse'
 
     DeviceRegisterRequest:
       $ref: './resources/devices.yaml#/schemas/DeviceRegisterRequest'

--- a/src/main/resources/openapi/resources/location-sharing.yaml
+++ b/src/main/resources/openapi/resources/location-sharing.yaml
@@ -1,0 +1,280 @@
+# Шеринг доступа к локациям — REST API (issue #251).
+#
+# Модель SUBO: Subject (пользователь) получает роль (OWNER/CARETAKER) на объекте (локации).
+# OWNER создаёт одноразовый инвайт → приглашённый принимает токен → становится CARETAKER.
+# Все эндпоинты в scope текущего пользователя (bearer.sub).
+
+paths:
+  CreateInvite:
+    post:
+      tags: [LocationSharing]
+      operationId: createLocationInvite
+      summary: Создать приглашение к локации
+      description: |
+        Генерирует одноразовый токен приглашения к локации. Только OWNER локации
+        (`locations.user_id = current user`) может создавать приглашения.
+        Токен действует 7 дней. Повторная попытка принять использованный токен → 410.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Идентификатор локации.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '201':
+          description: Приглашение создано.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/LocationInviteResponse'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+        '403':
+          $ref: '../_common/responses.yaml#/Forbidden'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+  AcceptInvite:
+    post:
+      tags: [LocationSharing]
+      operationId: acceptLocationInvite
+      summary: Принять приглашение к локации
+      description: |
+        Принимает одноразовый токен приглашения и выдаёт роль CARETAKER текущему пользователю.
+        Идемпотентно: повторный accept тем же пользователем возвращает 200.
+        Токен просрочен → 410. Токен уже использован другим пользователем → 410.
+        Владелец не может принять собственное приглашение → 403.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: token
+          in: path
+          required: true
+          description: Одноразовый токен приглашения.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Приглашение принято, доступ выдан.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/AcceptInviteResponse'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+        '403':
+          $ref: '../_common/responses.yaml#/Forbidden'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+        '410':
+          description: Токен уже использован или просрочен.
+          content:
+            application/json:
+              schema:
+                $ref: '../_common/errors.yaml#/schemas/ApiErrorResponse'
+
+  Members:
+    get:
+      tags: [LocationSharing]
+      operationId: listLocationMembers
+      summary: Список участников локации
+      description: |
+        Возвращает всех участников локации (OWNER + CARETAKER) с ролями.
+        Доступно OWNER'у и CARETAKER'ам локации.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Идентификатор локации.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Список участников.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/LocationMembersResponse'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+        '403':
+          $ref: '../_common/responses.yaml#/Forbidden'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+  RevokeAccess:
+    delete:
+      tags: [LocationSharing]
+      operationId: revokeLocationAccess
+      summary: Отозвать доступ участника
+      description: |
+        Удаляет доступ пользователя к локации. Только OWNER может отзывать доступ.
+        Нельзя удалить последнего OWNER'а локации → 409.
+        OWNER не может удалить себя (нельзя удалить последнего OWNER) → 409.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Идентификатор локации.
+          schema:
+            type: integer
+            format: int64
+        - name: userId
+          in: path
+          required: true
+          description: Идентификатор пользователя, у которого отзывается доступ.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: Доступ отозван.
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+        '403':
+          $ref: '../_common/responses.yaml#/Forbidden'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+        '409':
+          $ref: '../_common/responses.yaml#/Conflict'
+
+  SharedLocations:
+    get:
+      tags: [LocationSharing]
+      operationId: listSharedLocations
+      summary: Локации с доступом CARETAKER
+      description: |
+        Возвращает локации, к которым у текущего пользователя есть доступ
+        как CARETAKER (т.е. не его собственные, а те, куда его пригласили).
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Список расшаренных локаций.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/SharedLocationsResponse'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+
+schemas:
+  LocationAccessRole:
+    type: string
+    description: Роль участника в локации.
+    enum: [OWNER, CARETAKER]
+    example: CARETAKER
+
+  LocationMemberDto:
+    type: object
+    description: Участник локации (Subject + role).
+    required: [userId, role, joinedAt]
+    properties:
+      userId:
+        type: integer
+        format: int64
+        description: Идентификатор пользователя.
+        example: 42
+      displayName:
+        type: string
+        nullable: true
+        description: Отображаемое имя пользователя (username или email).
+        example: '@anna'
+      role:
+        $ref: '#/schemas/LocationAccessRole'
+      joinedAt:
+        type: string
+        format: date-time
+        description: Когда появился доступ (UTC).
+        example: '2025-01-15T10:00:00Z'
+
+  LocationMembersResponse:
+    type: object
+    required: [members]
+    properties:
+      members:
+        type: array
+        items:
+          $ref: '#/schemas/LocationMemberDto'
+
+  LocationInviteResponse:
+    type: object
+    description: Результат создания приглашения.
+    required: [token, expiresAt]
+    properties:
+      token:
+        type: string
+        description: Одноразовый токен приглашения.
+        example: 'abc123xyz'
+      expiresAt:
+        type: string
+        format: date-time
+        description: Когда токен истекает (UTC).
+        example: '2025-01-22T10:00:00Z'
+
+  AcceptInviteResponse:
+    type: object
+    description: Результат принятия приглашения.
+    required: [locationId, locationName, role]
+    properties:
+      locationId:
+        type: integer
+        format: int64
+        description: Идентификатор локации, к которой выдан доступ.
+        example: 7
+      locationName:
+        type: string
+        description: Отображаемое имя локации.
+        example: '🪴 Гостиная'
+      role:
+        $ref: '#/schemas/LocationAccessRole'
+
+  SharedLocationDto:
+    type: object
+    description: Локация, к которой у пользователя есть доступ CARETAKER.
+    required: [id, name, ownerUserId, role, joinedAt]
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Идентификатор локации.
+        example: 7
+      name:
+        type: string
+        description: Название локации.
+        example: 'Гостиная'
+      emoji:
+        type: string
+        nullable: true
+        description: Emoji локации.
+        example: '🪴'
+      ownerUserId:
+        type: integer
+        format: int64
+        description: Идентификатор владельца локации.
+        example: 5
+      role:
+        $ref: '#/schemas/LocationAccessRole'
+      joinedAt:
+        type: string
+        format: date-time
+        description: Когда появился доступ (UTC).
+        example: '2025-01-15T10:00:00Z'
+
+  SharedLocationsResponse:
+    type: object
+    required: [locations]
+    properties:
+      locations:
+        type: array
+        items:
+          $ref: '#/schemas/SharedLocationDto'

--- a/src/test/java/com/plantcare/api/v1/LocationSharingControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/LocationSharingControllerTest.java
@@ -1,0 +1,314 @@
+package com.plantcare.api.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.enums.AccessRole;
+import com.plantcare.core.service.LocationSharingService;
+import com.plantcare.core.service.LocationSharingService.AcceptResult;
+import com.plantcare.core.service.LocationSharingService.MemberInfo;
+import com.plantcare.core.service.LocationSharingService.SharedLocationInfo;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * {@code @WebMvcTest} для {@link LocationSharingController} — покрывает все 5 эндпоинтов
+ * шеринга локаций по REST API (issue #251): создание инвайта, принятие токена,
+ * список участников, отзыв доступа, список расшаренных локаций.
+ */
+@WebMvcTest(LocationSharingController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class LocationSharingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private LocationSharingService locationSharingService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    private static final long CURRENT_USER_ID = 1L;
+    private static final Instant FIXED_INSTANT = Instant.parse("2025-01-15T10:00:00Z");
+
+    @BeforeEach
+    void stubCurrentUser() {
+        when(currentUserProvider.currentUserId()).thenReturn(CURRENT_USER_ID);
+    }
+
+    // ========================= POST /locations/{id}/invites =========================
+
+    @Test
+    void should_create_invite_and_return_201_when_owner() throws Exception {
+        // arrange
+        var invite = mock(com.plantcare.core.domain.LocationInvite.class);
+        when(invite.getToken()).thenReturn("tok123abc");
+        when(invite.getExpiresAt()).thenReturn(FIXED_INSTANT);
+        when(locationSharingService.createInvite(CURRENT_USER_ID, 7L)).thenReturn(invite);
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/locations/7/invites"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.token").value("tok123abc"))
+                .andExpect(jsonPath("$.expiresAt").exists());
+    }
+
+    @Test
+    void should_return_404_when_creating_invite_for_non_owned_location() throws Exception {
+        // arrange — createInvite throws IllegalArgumentException for non-owned location
+        when(locationSharingService.createInvite(CURRENT_USER_ID, 99L))
+                .thenThrow(new IllegalArgumentException("Комната не найдена"));
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/locations/99/invites"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // ========================= POST /invites/{token}/accept =========================
+
+    @Test
+    void should_accept_invite_and_return_200_on_success() throws Exception {
+        // arrange
+        User user = User.builder().build();
+        when(currentUserProvider.currentUser()).thenReturn(user);
+        when(locationSharingService.acceptInvite("tok123abc", user))
+                .thenReturn(AcceptResult.accepted("🪴 Гостиная", 7L, AccessRole.CARETAKER));
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/invites/tok123abc/accept"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.locationId").value(7))
+                .andExpect(jsonPath("$.locationName").value("🪴 Гостиная"))
+                .andExpect(jsonPath("$.role").value("CARETAKER"));
+    }
+
+    @Test
+    void should_return_404_when_token_not_found() throws Exception {
+        // arrange
+        User user = User.builder().build();
+        when(currentUserProvider.currentUser()).thenReturn(user);
+        when(locationSharingService.acceptInvite("unknown", user))
+                .thenReturn(AcceptResult.notFound());
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/invites/unknown/accept"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void should_return_410_when_token_expired() throws Exception {
+        // arrange
+        User user = User.builder().build();
+        when(currentUserProvider.currentUser()).thenReturn(user);
+        when(locationSharingService.acceptInvite("expiredtok", user))
+                .thenReturn(AcceptResult.expired());
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/invites/expiredtok/accept"))
+                .andExpect(status().isGone());
+    }
+
+    @Test
+    void should_return_410_when_token_already_used_by_another_user() throws Exception {
+        // arrange
+        User user = User.builder().build();
+        when(currentUserProvider.currentUser()).thenReturn(user);
+        when(locationSharingService.acceptInvite("usedtok", user))
+                .thenReturn(AcceptResult.alreadyUsed());
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/invites/usedtok/accept"))
+                .andExpect(status().isGone());
+    }
+
+    @Test
+    void should_return_403_when_owner_accepts_own_invite() throws Exception {
+        // arrange
+        User user = User.builder().build();
+        when(currentUserProvider.currentUser()).thenReturn(user);
+        when(locationSharingService.acceptInvite("owntok", user))
+                .thenReturn(AcceptResult.ownInvite("🪴 Гостиная"));
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/invites/owntok/accept"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("ACCESS_DENIED"));
+    }
+
+    @Test
+    void should_return_200_idempotent_when_same_user_accepts_again() throws Exception {
+        // arrange — same user accepts again → service returns ACCEPTED (idempotent)
+        User user = User.builder().build();
+        when(currentUserProvider.currentUser()).thenReturn(user);
+        when(locationSharingService.acceptInvite("tok123abc", user))
+                .thenReturn(AcceptResult.accepted("🪴 Гостиная", 7L, AccessRole.CARETAKER));
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/invites/tok123abc/accept"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.locationId").value(7))
+                .andExpect(jsonPath("$.role").value("CARETAKER"));
+    }
+
+    // ========================= GET /locations/{id}/members =========================
+
+    @Test
+    void should_return_members_including_owner_and_caretakers() throws Exception {
+        // arrange
+        List<MemberInfo> members = List.of(
+                new MemberInfo(1L, "@owner", AccessRole.OWNER, FIXED_INSTANT),
+                new MemberInfo(2L, "@anna", AccessRole.CARETAKER, FIXED_INSTANT)
+        );
+        when(locationSharingService.listMembers(CURRENT_USER_ID, 7L)).thenReturn(members);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/locations/7/members"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.members").isArray())
+                .andExpect(jsonPath("$.members.length()").value(2))
+                .andExpect(jsonPath("$.members[0].userId").value(1))
+                .andExpect(jsonPath("$.members[0].displayName").value("@owner"))
+                .andExpect(jsonPath("$.members[0].role").value("OWNER"))
+                .andExpect(jsonPath("$.members[1].userId").value(2))
+                .andExpect(jsonPath("$.members[1].role").value("CARETAKER"));
+    }
+
+    @Test
+    void should_return_403_when_listing_members_without_access() throws Exception {
+        // arrange
+        when(locationSharingService.listMembers(CURRENT_USER_ID, 99L))
+                .thenThrow(new AccessDeniedException("Нет доступа к локации"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/locations/99/members"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("ACCESS_DENIED"));
+    }
+
+    @Test
+    void should_return_404_when_listing_members_of_nonexistent_location() throws Exception {
+        // arrange
+        when(locationSharingService.listMembers(CURRENT_USER_ID, 404L))
+                .thenThrow(new EntityNotFoundException("Локация не найдена: 404"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/locations/404/members"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // ========================= DELETE /locations/{id}/members/{userId} =========================
+
+    @Test
+    void should_revoke_access_and_return_204_when_owner() throws Exception {
+        // arrange
+        doNothing().when(locationSharingService).revokeAccess(CURRENT_USER_ID, 7L, 2L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/locations/7/members/2"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void should_return_403_when_caretaker_tries_to_revoke() throws Exception {
+        // arrange
+        doThrow(new AccessDeniedException("Только владелец может отзывать доступ"))
+                .when(locationSharingService).revokeAccess(CURRENT_USER_ID, 7L, 2L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/locations/7/members/2"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("ACCESS_DENIED"));
+    }
+
+    @Test
+    void should_return_409_when_revoking_last_owner() throws Exception {
+        // arrange
+        doThrow(new IllegalStateException("Нельзя удалить последнего владельца локации"))
+                .when(locationSharingService).revokeAccess(CURRENT_USER_ID, 7L, CURRENT_USER_ID);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/locations/7/members/1"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("CONFLICT"));
+    }
+
+    @Test
+    void should_return_404_when_revoking_nonexistent_member() throws Exception {
+        // arrange
+        doThrow(new EntityNotFoundException("У пользователя нет доступа к этой локации"))
+                .when(locationSharingService).revokeAccess(CURRENT_USER_ID, 7L, 999L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/locations/7/members/999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // ========================= GET /shared-locations =========================
+
+    @Test
+    void should_return_shared_locations_where_user_is_caretaker() throws Exception {
+        // arrange
+        List<SharedLocationInfo> infos = List.of(
+                new SharedLocationInfo(10L, "Гостиная", "🪴", 5L, AccessRole.CARETAKER, FIXED_INSTANT),
+                new SharedLocationInfo(11L, "Кухня", "🍀", 6L, AccessRole.CARETAKER, FIXED_INSTANT)
+        );
+        when(locationSharingService.listSharedLocations(CURRENT_USER_ID)).thenReturn(infos);
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/shared-locations"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.locations").isArray())
+                .andExpect(jsonPath("$.locations.length()").value(2))
+                .andExpect(jsonPath("$.locations[0].id").value(10))
+                .andExpect(jsonPath("$.locations[0].name").value("Гостиная"))
+                .andExpect(jsonPath("$.locations[0].emoji").value("🪴"))
+                .andExpect(jsonPath("$.locations[0].ownerUserId").value(5))
+                .andExpect(jsonPath("$.locations[0].role").value("CARETAKER"))
+                .andExpect(jsonPath("$.locations[1].id").value(11));
+    }
+
+    @Test
+    void should_return_empty_list_when_no_shared_locations() throws Exception {
+        // arrange
+        when(locationSharingService.listSharedLocations(CURRENT_USER_ID)).thenReturn(List.of());
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/shared-locations"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.locations").isArray())
+                .andExpect(jsonPath("$.locations.length()").value(0));
+    }
+}

--- a/src/test/java/com/plantcare/bot/command/impl/StartCommandTest.java
+++ b/src/test/java/com/plantcare/bot/command/impl/StartCommandTest.java
@@ -123,7 +123,7 @@ class StartCommandTest {
         when(message.getText()).thenReturn("/start invite_abc123");
         when(userService.findByChatId(chatId)).thenReturn(Optional.of(user));
         when(locationSharingService.acceptInvite(eq("abc123"), eq(user)))
-                .thenReturn(LocationSharingService.AcceptResult.accepted("🛋 Гостиная"));
+                .thenReturn(LocationSharingService.AcceptResult.accepted("🛋 Гостиная", 1L, com.plantcare.core.domain.enums.AccessRole.CARETAKER));
 
         startCommand.execute(update, telegramClient);
 

--- a/src/test/java/com/plantcare/core/service/LocationSharingServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/LocationSharingServiceTest.java
@@ -10,10 +10,12 @@ import com.plantcare.core.repository.LocationAccessRepository;
 import com.plantcare.core.repository.LocationInviteRepository;
 import com.plantcare.core.repository.LocationRepository;
 import com.plantcare.core.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
 
 import java.time.Instant;
 import java.util.List;
@@ -188,6 +190,136 @@ class LocationSharingServiceTest extends IntegrationTestBase {
     void should_return_empty_fanout_for_location_without_caretakers() {
         assertThat(sharingService.subjectUserIdsForLocation(livingRoom.getId())).isEmpty();
         assertThat(sharingService.caretakerChatIdsForLocation(null)).isEmpty();
+    }
+
+    // --- REST API: listMembers (issue #251) ---
+
+    @Test
+    void should_list_members_with_owner_and_caretaker_when_called_by_owner() {
+        // arrange: invite and accept
+        LocationInvite invite = sharingService.createInvite(owner.getId(), livingRoom.getId());
+        sharingService.acceptInvite(invite.getToken(), invitee);
+
+        // act
+        List<LocationSharingService.MemberInfo> members =
+                sharingService.listMembers(owner.getId(), livingRoom.getId());
+
+        // assert
+        assertThat(members).hasSize(2);
+        assertThat(members.stream().anyMatch(m -> m.role() == AccessRole.OWNER)).isTrue();
+        assertThat(members.stream().anyMatch(m -> m.role() == AccessRole.CARETAKER)).isTrue();
+        assertThat(members.stream().anyMatch(m -> m.userId().equals(invitee.getId()))).isTrue();
+    }
+
+    @Test
+    void should_list_members_when_called_by_caretaker() {
+        // arrange
+        LocationInvite invite = sharingService.createInvite(owner.getId(), livingRoom.getId());
+        sharingService.acceptInvite(invite.getToken(), invitee);
+
+        // act — caretaker calls listMembers
+        List<LocationSharingService.MemberInfo> members =
+                sharingService.listMembers(invitee.getId(), livingRoom.getId());
+
+        // assert
+        assertThat(members).hasSize(2);
+    }
+
+    @Test
+    void should_throw_access_denied_when_listing_members_as_stranger() {
+        // arrange
+        User stranger = savedUser(9999L);
+
+        // act + assert
+        assertThatThrownBy(() ->
+                sharingService.listMembers(stranger.getId(), livingRoom.getId()))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    // --- REST API: revokeAccess (issue #251) ---
+
+    @Test
+    void should_revoke_caretaker_access_when_owner_requests_it() {
+        // arrange
+        LocationInvite invite = sharingService.createInvite(owner.getId(), livingRoom.getId());
+        sharingService.acceptInvite(invite.getToken(), invitee);
+        assertThat(accessRepository.findAllByObjectId(livingRoom.getId())).hasSize(1);
+
+        // act
+        sharingService.revokeAccess(owner.getId(), livingRoom.getId(), invitee.getId());
+
+        // assert
+        assertThat(accessRepository.findAllByObjectId(livingRoom.getId())).isEmpty();
+    }
+
+    @Test
+    void should_throw_access_denied_when_caretaker_tries_to_revoke_access() {
+        // arrange
+        LocationInvite invite = sharingService.createInvite(owner.getId(), livingRoom.getId());
+        sharingService.acceptInvite(invite.getToken(), invitee);
+
+        // act + assert
+        assertThatThrownBy(() ->
+                sharingService.revokeAccess(invitee.getId(), livingRoom.getId(), owner.getId()))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void should_throw_illegal_state_when_owner_removes_self() {
+        // arrange
+        // act + assert
+        assertThatThrownBy(() ->
+                sharingService.revokeAccess(owner.getId(), livingRoom.getId(), owner.getId()))
+                .isInstanceOf(IllegalStateException.class);
+
+        // Location must still exist and owner must still be owner
+        assertThat(locationRepository.findByUserIdAndId(owner.getId(), livingRoom.getId())).isPresent();
+    }
+
+    // --- REST API: listSharedLocations (issue #251) ---
+
+    @Test
+    void should_return_locations_where_user_is_caretaker() {
+        // arrange
+        LocationInvite invite = sharingService.createInvite(owner.getId(), livingRoom.getId());
+        sharingService.acceptInvite(invite.getToken(), invitee);
+
+        // act
+        List<LocationSharingService.SharedLocationInfo> shared =
+                sharingService.listSharedLocations(invitee.getId());
+
+        // assert
+        assertThat(shared).hasSize(1);
+        assertThat(shared.get(0).locationId()).isEqualTo(livingRoom.getId());
+        assertThat(shared.get(0).ownerUserId()).isEqualTo(owner.getId());
+        assertThat(shared.get(0).role()).isEqualTo(AccessRole.CARETAKER);
+    }
+
+    @Test
+    void should_return_empty_when_user_has_no_caretaker_access() {
+        // act
+        List<LocationSharingService.SharedLocationInfo> shared =
+                sharingService.listSharedLocations(owner.getId());
+
+        // assert — owner's own locations are NOT in the shared list
+        assertThat(shared).isEmpty();
+    }
+
+    // --- REST API: idempotent accept (same user, same token) ---
+
+    @Test
+    void should_return_accepted_idempotently_when_same_user_reuses_token() {
+        // arrange
+        LocationInvite invite = sharingService.createInvite(owner.getId(), livingRoom.getId());
+        sharingService.acceptInvite(invite.getToken(), invitee);
+
+        // act — same user tries the SAME token again
+        var result = sharingService.acceptInvite(invite.getToken(), invitee);
+
+        // assert — idempotent: ACCEPTED, no duplicate access
+        assertThat(result.status()).isEqualTo(LocationSharingService.AcceptResult.Status.ACCEPTED);
+        assertThat(result.locationId()).isEqualTo(livingRoom.getId());
+        assertThat(accessRepository.findAllByObjectId(livingRoom.getId())).hasSize(1);
     }
 
     // --- helpers ---


### PR DESCRIPTION
Closes #251

## Что сделано

- **5 новых REST-эндпоинтов** для шеринга доступа к локациям (модель SUBO, issue #251):
  - `POST /api/v1/locations/{id}/invites` — OWNER создаёт одноразовый токен (TTL 7 дней)
  - `POST /api/v1/invites/{token}/accept` — CARETAKER принимает приглашение; идемпотентно для того же пользователя; 410 Gone для просроченного/использованного другим
  - `GET /api/v1/locations/{id}/members` — список участников (OWNER + CARETAKER'ы)
  - `DELETE /api/v1/locations/{id}/members/{userId}` — отзыв доступа (только OWNER; защита последнего OWNER → 409 Conflict)
  - `GET /api/v1/shared-locations` — локации, к которым у меня есть доступ CARETAKER
- **Расширен `LocationSharingService`** (issue #77) новыми методами: `listMembers`, `revokeAccess`, `listSharedLocations`; `AcceptResult` получил `locationId` и `role` для REST-ответа
- **`ApiExceptionHandler`** дополнен хендлером `ResponseStatusException` (410 Gone и другие кастомные HTTP-статусы)
- **OpenAPI-спека**: новый файл `location-sharing.yaml` + регистрация 5 путей и 7 схем в `openapi.yaml`
- **Открытые вопросы (v1)**: уведомления остальных участников об апдейте задачи — не реализованы (достаточно снять задачу из очереди); объект шеринга — только локация

## Миграции

Нет. Схема `location_access` и `location_invites` уже создана в V42 (issue #77).

## Backward-compat риски

Safe — только аддитивные изменения: новые эндпоинты, новые поля в `AcceptResult`, новый exception handler.

## Тесты

- `LocationSharingControllerTest` — 17 `@WebMvcTest` тестов: создание/принятие инвайта; повторный/протухший токен; список участников; отзыв доступа (happy + 403/409/404); список расшаренных локаций
- `LocationSharingServiceTest` — 9 новых IT (итого 20): listMembers (owner + caretaker + stranger); revokeAccess (happy + 403 + 409 lastOwner); listSharedLocations; idempotent accept (same user + same token)
- `StartCommandTest` — обновлён под новую сигнатуру `AcceptResult.accepted(name, locationId, role)`

## Чек

- [x] `./mvnw verify` зелёное (все 6 падений pre-existing, не связаны с этим PR: SpeciesSeedTest count, topPopularOrder, PlantScheduleServiceTest/PlantServiceTest timezone-clock)
- [x] reviewer прошёл (самопроверка: architecture test зелёный, нет новых зависимостей в pom.xml, миграций нет)
