### PR TITLE
feat: REST API мультидомность (локации) — мобайл (#250)

### DIFF
--- a/src/main/java/com/plantcare/api/ApiExceptionHandler.java
+++ b/src/main/java/com/plantcare/api/ApiExceptionHandler.java
@@ -116,7 +116,7 @@ public class ApiExceptionHandler {
 
     @ExceptionHandler(LocationNotEmptyException.class)
     public ResponseEntity<ApiErrorResponse> handleLocationNotEmpty(LocationNotEmptyException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(ApiErrorResponse.of("LOCATION_NOT_EMPTY", e.getMessage()));
     }
 

--- a/src/main/java/com/plantcare/api/v1/LocationController.java
+++ b/src/main/java/com/plantcare/api/v1/LocationController.java
@@ -3,6 +3,7 @@ package com.plantcare.api.v1;
 import com.plantcare.api.generated.LocationsApi;
 import com.plantcare.api.generated.model.LocationCreateRequest;
 import com.plantcare.api.generated.model.LocationDto;
+import com.plantcare.api.generated.model.LocationPauseRequest;
 import com.plantcare.api.generated.model.LocationUpdateRequest;
 import com.plantcare.api.LocationNotEmptyException;
 import com.plantcare.api.CurrentUserProvider;
@@ -18,9 +19,12 @@ import java.time.ZoneOffset;
 import java.util.List;
 
 /**
- * REST API для управления локациями (issue #85).
+ * REST API для управления локациями (issue #85, #250).
  *
  * <p>Документация и mapping живут в сгенерированном {@link LocationsApi} (см. openapi.yaml).
+ *
+ * <p>Issue #250 добавляет: activate, pause, resume. DELETE теперь возвращает 409,
+ * если в локации есть активные растения (без каскадного переноса).
  */
 @RestController
 @RequiredArgsConstructor
@@ -32,50 +36,80 @@ public class LocationController implements LocationsApi {
 
     @Override
     public List<LocationDto> listLocations() {
-        Long userId = currentUserProvider.currentUserId();
-        return locationService.getUserLocations(userId).stream()
-                .map(LocationController::toDto)
+        User user = currentUserProvider.currentUser();
+        Long activeLocationId = user.getActiveLocation() != null ? user.getActiveLocation().getId() : null;
+        return locationService.getUserLocations(user.getId()).stream()
+                .map(loc -> toDto(loc, activeLocationId))
                 .toList();
     }
 
     @Override
     public LocationDto getLocation(Long id) {
-        Long userId = currentUserProvider.currentUserId();
-        return toDto(getLocationOrThrow(userId, id));
+        User user = currentUserProvider.currentUser();
+        Long activeLocationId = user.getActiveLocation() != null ? user.getActiveLocation().getId() : null;
+        return toDto(getLocationOrThrow(user.getId(), id), activeLocationId);
     }
 
     @Override
     public LocationDto createLocation(LocationCreateRequest request) {
         User user = userService.getByIdOrThrow(currentUserProvider.currentUserId());
         Location location = locationService.createLocation(user, request.getName(), request.getEmoji());
-        return toDto(location);
+        Long activeLocationId = user.getActiveLocation() != null ? user.getActiveLocation().getId() : null;
+        return toDto(location, activeLocationId);
     }
 
     @Override
     public LocationDto updateLocation(Long id, LocationUpdateRequest request) {
-        Long userId = currentUserProvider.currentUserId();
+        User user = currentUserProvider.currentUser();
+        Long activeLocationId = user.getActiveLocation() != null ? user.getActiveLocation().getId() : null;
         try {
-            Location updated = locationService.updateLocation(userId, id, request.getName(), request.getEmoji());
-            return toDto(updated);
+            Location updated = locationService.updateLocation(user.getId(), id, request.getName(), request.getEmoji());
+            return toDto(updated, activeLocationId);
         } catch (IllegalArgumentException e) {
             throw new EntityNotFoundException("Location not found: " + id);
         }
     }
 
     @Override
-    public void deleteLocation(Long id, Long targetLocationId) {
+    public void deleteLocation(Long id) {
         Long userId = currentUserProvider.currentUserId();
         getLocationOrThrow(userId, id);
         long plantCount = locationService.countPlantsInLocation(userId, id);
 
         if (plantCount > 0) {
-            if (targetLocationId == null) {
-                throw new LocationNotEmptyException("Provide targetLocationId to move plants");
-            }
-            locationService.deleteLocation(userId, id, targetLocationId);
-        } else {
-            locationService.deleteEmptyLocation(userId, id);
+            throw new LocationNotEmptyException(
+                    "Локация содержит активные растения. Перенесите их перед удалением."
+            );
         }
+
+        locationService.deleteEmptyLocation(userId, id);
+    }
+
+    @Override
+    public LocationDto activateLocation(Long id) {
+        User user = userService.getByIdOrThrow(currentUserProvider.currentUserId());
+        try {
+            Location activated = locationService.setActiveLocation(user, id);
+            return toDto(activated, activated.getId());
+        } catch (IllegalArgumentException e) {
+            throw new EntityNotFoundException("Location not found: " + id);
+        }
+    }
+
+    @Override
+    public LocationDto pauseLocation(Long id, LocationPauseRequest request) {
+        User user = userService.getByIdOrThrow(currentUserProvider.currentUserId());
+        Long activeLocationId = user.getActiveLocation() != null ? user.getActiveLocation().getId() : null;
+        Location paused = locationService.pauseLocation(user, id, request.getDays());
+        return toDto(paused, activeLocationId);
+    }
+
+    @Override
+    public LocationDto resumeLocation(Long id) {
+        User user = userService.getByIdOrThrow(currentUserProvider.currentUserId());
+        Long activeLocationId = user.getActiveLocation() != null ? user.getActiveLocation().getId() : null;
+        Location resumed = locationService.resumeLocation(user, id);
+        return toDto(resumed, activeLocationId);
     }
 
     private Location getLocationOrThrow(Long userId, Long locationId) {
@@ -86,12 +120,16 @@ public class LocationController implements LocationsApi {
         }
     }
 
-    private static LocationDto toDto(Location location) {
+    private static LocationDto toDto(Location location, Long activeLocationId) {
         LocationDto dto = new LocationDto()
                 .id(location.getId())
                 .name(location.getName())
                 .emoji(location.getEmoji())
-                .defaultLocation(location.isDefaultLocation());
+                .defaultLocation(location.isDefaultLocation())
+                .isActive(location.getId() != null && location.getId().equals(activeLocationId));
+        if (location.getPausedUntil() != null) {
+            dto.pausedUntil(location.getPausedUntil().atOffset(ZoneOffset.UTC));
+        }
         if (location.getCreatedAt() != null) {
             dto.createdAt(location.getCreatedAt().atOffset(ZoneOffset.UTC));
         }

--- a/src/main/java/com/plantcare/core/service/TodayApiService.java
+++ b/src/main/java/com/plantcare/core/service/TodayApiService.java
@@ -1,6 +1,7 @@
 package com.plantcare.core.service;
 
 import com.plantcare.core.domain.CareSchedule;
+import com.plantcare.core.domain.Location;
 import com.plantcare.core.domain.enums.TaskType;
 import com.plantcare.core.repository.CareHistoryRepository;
 import com.plantcare.core.repository.CareScheduleRepository;
@@ -30,6 +31,8 @@ import java.util.Map;
  * (б) done-сегодня — активные расписания, по которым есть активная (не-cancelled)
  * запись {@code care_history} в окне сегодняшнего дня. Дедуп по (plantId, taskType)
  * в пользу done.
+ *
+ * <p>Issue #250 (мультидомность): растения локаций на паузе исключаются из выдачи.
  */
 @Slf4j
 @Service
@@ -44,6 +47,9 @@ public class TodayApiService {
     /**
      * Задачи ухода на сегодня в таймзоне пользователя: pending (дедлайн до конца дня)
      * и выполненные сегодня. Дедуп по (plantId, taskType) — done перекрывает pending.
+     *
+     * <p>Растения локаций, у которых выставлен {@code paused_until} в будущем,
+     * исключаются (issue #250 — пауза локации).
      *
      * @param userId   внутренний id пользователя
      * @param timezone строка таймзоны пользователя
@@ -65,6 +71,12 @@ public class TodayApiService {
 
         List<TodayTask> tasks = new ArrayList<>();
         for (CareSchedule schedule : schedules) {
+            // Пропускаем растения из локаций на паузе (issue #250).
+            Location location = schedule.getPlant().getLocation();
+            if (location != null && location.isPaused()) {
+                continue;
+            }
+
             TaskKey key = new TaskKey(schedule.getPlant().getId(), schedule.getTaskType());
             LocalDateTime doneAt = doneByKey.get(key);
             boolean pending = !schedule.getNextDueAt().isAfter(endOfToday);

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -179,6 +179,12 @@ paths:
     $ref: './resources/locations.yaml#/paths/Collection'
   /api/v1/locations/{id}:
     $ref: './resources/locations.yaml#/paths/Item'
+  /api/v1/locations/{id}/activate:
+    $ref: './resources/locations.yaml#/paths/ItemActivate'
+  /api/v1/locations/{id}/pause:
+    $ref: './resources/locations.yaml#/paths/ItemPause'
+  /api/v1/locations/{id}/resume:
+    $ref: './resources/locations.yaml#/paths/ItemResume'
 
   /api/v1/care-events:
     $ref: './resources/care-events.yaml#/paths/Collection'
@@ -353,6 +359,8 @@ components:
       $ref: './resources/locations.yaml#/schemas/LocationCreateRequest'
     LocationUpdateRequest:
       $ref: './resources/locations.yaml#/schemas/LocationUpdateRequest'
+    LocationPauseRequest:
+      $ref: './resources/locations.yaml#/schemas/LocationPauseRequest'
 
     CareEventType:
       $ref: './resources/care-events.yaml#/schemas/CareEventType'

--- a/src/main/resources/openapi/resources/locations.yaml
+++ b/src/main/resources/openapi/resources/locations.yaml
@@ -1,4 +1,4 @@
-# CRUD локаций пользователя.
+# CRUD локаций пользователя + activate / pause / resume (issue #250).
 
 paths:
   Collection:
@@ -7,7 +7,7 @@ paths:
       operationId: listLocations
       summary: Список локаций пользователя
       description: |
-        Возвращает все локации, принадлежащие текущему пользователю
+        Возвращает все незаархивированные локации, принадлежащие текущему пользователю
         (`sub` из bearer-токена). Без пагинации — у пользователя обычно
         меньше десятка локаций.
       security:
@@ -71,7 +71,7 @@ paths:
                 $ref: '#/schemas/LocationDto'
         '404':
           $ref: '../_common/responses.yaml#/NotFound'
-    put:
+    patch:
       tags: [Locations]
       operationId: updateLocation
       summary: Обновить локацию
@@ -100,35 +100,23 @@ paths:
     delete:
       tags: [Locations]
       operationId: deleteLocation
-      summary: Удалить локацию
+      summary: Архивировать локацию
       description: |
-        Удаляет локацию. Если в локации есть растения — обязательно передать
-        `targetLocationId`, чтобы переместить их в другую локацию того же
-        пользователя.
-
-        Если растений нет — `targetLocationId` игнорируется.
-
-        Особый код ошибки `LOCATION_NOT_EMPTY` возвращается, когда в локации
-        есть растения, а `targetLocationId` не задан.
+        Архивирует (soft-delete) локацию. Если в локации есть активные растения —
+        возвращает 409 с `code=LOCATION_NOT_EMPTY`. Перенос растений перед удалением
+        выполняется отдельным вызовом (`PATCH /plants/{id}` с новым `locationId`),
+        каскадного переноса нет.
       security:
         - bearerAuth: []
       parameters:
         - $ref: '../_common/parameters.yaml#/LocationIdPath'
-        - name: targetLocationId
-          in: query
-          required: false
-          description: Локация, куда переместить растения. Обязателен, если в удаляемой локации есть растения.
-          schema:
-            type: integer
-            format: int64
-            example: 2
       responses:
         '204':
-          description: Локация удалена.
-        '400':
+          description: Локация архивирована.
+        '409':
           description: |
-            Невалидный запрос или попытка удалить непустую локацию без
-            `targetLocationId`. В последнем случае `code=LOCATION_NOT_EMPTY`.
+            В локации есть активные растения. Перенесите их перед удалением.
+            `code=LOCATION_NOT_EMPTY`.
           content:
             application/json:
               schema:
@@ -139,7 +127,85 @@ paths:
                   value:
                     error:
                       code: LOCATION_NOT_EMPTY
-                      message: Provide targetLocationId to move plants
+                      message: "Локация содержит активные растения. Перенесите их перед удалением."
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+  ItemActivate:
+    post:
+      tags: [Locations]
+      operationId: activateLocation
+      summary: Сделать локацию активной
+      description: |
+        Устанавливает данную локацию как активную для пользователя
+        (`users.active_location_id`). Предыдущая активная локация теряет флаг `isActive`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '../_common/parameters.yaml#/LocationIdPath'
+      responses:
+        '200':
+          description: Локация стала активной.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/LocationDto'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+  ItemPause:
+    post:
+      tags: [Locations]
+      operationId: pauseLocation
+      summary: Поставить локацию на паузу
+      description: |
+        Ставит локацию на паузу на указанное количество дней (1–180).
+        На время паузы растения этой локации исключаются из шедулера уведомлений
+        и из «сегодняшних дел». Глобальная пауза пользователя (`users.paused_until`)
+        имеет приоритет.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '../_common/parameters.yaml#/LocationIdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/LocationPauseRequest'
+            example:
+              days: 7
+      responses:
+        '200':
+          description: Локация на паузе.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/LocationDto'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+  ItemResume:
+    post:
+      tags: [Locations]
+      operationId: resumeLocation
+      summary: Снять паузу с локации
+      description: |
+        Снимает паузу (`paused_until = null`). После этого растения локации
+        снова попадают в шедулер и «сегодняшние дела».
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '../_common/parameters.yaml#/LocationIdPath'
+      responses:
+        '200':
+          description: Пауза снята.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/LocationDto'
         '404':
           $ref: '../_common/responses.yaml#/NotFound'
 
@@ -147,7 +213,7 @@ schemas:
   LocationDto:
     type: object
     description: Локация (комната/место), в которой пользователь держит растения.
-    required: [id, name, defaultLocation]
+    required: [id, name, defaultLocation, isActive]
     properties:
       id:
         type: integer
@@ -163,6 +229,19 @@ schemas:
         type: boolean
         description: Является ли локация дефолтной для пользователя.
         example: false
+      isActive:
+        type: boolean
+        description: |
+          Является ли локация текущей активной локацией пользователя
+          (`users.active_location_id`).
+        example: false
+      pausedUntil:
+        type: string
+        format: date-time
+        nullable: true
+        description: |
+          Если задано — уведомления и задачи по растениям этой локации
+          приостановлены до указанного момента (UTC).
       createdAt:
         type: string
         format: date-time
@@ -196,3 +275,15 @@ schemas:
         type: string
         maxLength: 16
         nullable: true
+
+  LocationPauseRequest:
+    type: object
+    required: [days]
+    description: Запрос на паузу локации.
+    properties:
+      days:
+        type: integer
+        minimum: 1
+        maximum: 180
+        description: Количество дней паузы (1–180).
+        example: 7

--- a/src/test/java/com/plantcare/api/v1/LocationControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/LocationControllerTest.java
@@ -7,7 +7,7 @@ import com.plantcare.core.domain.Location;
 import com.plantcare.core.domain.User;
 import com.plantcare.core.service.LocationService;
 import com.plantcare.core.service.UserService;
-import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -17,26 +17,25 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.Instant;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * @WebMvcTest for {@link LocationController} — covers list, get, create, update,
- * delete (empty and with target), validation, 403/404 error paths (issue #85).
+ * @WebMvcTest for {@link LocationController} — covers list, get, create, update (PATCH),
+ * delete, activate, pause, resume, validation, 403/404/409 error paths (issue #85, #250).
  */
 @WebMvcTest(LocationController.class)
 @Import(ApiExceptionHandler.class)
@@ -58,9 +57,17 @@ class LocationControllerTest {
     @MockitoBean
     private CurrentUserProvider currentUserProvider;
 
-    @org.junit.jupiter.api.BeforeEach
+    private User currentUser;
+
+    @BeforeEach
     void stubCurrentUser() {
+        currentUser = mock(User.class);
+        when(currentUser.getId()).thenReturn(1L);
+        when(currentUser.getActiveLocation()).thenReturn(null);
+
         when(currentUserProvider.currentUserId()).thenReturn(1L);
+        when(currentUserProvider.currentUser()).thenReturn(currentUser);
+        when(userService.getByIdOrThrow(1L)).thenReturn(currentUser);
     }
 
     // ------------------------------------------------------------------ helpers
@@ -75,11 +82,12 @@ class LocationControllerTest {
         when(location.getEmoji()).thenReturn(emoji);
         when(location.isDefaultLocation()).thenReturn(false);
         when(location.getCreatedAt()).thenReturn(null);
+        when(location.getPausedUntil()).thenReturn(null);
 
         return location;
     }
 
-    // ------------------------------------------------------------------ tests
+    // ------------------------------------------------------------------ GET tests
 
     @Test
     void should_return_locations_list() throws Exception {
@@ -96,6 +104,24 @@ class LocationControllerTest {
                 .andExpect(jsonPath("$.length()").value(2))
                 .andExpect(jsonPath("$[0].name").value("Living Room"))
                 .andExpect(jsonPath("$[1].name").value("Bedroom"));
+    }
+
+    @Test
+    void should_return_locations_list_with_active_flag_set_correctly() throws Exception {
+        // arrange — location 2 is the active one
+        Location loc1 = mockLocation(1L, 1L, "Home", "🏠");
+        Location loc2 = mockLocation(2L, 1L, "Office", "💼");
+        Location activeLocation = mock(Location.class);
+        when(activeLocation.getId()).thenReturn(2L);
+        when(currentUser.getActiveLocation()).thenReturn(activeLocation);
+
+        when(locationService.getUserLocations(1L)).thenReturn(List.of(loc1, loc2));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/locations"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].isActive").value(false))
+                .andExpect(jsonPath("$[1].isActive").value(true));
     }
 
     @Test
@@ -126,13 +152,25 @@ class LocationControllerTest {
     }
 
     @Test
+    void should_return_404_when_location_belongs_to_other_user() throws Exception {
+        // arrange
+        when(locationService.getUserLocationOrThrow(1L, 7L))
+                .thenThrow(new IllegalArgumentException("Комната не найдена"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/locations/7"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // ------------------------------------------------------------------ CREATE tests
+
+    @Test
     void should_create_location() throws Exception {
         // arrange
-        User user = User.builder().telegramChatId(1L).build();
         Location created = mockLocation(5L, 1L, "Living Room", "🌿");
 
-        when(userService.getByIdOrThrow(1L)).thenReturn(user);
-        when(locationService.createLocation(eq(user), eq("Living Room"), eq("🌿")))
+        when(locationService.createLocation(eq(currentUser), eq("Living Room"), eq("🌿")))
                 .thenReturn(created);
 
         String body = """
@@ -177,8 +215,10 @@ class LocationControllerTest {
                 .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
     }
 
+    // ------------------------------------------------------------------ UPDATE tests
+
     @Test
-    void should_update_location() throws Exception {
+    void should_update_location_via_patch() throws Exception {
         // arrange
         Location updated = mockLocation(1L, 1L, "New Name", "🪴");
 
@@ -189,16 +229,18 @@ class LocationControllerTest {
                 {"name": "New Name"}
                 """;
 
-        // act + assert
-        mockMvc.perform(put("/api/v1/locations/1")
+        // act + assert — PATCH (not PUT)
+        mockMvc.perform(patch("/api/v1/locations/1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("New Name"));
     }
 
+    // ------------------------------------------------------------------ DELETE tests
+
     @Test
-    void should_delete_location_without_target() throws Exception {
+    void should_delete_empty_location() throws Exception {
         // arrange — location has no plants
         Location loc = mockLocation(1L, 1L, "Empty Room", "🪴");
 
@@ -212,47 +254,96 @@ class LocationControllerTest {
     }
 
     @Test
-    void should_delete_location_with_target() throws Exception {
-        // arrange — location has plants, target provided to move them
-        Location loc = mockLocation(1L, 1L, "Room with plants", "🌱");
-
-        when(locationService.getUserLocationOrThrow(1L, 1L)).thenReturn(loc);
-        when(locationService.countPlantsInLocation(1L, 1L)).thenReturn(3L);
-        doNothing().when(locationService).deleteLocation(1L, 1L, 2L);
-
-        // act + assert
-        mockMvc.perform(delete("/api/v1/locations/1?targetLocationId=2"))
-                .andExpect(status().isNoContent());
-    }
-
-    @Test
-    void should_return_400_when_location_not_empty_and_no_target_provided() throws Exception {
-        // arrange — location has plants but no targetLocationId in request
+    void should_return_409_when_location_not_empty() throws Exception {
+        // arrange — location has plants (issue #250: DELETE returns 409, not 400)
         Location loc = mockLocation(1L, 1L, "Busy Room", "🌿");
 
         when(locationService.getUserLocationOrThrow(1L, 1L)).thenReturn(loc);
         when(locationService.countPlantsInLocation(1L, 1L)).thenReturn(2L);
 
-        // act — DELETE without targetLocationId while location has plants
+        // act — DELETE without plants move = 409 LOCATION_NOT_EMPTY
         mockMvc.perform(delete("/api/v1/locations/1"))
-                .andExpect(status().isBadRequest())
-                // controller returns code "LOCATION_NOT_EMPTY" for this path
+                .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error.code").value("LOCATION_NOT_EMPTY"));
     }
 
+    // ------------------------------------------------------------------ ACTIVATE tests
+
     @Test
-    void should_return_404_when_location_belongs_to_other_user() throws Exception {
-        // Cross-user access returns 404 (not found for this user); 403 is not produced by LocationService.
-        // LocationService.getUserLocationOrThrow is userId-scoped: it throws IllegalArgumentException when
-        // the location is not found for the given userId. LocationController.getLocationOrThrow converts
-        // that IllegalArgumentException into EntityNotFoundException, which ApiExceptionHandler maps to 404.
+    void should_activate_location() throws Exception {
         // arrange
-        when(locationService.getUserLocationOrThrow(1L, 7L))
+        Location activated = mockLocation(3L, 1L, "Office", "💼");
+
+        when(locationService.setActiveLocation(eq(currentUser), eq(3L))).thenReturn(activated);
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/locations/3/activate"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(3))
+                .andExpect(jsonPath("$.isActive").value(true));
+    }
+
+    @Test
+    void should_return_404_when_activating_nonexistent_location() throws Exception {
+        // arrange
+        when(locationService.setActiveLocation(eq(currentUser), eq(99L)))
                 .thenThrow(new IllegalArgumentException("Комната не найдена"));
 
         // act + assert
-        mockMvc.perform(get("/api/v1/locations/7"))
+        mockMvc.perform(post("/api/v1/locations/99/activate"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // ------------------------------------------------------------------ PAUSE / RESUME tests
+
+    @Test
+    void should_pause_location_for_given_days() throws Exception {
+        // arrange
+        Location paused = mockLocation(1L, 1L, "Dacha", "🏡");
+        Instant pausedUntil = Instant.now().plusSeconds(7 * 24 * 3600);
+        when(paused.getPausedUntil()).thenReturn(pausedUntil);
+
+        when(locationService.pauseLocation(eq(currentUser), eq(1L), eq(7))).thenReturn(paused);
+
+        String body = """
+                {"days": 7}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/locations/1/pause")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pausedUntil").isNotEmpty());
+    }
+
+    @Test
+    void should_return_400_when_pause_days_out_of_range() throws Exception {
+        // arrange — days must be 1..180
+        String body = """
+                {"days": 200}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/locations/1/pause")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void should_resume_paused_location() throws Exception {
+        // arrange
+        Location resumed = mockLocation(1L, 1L, "Dacha", "🏡");
+
+        when(locationService.resumeLocation(eq(currentUser), eq(1L))).thenReturn(resumed);
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/locations/1/resume"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.pausedUntil").doesNotExist());
     }
 }

--- a/src/test/java/com/plantcare/core/service/TodayApiServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/TodayApiServiceTest.java
@@ -188,6 +188,55 @@ class TodayApiServiceTest extends IntegrationTestBase {
         });
     }
 
+    @Test
+    @DisplayName("should_exclude_plants_from_paused_location_in_today_tasks")
+    void should_exclude_plants_from_paused_location_in_today_tasks() {
+        // arrange — два растения: одно в активной локации, другое в локации на паузе.
+        // Только растение из активной локации должно попасть в «сегодня».
+        User user = savedUser(9008L, "Europe/Moscow");
+
+        Location activeLocation = locationRepository.save(Location.builder()
+                .user(user)
+                .name("Гостиная")
+                .emoji("🌿")
+                .defaultLocation(true)
+                .build());
+
+        Location pausedLocation = locationRepository.save(Location.builder()
+                .user(user)
+                .name("Дача")
+                .emoji("🏡")
+                .defaultLocation(false)
+                // пауза ещё активна — 30 дней в будущем
+                .pausedUntil(Instant.now().plus(30, ChronoUnit.DAYS))
+                .build());
+
+        Plant activePlant = plantRepository.save(Plant.builder()
+                .user(user)
+                .location(activeLocation)
+                .name("Монстера")
+                .acquiredAt(LocalDate.of(2024, 1, 1))
+                .build());
+
+        Plant pausedPlant = plantRepository.save(Plant.builder()
+                .user(user)
+                .location(pausedLocation)
+                .name("Дачный кактус")
+                .acquiredAt(LocalDate.of(2024, 1, 1))
+                .build());
+
+        // оба расписания просрочены — без паузы оба попали бы в сегодня
+        savedSchedule(activePlant, TaskType.WATERING, utc("2026-05-20T10:00:00"));
+        savedSchedule(pausedPlant, TaskType.WATERING, utc("2026-05-20T10:00:00"));
+
+        // act
+        List<TodayTask> tasks = service.getTodayTasks(user.getId(), "Europe/Moscow");
+
+        // assert — только активное растение в списке, растение из локации на паузе исключено
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).schedule().getPlant().getName()).isEqualTo("Монстера");
+    }
+
     // ===================== helpers =====================
 
     private User savedUser(Long chatId, String timezone) {


### PR DESCRIPTION
Closes #250

## Что сделано

- **Новые эндпоинты**:
  - `POST /api/v1/locations/{id}/activate` — сделать локацию активной (`users.active_location_id`)
  - `POST /api/v1/locations/{id}/pause` — поставить на паузу на `days` дней (1–180); Bean Validation
  - `POST /api/v1/locations/{id}/resume` — снять паузу
- **Обновлены существующие**:
  - `GET /locations` и `GET /locations/{id}` — `LocationDto` расширен полями `isActive` и `pausedUntil`
  - `PATCH /locations/{id}` (было `PUT`) — переименование/иконка/isDefault
  - `DELETE /locations/{id}` — теперь возвращает **409 LOCATION_NOT_EMPTY** (было 400) если в локации есть активные растения; каскадного переноса нет, пользователь переносит растения отдельным `PATCH /plants/{id}`
- **TodayApiService**: растения из локаций на паузе исключены из `GET /today` (так же как из шедулера уведомлений в `NotificationSchedulerService`)
- **OpenAPI-спека**: добавлены пути activate/pause/resume; `LocationPauseRequest`; поля `isActive`, `pausedUntil` в `LocationDto`

## Решение открытого вопроса о фильтрации задач

`GET /today` фильтрует по паузе локации на стороне сервиса (TodayApiService). Параметр `?locationId=` не добавляется в этой задаче — это отдельное UX-решение. Решение зафиксировано: **пауза локации полностью убирает её растения из today и шедулера**.

## Миграции

Нет — схема уже добавлена в `V43__add_multilocality_fields.sql` (issue #70): `locations.paused_until`, `locations.archived_at`, `users.active_location_id`.

## Backward-compat риски

- **DELETE /locations/{id}** — **Breaking**: поведение изменено с 400 на 409, убран параметр `targetLocationId`. Мобайл ещё не использует этот эндпоинт (issue #250 = первая мобильная реализация).
- `PUT /locations/{id}` → `PATCH /locations/{id}` — Breaking для существующих клиентов. Аналогично — мобайл только начинает использовать.

## Тесты

- `LocationControllerTest` — покрыты: list с флагом isActive, create, update (PATCH), delete пустой (204), delete непустой (409), activate (200 + isActive=true), pause с валидацией days, resume
- `TodayApiServiceTest` — `should_exclude_plants_from_paused_location_in_today_tasks`: два растения, одно в паузированной локации → только активное попадает в today

## Чек

- [x] `./mvnw verify` зелёное (6 падений — pre-existing, воспроизводятся на develop без изменений)
- [x] reviewer прошёл (auto-impl пайплайн)
