### PR TITLE
feat: Redis infrastructure (Lettuce + Railway + Testcontainers) (#278)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,26 @@ services:
     ports:
       - "${APP_PORT:-8080}:8080"
 
+  redis:
+    # Issue #278, эпик #277 фаза 0: Redis для локальной разработки.
+    # Запускать через профиль "redis":
+    #   docker compose --profile redis up -d
+    # или вместе с Postgres:
+    #   docker compose --profile redis up -d postgres redis
+    # На Railway Redis поднят отдельным сервисом; здесь — только для dev/локалки.
+    profiles: ["redis"]
+    image: redis:7-alpine
+    container_name: plants-care-redis
+    restart: unless-stopped
+    command: redis-server --save "" --appendonly no
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   prometheus:
     # Локальный Prometheus, скрейпит /actuator/prometheus приложения.
     # Запускать через профиль monitoring:
@@ -97,3 +117,4 @@ volumes:
   postgres_data:
   prometheus_data:
   grafana_data:
+  redis_data:

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,15 @@
             <version>${shedlock.version}</version>
         </dependency>
 
+        <!-- Issue #278, эпик #277 фаза 0: Redis (Lettuce). Пререквизит для rate-limit (#277b),
+             cache (#277c) и токен-хранилища (#277d). Намеренно Lettuce (по умолчанию
+             в spring-boot-starter-data-redis): неблокирующий клиент, thread-safe
+             shared connection, хорошо работает с виртуальными потоками Java 21. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+
         <!-- Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -238,6 +247,7 @@
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
+
 
         <!-- Issue #127: ArchUnit — фитнес-функция границ модульного монолита. -->
         <dependency>

--- a/src/main/java/com/plantcare/bot/config/RedisConfig.java
+++ b/src/main/java/com/plantcare/bot/config/RedisConfig.java
@@ -1,0 +1,119 @@
+package com.plantcare.bot.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.SocketOptions;
+import io.lettuce.core.TimeoutOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.data.redis.LettuceClientConfigurationBuilderCustomizer;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * Issue #278, эпик #277 фаза 0: конфигурация Redis (Lettuce).
+ *
+ * <p>Подключение настраивается через {@code spring.data.redis.url} (из env {@code REDIS_URL})
+ * или через отдельные host/port-параметры для локального dev-профиля.
+ *
+ * <p>Принципы:
+ * <ul>
+ *   <li>Lettuce — неблокирующий клиент; shared connection thread-safe.</li>
+ *   <li>Сериализация значений через {@link GenericJackson2JsonRedisSerializer} с type info.</li>
+ *   <li>Ключи — строки с префиксом {@code pc:} (задаётся в {@link RedisProperties#keyPrefix()}).</li>
+ *   <li>Таймауты подключения/команды настраиваются из {@link RedisProperties}.</li>
+ *   <li>Redis НЕ является жёстким пререквизитом для старта (graceful degradation).</li>
+ * </ul>
+ */
+@Slf4j
+@Configuration
+@EnableConfigurationProperties(RedisProperties.class)
+public class RedisConfig {
+
+    /**
+     * Настраивает Lettuce-клиент: таймауты подключения и команд.
+     *
+     * <p>Короткие таймауты (connect: 2 s, command: 1 s) обеспечивают быстрый fail-fast
+     * при недоступном Redis — приложение не зависает на старте, деградирует по фазам.
+     */
+    @Bean
+    public LettuceClientConfigurationBuilderCustomizer lettuceClientConfigurationCustomizer(
+            RedisProperties redisProperties) {
+
+        return builder -> builder.clientOptions(
+                ClientOptions.builder()
+                        .socketOptions(SocketOptions.builder()
+                                .connectTimeout(redisProperties.connectTimeout())
+                                .build())
+                        .timeoutOptions(TimeoutOptions.enabled(redisProperties.commandTimeout()))
+                        .disconnectedBehavior(ClientOptions.DisconnectedBehavior.REJECT_COMMANDS)
+                        .autoReconnect(true)
+                        .build()
+        );
+    }
+
+    /**
+     * Настраивает {@link ObjectMapper} для Redis-сериализации с поддержкой type info.
+     *
+     * <p>Type info необходима для корректной десериализации полиморфных типов при
+     * восстановлении данных из Redis (иначе Jackson не знает в какой класс маппить).
+     */
+    @Bean("redisObjectMapper")
+    public ObjectMapper redisObjectMapper() {
+        var mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        // Включаем type info: без этого GenericJackson2JsonRedisSerializer
+        // не сможет корректно десериализовать значения обратно в конкретный тип.
+        mapper.activateDefaultTyping(
+                mapper.getPolymorphicTypeValidator(),
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
+        return mapper;
+    }
+
+    /**
+     * Основной {@link RedisTemplate} для работы с Redis.
+     *
+     * <ul>
+     *   <li>Ключи: строки (UTF-8).</li>
+     *   <li>Значения: JSON с type info через {@link GenericJackson2JsonRedisSerializer}.</li>
+     *   <li>Hash-ключи и hash-значения — аналогично.</li>
+     * </ul>
+     *
+     * <p>Namespacing ключей (префикс {@code pc:}) реализуется на уровне сервисов-потребителей
+     * через {@link RedisProperties#keyPrefix()}, а не на уровне шаблона,
+     * чтобы не ломать Spring Data Redis {@code @Cacheable} и прочие механизмы.
+     */
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(
+            RedisConnectionFactory connectionFactory,
+            ObjectMapper redisObjectMapper) {
+
+        var template = new RedisTemplate<String, Object>();
+        template.setConnectionFactory(connectionFactory);
+
+        var stringSerializer = new StringRedisSerializer();
+        var jsonSerializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper);
+
+        template.setKeySerializer(stringSerializer);
+        template.setHashKeySerializer(stringSerializer);
+        template.setValueSerializer(jsonSerializer);
+        template.setHashValueSerializer(jsonSerializer);
+        template.setDefaultSerializer(jsonSerializer);
+        template.afterPropertiesSet();
+
+        log.info("RedisTemplate initialized with GenericJackson2JsonRedisSerializer");
+        return template;
+    }
+}

--- a/src/main/java/com/plantcare/bot/config/RedisProperties.java
+++ b/src/main/java/com/plantcare/bot/config/RedisProperties.java
@@ -1,0 +1,47 @@
+package com.plantcare.bot.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+/**
+ * Issue #278, эпик #277 фаза 0: настройки подключения к Redis.
+ *
+ * <p>Все чувствительные значения берутся из env-переменных (Railway reference variables).
+ * В репо хранятся только безопасные дефолты для локального запуска.
+ *
+ * <p>Railway-переменные:
+ * <ul>
+ *   <li>{@code REDIS_URL} — полный URL в формате {@code redis://[:password@]host:port[/db]}
+ *       или {@code rediss://...} (TLS), инжектится как reference variable из Redis-сервиса.
+ *       Внутренняя сеть Railway: хост заканчивается на {@code .railway.internal}.</li>
+ * </ul>
+ */
+@ConfigurationProperties(prefix = "app.redis")
+public record RedisProperties(
+
+        /**
+         * Таймаут подключения к Redis. По умолчанию 2 секунды.
+         * Короткий таймаут = быстрый фейл при недоступном Redis, без зависания приложения.
+         */
+        Duration connectTimeout,
+
+        /**
+         * Таймаут команды Redis (read timeout). По умолчанию 1 секунда.
+         */
+        Duration commandTimeout,
+
+        /**
+         * Префикс для всех ключей приложения. Обеспечивает namespacing при shared Redis.
+         * Дефолт: {@code pc:}
+         */
+        String keyPrefix
+
+) {
+
+    public RedisProperties {
+        if (connectTimeout == null) connectTimeout = Duration.ofSeconds(2);
+        if (commandTimeout == null) commandTimeout = Duration.ofSeconds(1);
+        if (keyPrefix == null || keyPrefix.isBlank()) keyPrefix = "pc:";
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,9 +48,27 @@ spring:
           starttls:
             enable: ${MAIL_SMTP_STARTTLS:false}
 
+  # Issue #278, эпик #277 фаза 0: Redis (Lettuce).
+  # На Railway REDIS_URL инжектится как reference variable из Redis-сервиса.
+  # Внутренняя сеть Railway: app ↔ Redis по приватному хосту *.railway.internal.
+  # Пустой дефолт: при отсутствии REDIS_URL Spring Boot использует host/port ниже.
+  data:
+    redis:
+      url: ${REDIS_URL:}
+      # Ниже — ручные параметры для случаев, когда REDIS_URL не задан (dev-локалка).
+      # При наличии url эти значения игнорируются.
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
 app:
   species:
     search-limit: 5
+
+  # Issue #278, эпик #277 фаза 0: параметры Lettuce-клиента и namespacing ключей.
+  redis:
+    connect-timeout: ${REDIS_CONNECT_TIMEOUT:PT2S}
+    command-timeout: ${REDIS_COMMAND_TIMEOUT:PT1S}
+    key-prefix: ${REDIS_KEY_PREFIX:pc:}
 
   # Issue #79: публичная подписка на .ics календарь.
   calendar:
@@ -187,6 +205,13 @@ management:
     # Отправка magic-link писем не должна влиять на liveness/health приложения.
     mail:
       enabled: false
+    # Issue #278: Redis health-индикатор включён (появляется из starter-data-redis).
+    # readiness НЕ делаем жёстко зависимым от Redis — деградация по фазам.
+    # Spring Boot 3.x: redis HealthIndicator включается автоматически при наличии
+    # RedisConnectionFactory. Падение Redis = DOWN в /actuator/health, но приложение
+    # продолжает работать (планировщик на JDBC, Telegram — независимы от Redis).
+    redis:
+      enabled: true
   prometheus:
     metrics:
       export:

--- a/src/test/java/com/plantcare/bot/config/RedisConnectionIT.java
+++ b/src/test/java/com/plantcare/bot/config/RedisConnectionIT.java
@@ -1,0 +1,85 @@
+package com.plantcare.bot.config;
+
+import com.plantcare.bot.support.IntegrationTestBase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.actuate.redis.RedisHealthIndicator;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #278, эпик #277 фаза 0: интеграционный тест Redis-инфраструктуры.
+ *
+ * <p>Проверяет:
+ * <ul>
+ *   <li>RedisConnectionFactory доступна и создаётся корректно.</li>
+ *   <li>RedisTemplate инжектируется и выполняет базовые команды (ping).</li>
+ *   <li>RedisHealthIndicator возвращает UP при доступном Redis.</li>
+ *   <li>Namespacing ключей (префикс {@code pc:}) через RedisProperties.</li>
+ * </ul>
+ *
+ * <p>Redis в тестах поднимается через Testcontainers (GenericContainer redis:7-alpine),
+ * конфигурируется в {@link IntegrationTestBase}.
+ */
+class RedisConnectionIT extends IntegrationTestBase {
+
+    @Autowired
+    private RedisConnectionFactory redisConnectionFactory;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired
+    private RedisProperties redisProperties;
+
+    @Test
+    void should_connect_to_redis_when_container_is_running() {
+        // act
+        var connection = redisConnectionFactory.getConnection();
+
+        // assert
+        assertThat(connection).isNotNull();
+        assertThat(connection.ping()).isEqualTo("PONG");
+
+        connection.close();
+    }
+
+    @Test
+    void should_write_and_read_value_when_redis_is_available() {
+        var key = redisProperties.keyPrefix() + "test:redis-connection-it";
+        var value = "hello-redis-278";
+
+        // act
+        redisTemplate.opsForValue().set(key, value);
+        var result = redisTemplate.opsForValue().get(key);
+
+        // assert
+        assertThat(result).isEqualTo(value);
+
+        // cleanup
+        redisTemplate.delete(key);
+    }
+
+    @Test
+    void should_have_pc_key_prefix_by_default() {
+        // assert
+        assertThat(redisProperties.keyPrefix()).isEqualTo("pc:");
+    }
+
+    @Test
+    void should_return_up_status_in_health_indicator_when_redis_is_reachable() {
+        // arrange
+        var healthIndicator = new RedisHealthIndicator(redisConnectionFactory);
+
+        // act
+        Health health = healthIndicator.health();
+
+        // assert
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsKey("version");
+    }
+}

--- a/src/test/java/com/plantcare/bot/support/IntegrationTestBase.java
+++ b/src/test/java/com/plantcare/bot/support/IntegrationTestBase.java
@@ -5,20 +5,24 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * Базовый класс для интеграционных тестов.
  *
- * Поднимает один экземпляр PostgreSQL на всю тестовую сессию (через статический
- * контейнер с .withReuse(true)), что в разы быстрее, чем стартовать новый
- * контейнер для каждого тестового класса.
+ * Поднимает один экземпляр PostgreSQL и один Redis на всю тестовую сессию
+ * (через статические контейнеры с .withReuse(true)), что в разы быстрее, чем
+ * стартовать новые контейнеры для каждого тестового класса.
  *
- * Для повторного использования контейнера между запусками нужно создать файл
+ * Для повторного использования контейнеров между запусками нужно создать файл
  * ~/.testcontainers.properties со строкой:
  *   testcontainers.reuse.enable=true
  * Без этого .withReuse игнорируется (это сознательный opt-in от Testcontainers).
+ *
+ * Issue #278, эпик #277 фаза 0: Redis Testcontainers — база для фаз 2–4.
  */
 @SpringBootTest
 @ActiveProfiles("test")
@@ -33,14 +37,34 @@ public abstract class IntegrationTestBase {
                     .withPassword("test")
                     .withReuse(true);
 
+    /**
+     * Redis 7 через GenericContainer (Testcontainers не имеет отдельного RedisContainer
+     * в официальном модуле — используем GenericContainer с образом redis:7-alpine).
+     * Порт 6379 проксируется на случайный хостовый, конфигурируется через DynamicPropertySource.
+     */
+    @SuppressWarnings("resource")
+    protected static final GenericContainer<?> REDIS =
+            new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+                    .withExposedPorts(6379)
+                    .withReuse(true);
+
     static {
         POSTGRES.start();
+        REDIS.start();
     }
 
     @DynamicPropertySource
-    static void configureDataSource(DynamicPropertyRegistry registry) {
+    static void configureInfrastructure(DynamicPropertyRegistry registry) {
+        // PostgreSQL
         registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
         registry.add("spring.datasource.username", POSTGRES::getUsername);
         registry.add("spring.datasource.password", POSTGRES::getPassword);
+
+        // Redis: подключаем через host/port (не url), чтобы не конфликтовать
+        // с REDIS_URL env-переменной Railway (она пустая в тестах).
+        registry.add("spring.data.redis.host", REDIS::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379).toString());
+        // Явно сбрасываем url, чтобы host/port взяли приоритет
+        registry.add("spring.data.redis.url", () -> "");
     }
 }


### PR DESCRIPTION
Closes #278

## Что сделано
- Добавлена зависимость `spring-boot-starter-data-redis` (Lettuce) — обоснование: пререквизит фаз 2–4 эпика #277
- Подключение через Railway reference variable `REDIS_URL` → `spring.data.redis.url`; для dev/локалки — отдельные `REDIS_HOST`/`REDIS_PORT` (дефолт localhost:6379)
- `RedisProperties` (`app.redis.*`): `connect-timeout` (2s), `command-timeout` (1s), `key-prefix` (`pc:`)
- `RedisConfig`: `LettuceClientConfigurationBuilderCustomizer` с таймаутами + авто-реконнект; `RedisTemplate<String, Object>` с `GenericJackson2JsonRedisSerializer` (type info) + `StringRedisSerializer` для ключей
- Redis health-индикатор включён в `/actuator/health` (не влияет на старт — Lettuce ленивое соединение)
- `docker-compose.yml`: сервис `redis` (redis:7-alpine) под профилем `redis` для локальной разработки
- `IntegrationTestBase`: добавлен `REDIS` контейнер (`GenericContainer redis:7-alpine`) с `DynamicPropertySource`
- `RedisConnectionIT`: IT-тесты на подключение, PING, write/read, prefixed ключи, `RedisHealthIndicator.UP`

## Миграции
нет

## Backward-compat риски
safe — инфраструктурная добавка, не меняет существующую функциональность

## Env-переменные Railway

| Переменная | Откуда | Назначение |
|---|---|---|
| `REDIS_URL` | Reference variable из Redis-сервиса Railway | Полный URL (`redis://host:port`) — внутренняя сеть Railway (`*.railway.internal`) |
| `REDIS_HOST` | Опционально (для docker-compose) | Хост Redis (дефолт: `localhost`) |
| `REDIS_PORT` | Опционально (для docker-compose) | Порт Redis (дефолт: `6379`) |

### Как поднять локально
```bash
docker compose --profile redis up -d          # поднять Redis
# приложение подключится к localhost:6379 по умолчанию
```

## Тесты
`RedisConnectionIT` покрывает:
- Подключение и PING
- Write/read через `RedisTemplate`
- Дефолтный ключ-префикс `pc:`
- `RedisHealthIndicator` возвращает `UP` при живом Redis

## Чек
- [x] Код скомпилирован и проверен локально
- [x] `IntegrationTestBase` расширен Redis-контейнером (Testcontainers)
- [x] Нет секретов в репо (только env-плейсхолдеры)
- [x] Health-индикатор Redis включён, readiness НЕ жёстко зависит от Redis
- [x] reviewer прошёл (принято как инфраструктурный PR без блокеров)
