### PR TITLE
fix(test): мок SeasonalSettingsService в WeatherLocationControllerTest (чинит красный develop)

### DIFF
--- a/src/test/java/com/plantcare/api/v1/WeatherLocationControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/WeatherLocationControllerTest.java
@@ -3,6 +3,7 @@ package com.plantcare.api.v1;
 import com.plantcare.api.ApiExceptionHandler;
 import com.plantcare.api.CurrentUserProvider;
 import com.plantcare.core.domain.User;
+import com.plantcare.core.seasonal.service.SeasonalSettingsService;
 import com.plantcare.core.service.AccountDeletionService;
 import com.plantcare.core.service.UserProfileService;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,6 +49,9 @@ class WeatherLocationControllerTest {
 
     @MockitoBean
     private AccountDeletionService accountDeletionService;
+
+    @MockitoBean
+    private SeasonalSettingsService seasonalSettingsService;
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
## Проблема
`develop` красный по «Java CI with Maven» с момента мержа #257 (PR #264, 18:40): **5 ошибок**, все в `WeatherLocationControllerTest` — `IllegalState: No qualifying bean of type SeasonalSettingsService`.

## Причина
`WeatherLocationControllerTest` — `@WebMvcTest(MeController.class)`. Эндпоинт `PUT /me/weather-location` (#257) живёт в `MeController`, который **к моменту мержа #257 уже получил** зависимость `SeasonalSettingsService` из #256 (per-season сезонность, влит раньше). Тест #257 написан до #256 и эту зависимость не мокал → `@WebMvcTest`-контекст не поднимался.

Текстового конфликта в тест-файле при мерже develop→#257 не было (конфликтили только `MeController.java` и `openapi.yaml`), поэтому разрешение конфликта его не затронуло — чисто семантическая интеграционная дыра между двумя PR.

## Фикс
Добавлен `@MockitoBean SeasonalSettingsService` в тест (по образцу остальных моков).

## Проверка
Локально: `Tests run: 5, Failures: 0, Errors: 0` — BUILD SUCCESS.

Мерж — за человеком.

🤖 Generated with [Claude Code](https://claude.com/claude-code)