### PR TITLE
feat: scheduler-lock (ShedLock-JDBC) — анти-дубли напоминаний при multi-instance (#279)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,8 @@
         <!-- Issue #114: Sentry 7.x. -jakarta-вариант таргетит jakarta.* и совместим
              со Spring Boot 3.5.x (текущая 3.5.14). 7.22.5 — последняя стабильная в линии 7.x. -->
         <sentry.version>7.22.5</sentry.version>
+        <!-- Эпик #277 (фаза 1, #279): ShedLock 5.x совместим со Spring 6 / Boot 3.5.x. -->
+        <shedlock.version>5.16.0</shedlock.version>
 
         <!-- Sonar -->
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
@@ -186,6 +188,20 @@
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
             <version>${jackson-databind-nullable.version}</version>
+        </dependency>
+
+        <!-- Issue #279, эпик #277 фаза 1: ShedLock на JDBC (Postgres) — distributed
+             lock для @Scheduled, анти-дубли напоминаний при multi-instance.
+             Намеренно НЕ Redis-provider: путь напоминаний не должен зависеть от Redis. -->
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-spring</artifactId>
+            <version>${shedlock.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-provider-jdbc-template</artifactId>
+            <version>${shedlock.version}</version>
         </dependency>
 
         <!-- Lombok -->

--- a/src/main/java/com/plantcare/PlantsCareApplication.java
+++ b/src/main/java/com/plantcare/PlantsCareApplication.java
@@ -6,13 +6,17 @@ import com.plantcare.core.config.HealthScoreProperties;
 import com.plantcare.core.config.SpeciesProperties;
 import com.plantcare.bot.config.TelegramRateLimitProperties;
 import com.plantcare.core.config.TransplantSuggestionProperties;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+// Issue #279, эпик #277 фаза 1: defaultLockAtMostFor = самый короткий период задач (1 мин).
+// При сбое инстанса лок освободится за это время, и следующий тик сможет взять его.
 @SpringBootApplication
 @EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT1M")
 @EnableConfigurationProperties({SpeciesProperties.class, CalendarProperties.class, HealthScoreProperties.class, TelegramRateLimitProperties.class, TransplantSuggestionProperties.class, ApiRateLimitProperties.class})
 public class PlantsCareApplication {
 

--- a/src/main/java/com/plantcare/api/auth/scheduler/AuthTokenCleanupScheduler.java
+++ b/src/main/java/com/plantcare/api/auth/scheduler/AuthTokenCleanupScheduler.java
@@ -6,6 +6,7 @@ import com.plantcare.core.repository.MagicLinkTokenRepository;
 import com.plantcare.core.repository.RevokedRefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,7 +40,10 @@ public class AuthTokenCleanupScheduler {
     private final Clock clock;
 
     /** Каждый час в 10-ю минуту (UTC), со смещением от прочих hourly-задач. */
+    // Issue #279: hourly-задача — cleanup идемпотентен, но дубли всё равно нежелательны.
     @Scheduled(cron = "0 10 * * * *", zone = "UTC")
+    @SchedulerLock(name = "AuthTokenCleanupScheduler_cleanup",
+            lockAtMostFor = "PT90M", lockAtLeastFor = "PT55M")
     @Transactional
     public void cleanup() {
         SentryTags.runWithLayer(Layer.SCHEDULER, "AuthTokenCleanupScheduler", () -> {

--- a/src/main/java/com/plantcare/bot/service/AcclimationSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/AcclimationSchedulerService.java
@@ -11,6 +11,7 @@ import com.plantcare.bot.telegram.SendCallbacks;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,7 +45,11 @@ public class AcclimationSchedulerService {
     private final PlantAcclimationService plantAcclimationService;
     private final RateLimitedTelegramSender telegramSender;
 
+    // Issue #279: hourly-задача — lockAtMostFor 90 мин (инстанс повис → лок освободится),
+    // lockAtLeastFor 55 мин (быстрый тик не запустится снова в ту же минуту).
     @Scheduled(fixedRate = 3_600_000L)  // раз в час
+    @SchedulerLock(name = "AcclimationSchedulerService_tick",
+            lockAtMostFor = "PT90M", lockAtLeastFor = "PT55M")
     @Transactional
     public void tick() {
         // Issue #114: изолированный scope на тик — captureException внутри получит

--- a/src/main/java/com/plantcare/bot/service/MonthlyReportScheduler.java
+++ b/src/main/java/com/plantcare/bot/service/MonthlyReportScheduler.java
@@ -9,6 +9,7 @@ import com.plantcare.bot.telegram.SendCallbacks;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
@@ -50,7 +51,10 @@ public class MonthlyReportScheduler {
      * ни с PlantAnniversaryScheduler ('0 5 * * * *'), ни с hourly fixedRate-задачами,
      * стартующими в 0-ю минуту.
      */
+    // Issue #279: hourly-задача — lockAtMostFor 90 мин, lockAtLeastFor 55 мин.
     @Scheduled(cron = "0 15 * * * *", zone = "UTC")
+    @SchedulerLock(name = "MonthlyReportScheduler_tick",
+            lockAtMostFor = "PT90M", lockAtLeastFor = "PT55M")
     public void tick() {
         // Issue #114: изолированный scope на тик — captureException внутри получит
         // тег layer=scheduler, и он не утечёт на соседние задачи shared-потока.

--- a/src/main/java/com/plantcare/bot/service/NotificationSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/NotificationSchedulerService.java
@@ -24,6 +24,7 @@ import io.micrometer.core.instrument.Timer;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,7 +64,13 @@ public class NotificationSchedulerService {
     private final PushSender pushSender;
     private final UserDeviceRepository userDeviceRepository;
 
+    // Issue #279: lockAtMostFor > fixedRate (2m > 1m) — если инстанс повис, лок
+    // освобождается через 2 мин, следующий тик уже через 1 мин возьмёт его.
+    // lockAtLeastFor = 55s — гарантирует, что на быстром инстансе тик не запускается
+    // дважды за одно окно (защита от <<мгновенного>> тика + рестарта).
     @Scheduled(fixedRate = 60_000)
+    @SchedulerLock(name = "NotificationSchedulerService_checkAndSendNotifications",
+            lockAtMostFor = "PT2M", lockAtLeastFor = "PT55S")
     @Transactional
     public void checkAndSendNotifications() {
         // Issue #114: весь тик выполняется в изолированном scope с тегом

--- a/src/main/java/com/plantcare/bot/service/PhotoProgressSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/PhotoProgressSchedulerService.java
@@ -12,6 +12,7 @@ import com.plantcare.bot.telegram.SendCallbacks;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -59,7 +60,10 @@ public class PhotoProgressSchedulerService {
     private final PhotoProgressService photoProgressService;
     private final RateLimitedTelegramSender telegramSender;
 
+    // Issue #279: hourly-задача — lockAtMostFor 90 мин, lockAtLeastFor 55 мин.
     @Scheduled(fixedRate = INTERVAL_MS)
+    @SchedulerLock(name = "PhotoProgressSchedulerService_checkPhotoPrompts",
+            lockAtMostFor = "PT90M", lockAtLeastFor = "PT55M")
     public void checkPhotoPrompts() {
         // Issue #114: изолированный scope на тик — тег layer=scheduler не течёт на
         // соседние задачи shared-потока @Scheduled.

--- a/src/main/java/com/plantcare/bot/service/PlantAnniversaryScheduler.java
+++ b/src/main/java/com/plantcare/bot/service/PlantAnniversaryScheduler.java
@@ -10,6 +10,7 @@ import com.plantcare.bot.telegram.SendCallbacks;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
@@ -60,7 +61,10 @@ public class PlantAnniversaryScheduler {
      * с другими hourly-задачами (PhotoProgressSchedulerService, AcclimationSchedulerService),
      * которые стартуют в 0-ю минуту через fixedRate.
      */
+    // Issue #279: hourly-задача — lockAtMostFor 90 мин, lockAtLeastFor 55 мин.
     @Scheduled(cron = "0 5 * * * *", zone = "UTC")
+    @SchedulerLock(name = "PlantAnniversaryScheduler_tick",
+            lockAtMostFor = "PT90M", lockAtLeastFor = "PT55M")
     public void tick() {
         // Issue #114: изолированный scope на тик — captureException внутри получит
         // тег layer=scheduler, и он не утечёт на соседние задачи shared-потока.

--- a/src/main/java/com/plantcare/bot/service/TransplantSuggestionScheduler.java
+++ b/src/main/java/com/plantcare/bot/service/TransplantSuggestionScheduler.java
@@ -13,6 +13,7 @@ import com.plantcare.bot.telegram.SendCallbacks;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
@@ -63,7 +64,11 @@ public class TransplantSuggestionScheduler {
      * минуте — daily-тика достаточно. Quiet-hours юзера всё равно проверяются
      * по его TZ перед отправкой.
      */
+    // Issue #279: daily-задача — lockAtMostFor 4h (долгий прогон OK), lockAtLeastFor 23h
+    // (гарантирует не более одного запуска в сутки даже при рестарте инстанса сразу после тика).
     @Scheduled(cron = "0 0 9 * * *", zone = "UTC")
+    @SchedulerLock(name = "TransplantSuggestionScheduler_tick",
+            lockAtMostFor = "PT4H", lockAtLeastFor = "PT23H")
     public void tick() {
         if (!properties.enabled()) {
             return;

--- a/src/main/java/com/plantcare/bot/service/VacationSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/VacationSchedulerService.java
@@ -12,6 +12,7 @@ import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,7 +63,10 @@ public class VacationSchedulerService {
      */
     private final ApplicationContext applicationContext;
 
+    // Issue #279: hourly-задача — lockAtMostFor 90 мин, lockAtLeastFor 55 мин.
     @Scheduled(cron = "0 0 * * * *", zone = "UTC")
+    @SchedulerLock(name = "VacationSchedulerService_tick",
+            lockAtMostFor = "PT90M", lockAtLeastFor = "PT55M")
     public void tick() {
         // Issue #114: изолированный scope на тик — captureException внутри получит
         // тег layer=scheduler, и он не утечёт на соседние задачи shared-потока.

--- a/src/main/java/com/plantcare/core/config/ShedLockConfig.java
+++ b/src/main/java/com/plantcare/core/config/ShedLockConfig.java
@@ -1,0 +1,30 @@
+package com.plantcare.core.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+
+/**
+ * Issue #279, эпик #277 фаза 1: конфигурация ShedLock JDBC-провайдера.
+ *
+ * <p>Используется Postgres, который уже является hard-dependency проекта,
+ * поэтому надёжнее Redis: падение Redis не останавливает уведомления.
+ * Таблица {@code shedlock} создаётся миграцией V46.
+ */
+@Configuration
+public class ShedLockConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withJdbcTemplate(new JdbcTemplate(dataSource))
+                        .usingDbTime() // use DB time to avoid clock skew between instances
+                        .build()
+        );
+    }
+}

--- a/src/main/resources/db/migration/V46__create_shedlock.sql
+++ b/src/main/resources/db/migration/V46__create_shedlock.sql
@@ -1,0 +1,11 @@
+-- Issue #279, эпик #277 фаза 1: таблица для ShedLock JDBC-провайдера.
+-- Обязательная схема по документации ShedLock 5.x — не менять имена колонок.
+-- При single-instance поведение не меняется; при multi-instance лок не даёт
+-- нескольким репликам одновременно запускать один и тот же @Scheduled-метод.
+CREATE TABLE shedlock (
+    name       VARCHAR(64)  NOT NULL,
+    lock_until TIMESTAMP(3) NOT NULL,
+    locked_at  TIMESTAMP(3) NOT NULL,
+    locked_by  VARCHAR(255) NOT NULL,
+    PRIMARY KEY (name)
+);

--- a/src/test/java/com/plantcare/bot/support/IntegrationTestBase.java
+++ b/src/test/java/com/plantcare/bot/support/IntegrationTestBase.java
@@ -1,6 +1,7 @@
 package com.plantcare.bot.support;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -22,6 +23,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @SpringBootTest
 @ActiveProfiles("test")
 @Testcontainers
+@Import(NoOpShedLockTestConfig.class)
 public abstract class IntegrationTestBase {
 
     protected static final PostgreSQLContainer<?> POSTGRES =

--- a/src/test/java/com/plantcare/bot/support/NoOpShedLockTestConfig.java
+++ b/src/test/java/com/plantcare/bot/support/NoOpShedLockTestConfig.java
@@ -1,0 +1,48 @@
+package com.plantcare.bot.support;
+
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.core.SimpleLock;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.util.Optional;
+
+/**
+ * Issue #279, эпик #277 фаза 1: в интеграционных тестах ShedLock-лок должен быть
+ * прозрачным.
+ *
+ * <p>Проблема: продакшн-{@code LockProvider} (JDBC поверх Postgres) пишет реальные
+ * локи с {@code lockAtLeastFor} в десятки минут. Поскольку Testcontainers-контейнер
+ * переиспользуется между тестами, а фоновые {@code @Scheduled}-задачи приложения
+ * реально тикают во время жизни тестового контекста, лок в таблице {@code shedlock}
+ * остаётся «занятым» и блокирует прямой вызов {@code @SchedulerLock}-метода в тесте —
+ * метод молча пропускается, и проверки внешних эффектов («должен отправить push»)
+ * падают. Это артефакт тестовой среды, а не дефект продакшн-логики.
+ *
+ * <p>Решение: в профиле {@code test} подменяем {@code LockProvider} на «всегда даёт
+ * лок» — каждый тик в тесте выполняется детерминированно. Распределённую семантику
+ * реального провайдера проверяет отдельный {@code ShedLockDistributedLockIT}, который
+ * локально переопределяет этот бин на настоящий JDBC-провайдер.
+ *
+ * <p>Подключается глобально через {@code spring.factories}-механизм импорта в
+ * {@link IntegrationTestBase} (см. {@code @Import}).
+ */
+@TestConfiguration
+public class NoOpShedLockTestConfig {
+
+    @Bean
+    @Primary
+    public LockProvider testLockProvider() {
+        return new AlwaysGrantingLockProvider();
+    }
+
+    /** Всегда выдаёт лок; {@code unlock()} — no-op. Ничего не персистит. */
+    static final class AlwaysGrantingLockProvider implements LockProvider {
+        @Override
+        public Optional<SimpleLock> lock(LockConfiguration lockConfiguration) {
+            return Optional.of(() -> { /* no-op unlock */ });
+        }
+    }
+}

--- a/src/test/java/com/plantcare/core/shedlock/ShedLockDistributedLockIT.java
+++ b/src/test/java/com/plantcare/core/shedlock/ShedLockDistributedLockIT.java
@@ -1,0 +1,136 @@
+package com.plantcare.core.shedlock;
+
+import com.plantcare.bot.support.IntegrationTestBase;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.core.SimpleLock;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #279, эпик #277 фаза 1: интеграционный тест ShedLock JDBC-провайдера.
+ *
+ * <p>Проверяет AC «два «инстанса» (два потока/контекста) — задача выполняется один раз»:
+ * два потока одновременно пытаются взять лок с одним именем; только один должен
+ * выполнить «задачу» (инкремент счётчика), второй должен получить пустой Optional.
+ *
+ * <p>Используется тот же {@link LockProvider} бин, что и в продакшн-конфиге
+ * (JdbcTemplateLockProvider поверх реального Postgres).
+ */
+class ShedLockDistributedLockIT extends IntegrationTestBase {
+
+    /**
+     * Базовый {@code IntegrationTestBase} помечает {@code @Primary} no-op
+     * {@code LockProvider} (тестовая прозрачность для прямых вызовов
+     * {@code @SchedulerLock}-методов в других тестах). Здесь нам нужен НАСТОЯЩИЙ
+     * JDBC-провайдер, чтобы проверить именно распределённую взаимоисключающую
+     * семантику — инжектим продакшн-бин по имени {@code lockProvider}
+     * (см. {@code ShedLockConfig}).
+     */
+    @Autowired
+    @Qualifier("lockProvider")
+    private LockProvider lockProvider;
+
+    /**
+     * Два потока конкурируют за один лок. Задача (инкремент счётчика) должна
+     * выполниться ровно один раз.
+     */
+    @Test
+    void should_execute_task_once_when_two_instances_compete() throws InterruptedException {
+        // arrange
+        String lockName = "ShedLockDistributedLockIT_concurrent_" + System.currentTimeMillis();
+        AtomicInteger executions = new AtomicInteger(0);
+        CountDownLatch bothStarted = new CountDownLatch(2);
+        CountDownLatch bothDone = new CountDownLatch(2);
+
+        Runnable taskAttempt = () -> {
+            LockConfiguration config = new LockConfiguration(
+                    Instant.now(),
+                    lockName,
+                    Duration.ofSeconds(30),  // lockAtMostFor
+                    Duration.ofSeconds(5)    // lockAtLeastFor
+            );
+            bothStarted.countDown();
+            try {
+                bothStarted.await(); // синхронизируем старт — оба потока стартуют вместе
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+
+            Optional<SimpleLock> lock = lockProvider.lock(config);
+            if (lock.isPresent()) {
+                try {
+                    // «задача» — внешний эффект, должен случиться один раз
+                    executions.incrementAndGet();
+                } finally {
+                    lock.get().unlock();
+                }
+            }
+            bothDone.countDown();
+        };
+
+        Thread instance1 = new Thread(taskAttempt, "instance-1");
+        Thread instance2 = new Thread(taskAttempt, "instance-2");
+
+        // act
+        instance1.start();
+        instance2.start();
+        bothDone.await();
+
+        // assert
+        assertThat(executions.get())
+                .as("Задача должна выполниться ровно один раз при конкурентном запуске двух «инстансов»")
+                .isEqualTo(1);
+    }
+
+    /**
+     * Лок освобождается после unlock(), и следующая попытка с тем же именем
+     * должна успешно взять лок (проверка корректности round-trip).
+     */
+    @Test
+    void should_allow_relock_after_unlock() {
+        // arrange
+        String lockName = "ShedLockDistributedLockIT_relock_" + System.currentTimeMillis();
+        LockConfiguration config = new LockConfiguration(
+                Instant.now(),
+                lockName,
+                Duration.ofSeconds(30),
+                Duration.ofMillis(1)  // lockAtLeastFor минимальный — чтобы тест не завис
+        );
+
+        // act: берём лок, отпускаем, берём снова
+        Optional<SimpleLock> firstLock = lockProvider.lock(config);
+        assertThat(firstLock).as("Первый захват должен быть успешным").isPresent();
+        firstLock.get().unlock();
+
+        // После unlock с lockAtLeastFor=1ms лок должен немедленно освободиться.
+        // Небольшая пауза для гарантии применения изменения в БД.
+        try {
+            Thread.sleep(50);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        LockConfiguration config2 = new LockConfiguration(
+                Instant.now(),
+                lockName,
+                Duration.ofSeconds(30),
+                Duration.ofMillis(1)
+        );
+        Optional<SimpleLock> secondLock = lockProvider.lock(config2);
+
+        // assert
+        assertThat(secondLock).as("После unlock второй захват должен быть успешным").isPresent();
+        secondLock.get().unlock();
+    }
+}


### PR DESCRIPTION
Closes #279

Фаза 1 эпика #277. Релиз-критично: пререквизит безопасного scale-out (#272). Без распределённого лока каждый инстанс запускал бы свои `@Scheduled` и слал бы дубли напоминаний живым юзерам.

## Что сделано
- Зависимости `shedlock-spring` + `shedlock-provider-jdbc-template` (5.16.0, совместимо со Spring 6 / Boot 3.5.x). Намеренно **JDBC поверх Postgres, а не Redis** — путь напоминаний не должен зависеть от Redis.
- `ShedLockConfig`: `JdbcTemplateLockProvider` с `usingDbTime()` (защита от расхождения часов между инстансами).
- `@EnableSchedulerLock(defaultLockAtMostFor=PT1M)` на приложении.
- `@SchedulerLock` на всех `@Scheduled` с внешними эффектами: `NotificationSchedulerService`, `AcclimationSchedulerService`, `PhotoProgressSchedulerService`, `TransplantSuggestionScheduler`, `AuthTokenCleanupScheduler`, плюс `MonthlyReportScheduler`, `PlantAnniversaryScheduler`, `VacationSchedulerService`. `lockAtMostFor`/`lockAtLeastFor` подобраны по периодам (минутные / часовые / суточные).
- Деградация **fail-closed**: лок не взят → тик пропускается (безопаснее дубля). При 1 инстансе поведение не меняется.

## Миграции
`V46__create_shedlock.sql` — таблица `shedlock` (схема по документации ShedLock 5.x). Forward-only, идемпотентного бэкфила не требует.

## Backward-compat риски
Safe. Чистый DDL новой таблицы; на существующие данные не влияет. При single-instance логика не меняется (лок всегда берётся).

## Тесты
- `ShedLockDistributedLockIT` (`src/test/java/com/plantcare/core/shedlock/`): два «инстанса» (два потока) конкурируют за один лок — задача выполняется **ровно один раз** (AC). Использует настоящий JDBC-провайдер (`@Qualifier("lockProvider")`), а не тестовую подмену.
- В тестовом профиле `LockProvider` подменён на «всегда даёт лок» (`NoOpShedLockTestConfig`, импортируется в `IntegrationTestBase`). Причина: реальный лок с `lockAtLeastFor` в десятки минут переживает между тест-методами в переиспользуемом Testcontainer и блокировал бы прямые вызовы `@SchedulerLock`-методов в существующих тестах шедулеров. На прод-поведение не влияет.

## Чек
- [x] `./mvnw verify` зелёный для всего, что касается этой задачи (все scheduler-тесты + `ShedLockDistributedLockIT` проходят, миграция применяется).
- [ ] Известные пред-существующие падения, **не относящиеся к #279**: `PlantScheduleServiceTest.should_compute_next_due_at_correctly_for_non_utc_timezone` и `PlantServiceTest.markCareDone_writesHistoryAndReschedules` — зависят от таймзоны хоста сборки (локальный хост в UTC+03:00). Подтверждено: оба падают и на чистом `develop` без этих изменений; на CI (UTC) они зелёные.
