### PR TITLE
feat: REST API управление комнатами (rooms CRUD) (#283)

### DIFF
--- a/src/main/java/com/plantcare/api/ApiExceptionHandler.java
+++ b/src/main/java/com/plantcare/api/ApiExceptionHandler.java
@@ -121,6 +121,12 @@ public class ApiExceptionHandler {
                 .body(ApiErrorResponse.of("LOCATION_NOT_EMPTY", e.getMessage()));
     }
 
+    @ExceptionHandler(RoomNotEmptyException.class)
+    public ResponseEntity<ApiErrorResponse> handleRoomNotEmpty(RoomNotEmptyException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiErrorResponse.of("ROOM_NOT_EMPTY", e.getMessage()));
+    }
+
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<ApiErrorResponse> handleConflict(IllegalStateException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT)

--- a/src/main/java/com/plantcare/api/RoomNotEmptyException.java
+++ b/src/main/java/com/plantcare/api/RoomNotEmptyException.java
@@ -1,0 +1,19 @@
+package com.plantcare.api;
+
+/**
+ * Бросается когда пользователь пытается удалить комнату,
+ * в которой есть активные растения. Маппится {@link ApiExceptionHandler}
+ * в 409 с {@code code=ROOM_NOT_EMPTY}.
+ */
+public class RoomNotEmptyException extends RuntimeException {
+
+    public RoomNotEmptyException(String message) {
+        super(message);
+    }
+
+    public static RoomNotEmptyException forRoom(Long roomId, long plantCount) {
+        return new RoomNotEmptyException(
+                "Комната содержит " + plantCount + " активных растений. Перенесите их перед удалением."
+        );
+    }
+}

--- a/src/main/java/com/plantcare/api/v1/RoomController.java
+++ b/src/main/java/com/plantcare/api/v1/RoomController.java
@@ -1,0 +1,78 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.api.RoomNotEmptyException;
+import com.plantcare.api.generated.RoomsApi;
+import com.plantcare.api.generated.model.RoomCreateRequest;
+import com.plantcare.api.generated.model.RoomDto;
+import com.plantcare.api.generated.model.RoomUpdateRequest;
+import com.plantcare.core.domain.Room;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.service.RoomService;
+import com.plantcare.core.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.ZoneOffset;
+import java.util.List;
+
+/**
+ * REST API для управления комнатами внутри локации (issue #283).
+ *
+ * <p>Документация и маппинг живут в сгенерированном {@link RoomsApi}
+ * (см. openapi/resources/rooms.yaml).
+ */
+@RestController
+@RequiredArgsConstructor
+public class RoomController implements RoomsApi {
+
+    private final RoomService roomService;
+    private final UserService userService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    public List<RoomDto> listRooms(Long locationId) {
+        Long userId = currentUserProvider.currentUserId();
+        return roomService.getRoomsInLocation(userId, locationId)
+                .stream()
+                .map(RoomController::toDto)
+                .toList();
+    }
+
+    @Override
+    public RoomDto createRoom(Long locationId, RoomCreateRequest request) {
+        User user = userService.getByIdOrThrow(currentUserProvider.currentUserId());
+        Room room = roomService.createRoom(user, locationId, request.getName(), request.getDisplayOrder());
+        return toDto(room);
+    }
+
+    @Override
+    public RoomDto updateRoom(Long id, RoomUpdateRequest request) {
+        Long userId = currentUserProvider.currentUserId();
+        Room room = roomService.updateRoom(userId, id, request.getName(), request.getDisplayOrder());
+        return toDto(room);
+    }
+
+    @Override
+    public void deleteRoom(Long id) {
+        Long userId = currentUserProvider.currentUserId();
+        try {
+            roomService.deleteRoom(userId, id);
+        } catch (IllegalStateException e) {
+            throw new RoomNotEmptyException(e.getMessage());
+        }
+    }
+
+    private static RoomDto toDto(Room room) {
+        Long locationId = room.getLocation() != null ? room.getLocation().getId() : null;
+        RoomDto dto = new RoomDto()
+                .id(room.getId())
+                .name(room.getName())
+                .locationId(locationId)
+                .displayOrder(room.getDisplayOrder());
+        if (room.getCreatedAt() != null) {
+            dto.createdAt(room.getCreatedAt().atOffset(ZoneOffset.UTC));
+        }
+        return dto;
+    }
+}

--- a/src/main/java/com/plantcare/core/domain/Room.java
+++ b/src/main/java/com/plantcare/core/domain/Room.java
@@ -30,6 +30,15 @@ public class Room extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    /**
+     * Локация, к которой принадлежит комната (issue #283).
+     * NULL для старых записей Telegram-бота (до введения локаций).
+     * REST API комнат требует location_id при создании.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id")
+    private Location location;
+
     @Column(nullable = false, length = 100)
     private String name;
 

--- a/src/main/java/com/plantcare/core/repository/PlantRepository.java
+++ b/src/main/java/com/plantcare/core/repository/PlantRepository.java
@@ -86,6 +86,9 @@ public interface PlantRepository extends JpaRepository<Plant, Long> {
 
     long countByUserIdAndLocationIdAndArchivedAtIsNull(Long userId, Long locationId);
 
+    /** Сколько активных растений привязано к данной комнате (issue #283). */
+    long countByRoomIdAndArchivedAtIsNull(Long roomId);
+
     // ===== Архив (issue #117) =====
 
     /** Количество архивированных растений юзера — счётчик у кнопки «📦 Архив (N)». */

--- a/src/main/java/com/plantcare/core/repository/RoomRepository.java
+++ b/src/main/java/com/plantcare/core/repository/RoomRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RoomRepository extends JpaRepository<Room, Long> {
@@ -12,4 +13,18 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
     List<Room> findAllByUserIdOrderByDisplayOrderAscNameAsc(Long userId);
 
     boolean existsByUserIdAndName(Long userId, String name);
+
+    // ---- REST API rooms-in-location (issue #283) ----
+
+    List<Room> findAllByUserIdAndLocationIdOrderByDisplayOrderAscNameAsc(Long userId, Long locationId);
+
+    Optional<Room> findByIdAndUserId(Long id, Long userId);
+
+    boolean existsByUserIdAndLocationIdAndNameIgnoreCase(Long userId, Long locationId, String name);
+
+    boolean existsByUserIdAndLocationIdAndNameIgnoreCaseAndIdNot(Long userId, Long locationId, String name, Long excludeId);
+
+    long countByUserIdAndLocationId(Long userId, Long locationId);
+
+    boolean existsByUserIdAndId(Long userId, Long id);
 }

--- a/src/main/java/com/plantcare/core/service/RoomService.java
+++ b/src/main/java/com/plantcare/core/service/RoomService.java
@@ -1,0 +1,141 @@
+package com.plantcare.core.service;
+
+import com.plantcare.core.domain.Location;
+import com.plantcare.core.domain.Room;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.repository.LocationRepository;
+import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.RoomRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Бизнес-логика CRUD комнат в рамках локации (issue #283).
+ * Комната принадлежит локации; при создании/обновлении проверяется,
+ * что локация принадлежит тому же пользователю.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RoomService {
+
+    private static final int MAX_ROOMS_PER_LOCATION = 50;
+
+    private final RoomRepository roomRepository;
+    private final LocationRepository locationRepository;
+    private final PlantRepository plantRepository;
+
+    @Transactional(readOnly = true)
+    public List<Room> getRoomsInLocation(Long userId, Long locationId) {
+        getLocationOrThrow(userId, locationId);
+        return roomRepository.findAllByUserIdAndLocationIdOrderByDisplayOrderAscNameAsc(userId, locationId);
+    }
+
+    @Transactional
+    public Room createRoom(User user, Long locationId, String name, Integer displayOrder) {
+        Location location = getLocationOrThrow(user.getId(), locationId);
+
+        String normalizedName = normalizeName(name);
+        validateName(normalizedName);
+
+        if (roomRepository.existsByUserIdAndLocationIdAndNameIgnoreCase(user.getId(), locationId, normalizedName)) {
+            throw new IllegalArgumentException("Комната с таким названием уже существует в этой локации");
+        }
+
+        long count = roomRepository.countByUserIdAndLocationId(user.getId(), locationId);
+        if (count >= MAX_ROOMS_PER_LOCATION) {
+            throw new IllegalArgumentException(
+                    "Превышен лимит комнат в локации (" + MAX_ROOMS_PER_LOCATION + ")");
+        }
+
+        Room room = Room.builder()
+                .user(user)
+                .location(location)
+                .name(normalizedName)
+                .displayOrder(displayOrder != null ? displayOrder : 0)
+                .build();
+
+        Room saved = roomRepository.save(room);
+        log.info("Created room {} '{}' in location {} for user {}", saved.getId(), saved.getName(), locationId, user.getId());
+        return saved;
+    }
+
+    @Transactional
+    public Room updateRoom(Long userId, Long roomId, String name, Integer displayOrder) {
+        Room room = getRoomOrThrow(userId, roomId);
+
+        if (name != null && !name.isBlank()) {
+            String normalizedName = normalizeName(name);
+            validateName(normalizedName);
+
+            Long locationId = room.getLocation() != null ? room.getLocation().getId() : null;
+            if (locationId != null) {
+                boolean duplicate = roomRepository.existsByUserIdAndLocationIdAndNameIgnoreCaseAndIdNot(
+                        userId, locationId, normalizedName, roomId);
+                if (duplicate) {
+                    throw new IllegalArgumentException("Комната с таким названием уже существует в этой локации");
+                }
+            }
+            room.setName(normalizedName);
+        }
+
+        if (displayOrder != null) {
+            room.setDisplayOrder(displayOrder);
+        }
+
+        Room saved = roomRepository.save(room);
+        log.info("Updated room {} for user {}", roomId, userId);
+        return saved;
+    }
+
+    /**
+     * Удалить комнату. Если в ней есть активные растения — бросает
+     * {@link IllegalStateException} с количеством растений.
+     * Контроллер преобразует это в 409 ROOM_NOT_EMPTY.
+     */
+    @Transactional
+    public void deleteRoom(Long userId, Long roomId) {
+        Room room = getRoomOrThrow(userId, roomId);
+
+        long plantCount = plantRepository.countByRoomIdAndArchivedAtIsNull(roomId);
+        if (plantCount > 0) {
+            throw new IllegalStateException(
+                    "Комната содержит " + plantCount + " активных растений. Перенесите их перед удалением."
+            );
+        }
+
+        roomRepository.delete(room);
+        log.info("Deleted room {} for user {}", roomId, userId);
+    }
+
+    @Transactional(readOnly = true)
+    public Room getRoomOrThrow(Long userId, Long roomId) {
+        return roomRepository.findByIdAndUserId(roomId, userId)
+                .orElseThrow(() -> new EntityNotFoundException("Room not found: " + roomId));
+    }
+
+    // ----------- private helpers -----------
+
+    private Location getLocationOrThrow(Long userId, Long locationId) {
+        return locationRepository.findByUserIdAndId(userId, locationId)
+                .orElseThrow(() -> new EntityNotFoundException("Location not found: " + locationId));
+    }
+
+    private String normalizeName(String name) {
+        return name == null ? "" : name.trim();
+    }
+
+    private void validateName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Название комнаты не может быть пустым");
+        }
+        if (name.length() > 100) {
+            throw new IllegalArgumentException("Название комнаты должно быть не длиннее 100 символов");
+        }
+    }
+}

--- a/src/main/resources/db/migration/V47__add_location_id_to_rooms.sql
+++ b/src/main/resources/db/migration/V47__add_location_id_to_rooms.sql
@@ -1,0 +1,49 @@
+-- =====================================================
+-- V47: Комнаты в локации (issue #283)
+--   Добавляем nullable location_id в rooms (FK -> locations)
+--   для привязки комнаты к конкретной локации пользователя.
+--   Nullable для backward-compat: существующие записи rooms (из Telegram-бота)
+--   не имеют локации — их location_id останется NULL пока не будет задан явно.
+-- =====================================================
+
+-- Добавляем колонку если её нет
+ALTER TABLE rooms
+    ADD COLUMN IF NOT EXISTS location_id BIGINT;
+
+-- Гарантируем nullable (на случай, если колонка уже была добавлена как NOT NULL
+-- в другом окружении или более ранней версии миграции)
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'rooms'
+          AND column_name = 'location_id'
+          AND is_nullable = 'NO'
+    ) THEN
+        ALTER TABLE rooms ALTER COLUMN location_id DROP NOT NULL;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'fk_rooms_location'
+          AND conrelid = 'rooms'::regclass
+    ) THEN
+        ALTER TABLE rooms
+            ADD CONSTRAINT fk_rooms_location
+                FOREIGN KEY (location_id)
+                    REFERENCES locations(id)
+                    ON DELETE SET NULL
+            NOT VALID;
+    END IF;
+END $$;
+
+COMMENT ON COLUMN rooms.location_id IS
+    'Локация, к которой принадлежит комната (issue #283). NULL = не привязана (старые записи Telegram-бота).';
+
+CREATE INDEX IF NOT EXISTS idx_rooms_location_id
+    ON rooms(location_id)
+    WHERE location_id IS NOT NULL;

--- a/src/main/resources/db/migration/V48__rooms_location_id_drop_not_null.sql
+++ b/src/main/resources/db/migration/V48__rooms_location_id_drop_not_null.sql
@@ -1,0 +1,18 @@
+-- =====================================================
+-- V48: Гарантируем nullable location_id в rooms (issue #283)
+--   Если V47 была применена в окружении, где location_id был создан
+--   как NOT NULL (ошибка в ранней версии), исправляем это.
+--   В чистых окружениях — no-op.
+-- =====================================================
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'rooms'
+          AND column_name = 'location_id'
+          AND is_nullable = 'NO'
+    ) THEN
+        ALTER TABLE rooms ALTER COLUMN location_id DROP NOT NULL;
+    END IF;
+END $$;

--- a/src/main/resources/openapi/_common/parameters.yaml
+++ b/src/main/resources/openapi/_common/parameters.yaml
@@ -21,3 +21,13 @@ LocationIdPath:
     type: integer
     format: int64
     example: 1
+
+RoomIdPath:
+  name: id
+  in: path
+  required: true
+  description: Идентификатор комнаты.
+  schema:
+    type: integer
+    format: int64
+    example: 1

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -70,6 +70,11 @@ tags:
     description: |
       Локации (комнаты/места) пользователя, в которых стоят растения. Каждый
       пользователь имеет «дефолтную» локацию, создаваемую автоматически.
+  - name: Rooms
+    description: |
+      CRUD комнат внутри локации (issue #283). Комната принадлежит локации;
+      GET/POST идут через /locations/{locationId}/rooms,
+      PATCH/DELETE — через /rooms/{id}.
   - name: Care Events
     description: |
       Регистрация выполнения ухода (полив, опрыскивание, удобрение) и его отмена.
@@ -271,6 +276,11 @@ paths:
   /api/v1/sharing/invites:
     $ref: './resources/sharing.yaml#/paths/Invites'
 
+  /api/v1/locations/{locationId}/rooms:
+    $ref: './resources/rooms.yaml#/paths/CollectionByLocation'
+  /api/v1/rooms/{id}:
+    $ref: './resources/rooms.yaml#/paths/Item'
+
   /api/v1/locations/{id}/invites:
     $ref: './resources/location-sharing.yaml#/paths/CreateInvite'
   /api/v1/locations/{id}/members:
@@ -308,6 +318,8 @@ components:
       $ref: './_common/parameters.yaml#/PlantIdPath'
     LocationIdPath:
       $ref: './_common/parameters.yaml#/LocationIdPath'
+    RoomIdPath:
+      $ref: './_common/parameters.yaml#/RoomIdPath'
 
   responses:
     BadRequest:
@@ -397,6 +409,13 @@ components:
       $ref: './resources/locations.yaml#/schemas/LocationUpdateRequest'
     LocationPauseRequest:
       $ref: './resources/locations.yaml#/schemas/LocationPauseRequest'
+
+    RoomDto:
+      $ref: './resources/rooms.yaml#/schemas/RoomDto'
+    RoomCreateRequest:
+      $ref: './resources/rooms.yaml#/schemas/RoomCreateRequest'
+    RoomUpdateRequest:
+      $ref: './resources/rooms.yaml#/schemas/RoomUpdateRequest'
 
     CareEventType:
       $ref: './resources/care-events.yaml#/schemas/CareEventType'

--- a/src/main/resources/openapi/resources/rooms.yaml
+++ b/src/main/resources/openapi/resources/rooms.yaml
@@ -1,0 +1,204 @@
+# CRUD комнат внутри локации (issue #283).
+# Комната принадлежит локации: GET/POST идут через /locations/{locationId}/rooms,
+# PATCH/DELETE — через /rooms/{id} (roomId глобально уникален).
+
+paths:
+  CollectionByLocation:
+    get:
+      tags: [Rooms]
+      operationId: listRooms
+      summary: Список комнат локации
+      description: |
+        Возвращает все комнаты локации, принадлежащей текущему пользователю.
+        Отсортированы по display_order, затем по имени.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: locationId
+          in: path
+          required: true
+          description: Идентификатор локации.
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: Список комнат.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/schemas/RoomDto'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+    post:
+      tags: [Rooms]
+      operationId: createRoom
+      summary: Создать комнату в локации
+      description: |
+        Создаёт комнату в указанной локации. Имя уникально в рамках локации
+        (без учёта регистра) — при коллизии 400.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: locationId
+          in: path
+          required: true
+          description: Идентификатор локации.
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/RoomCreateRequest'
+            example:
+              name: Подоконник у окна
+              displayOrder: 0
+      responses:
+        '201':
+          description: Комната создана.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/RoomDto'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+  Item:
+    patch:
+      tags: [Rooms]
+      operationId: updateRoom
+      summary: Обновить комнату
+      description: PATCH-семантика — обновляются только переданные поля.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Идентификатор комнаты.
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/RoomUpdateRequest'
+      responses:
+        '200':
+          description: Комната обновлена.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/RoomDto'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+    delete:
+      tags: [Rooms]
+      operationId: deleteRoom
+      summary: Удалить комнату
+      description: |
+        Удаляет комнату. Если в комнате есть активные растения —
+        возвращает 409 с `code=ROOM_NOT_EMPTY`. Перенесите растения
+        в другую комнату или обнулите привязку перед удалением.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Идентификатор комнаты.
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '204':
+          description: Комната удалена.
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+        '409':
+          description: |
+            В комнате есть активные растения. `code=ROOM_NOT_EMPTY`.
+          content:
+            application/json:
+              schema:
+                $ref: '../_common/errors.yaml#/schemas/ApiErrorResponse'
+              examples:
+                notEmpty:
+                  summary: Комната содержит растения
+                  value:
+                    error:
+                      code: ROOM_NOT_EMPTY
+                      message: "Комната содержит активные растения. Перенесите их перед удалением."
+
+schemas:
+  RoomDto:
+    type: object
+    description: Комната внутри локации пользователя.
+    required: [id, name, locationId, displayOrder]
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+        maxLength: 100
+        example: Подоконник у окна
+      locationId:
+        type: integer
+        format: int64
+        description: ID локации, к которой принадлежит комната.
+      displayOrder:
+        type: integer
+        description: Порядок отображения (по возрастанию).
+        example: 0
+      createdAt:
+        type: string
+        format: date-time
+        nullable: true
+
+  RoomCreateRequest:
+    type: object
+    required: [name]
+    properties:
+      name:
+        type: string
+        minLength: 1
+        maxLength: 100
+        example: Подоконник у окна
+      displayOrder:
+        type: integer
+        minimum: 0
+        nullable: true
+        description: Порядок отображения (по умолчанию 0).
+        example: 0
+
+  RoomUpdateRequest:
+    type: object
+    description: Все поля опциональны.
+    properties:
+      name:
+        type: string
+        minLength: 1
+        maxLength: 100
+        nullable: true
+      displayOrder:
+        type: integer
+        minimum: 0
+        nullable: true

--- a/src/test/java/com/plantcare/api/v1/RoomControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/RoomControllerTest.java
@@ -1,0 +1,335 @@
+package com.plantcare.api.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.api.RoomNotEmptyException;
+import com.plantcare.core.domain.Location;
+import com.plantcare.core.domain.Room;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.service.RoomService;
+import com.plantcare.core.service.UserService;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @WebMvcTest for {@link RoomController} — covers list, create, update (PATCH),
+ * delete, validation, 404/409 error paths (issue #283).
+ */
+@WebMvcTest(RoomController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class RoomControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private RoomService roomService;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    private User currentUser;
+
+    @BeforeEach
+    void stubCurrentUser() {
+        currentUser = mock(User.class);
+        when(currentUser.getId()).thenReturn(1L);
+
+        when(currentUserProvider.currentUserId()).thenReturn(1L);
+        when(currentUserProvider.currentUser()).thenReturn(currentUser);
+        when(userService.getByIdOrThrow(1L)).thenReturn(currentUser);
+    }
+
+    // ---------- helpers ----------
+
+    private Room mockRoom(long id, long locationId, String name) {
+        Location location = mock(Location.class);
+        when(location.getId()).thenReturn(locationId);
+
+        Room room = mock(Room.class);
+        when(room.getId()).thenReturn(id);
+        when(room.getName()).thenReturn(name);
+        when(room.getLocation()).thenReturn(location);
+        when(room.getDisplayOrder()).thenReturn(0);
+        when(room.getCreatedAt()).thenReturn(null);
+        return room;
+    }
+
+    // ---------- GET /api/v1/locations/{locationId}/rooms ----------
+
+    @Test
+    void should_return_rooms_list_when_location_exists() throws Exception {
+        // arrange
+        Room r1 = mockRoom(1L, 10L, "Подоконник");
+        Room r2 = mockRoom(2L, 10L, "Угол");
+
+        when(roomService.getRoomsInLocation(1L, 10L)).thenReturn(List.of(r1, r2));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/locations/10/rooms"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].name").value("Подоконник"))
+                .andExpect(jsonPath("$[1].name").value("Угол"));
+    }
+
+    @Test
+    void should_return_empty_list_when_no_rooms_in_location() throws Exception {
+        // arrange
+        when(roomService.getRoomsInLocation(1L, 10L)).thenReturn(List.of());
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/locations/10/rooms"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void should_return_404_when_location_not_found_on_list() throws Exception {
+        // arrange
+        when(roomService.getRoomsInLocation(1L, 99L))
+                .thenThrow(new EntityNotFoundException("Location not found: 99"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/locations/99/rooms"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // ---------- POST /api/v1/locations/{locationId}/rooms ----------
+
+    @Test
+    void should_create_room_and_return_201() throws Exception {
+        // arrange
+        Room created = mockRoom(5L, 10L, "Кухня");
+
+        when(roomService.createRoom(eq(currentUser), eq(10L), eq("Кухня"), isNull()))
+                .thenReturn(created);
+
+        String body = """
+                {"name": "Кухня"}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/locations/10/rooms")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(5))
+                .andExpect(jsonPath("$.name").value("Кухня"))
+                .andExpect(jsonPath("$.locationId").value(10));
+    }
+
+    @Test
+    void should_create_room_with_display_order() throws Exception {
+        // arrange
+        Room created = mockRoom(6L, 10L, "Спальня");
+
+        when(roomService.createRoom(eq(currentUser), eq(10L), eq("Спальня"), eq(2)))
+                .thenReturn(created);
+
+        String body = """
+                {"name": "Спальня", "displayOrder": 2}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/locations/10/rooms")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(6));
+    }
+
+    @Test
+    void should_return_400_when_room_name_blank_on_create() throws Exception {
+        // arrange
+        String body = """
+                {"name": ""}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/locations/10/rooms")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void should_return_400_when_room_name_missing_on_create() throws Exception {
+        // arrange
+        String body = "{}";
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/locations/10/rooms")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void should_return_400_when_name_duplicate_on_create() throws Exception {
+        // arrange
+        when(roomService.createRoom(any(), any(), any(), any()))
+                .thenThrow(new IllegalArgumentException("Комната с таким названием уже существует в этой локации"));
+
+        String body = """
+                {"name": "Кухня"}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/locations/10/rooms")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("BAD_REQUEST"));
+    }
+
+    @Test
+    void should_return_404_when_location_not_found_on_create() throws Exception {
+        // arrange
+        when(roomService.createRoom(any(), any(), any(), any()))
+                .thenThrow(new EntityNotFoundException("Location not found: 99"));
+
+        String body = """
+                {"name": "Кухня"}
+                """;
+
+        // act + assert
+        mockMvc.perform(post("/api/v1/locations/99/rooms")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // ---------- PATCH /api/v1/rooms/{id} ----------
+
+    @Test
+    void should_update_room_name_via_patch() throws Exception {
+        // arrange
+        Room updated = mockRoom(1L, 10L, "Новое название");
+
+        when(roomService.updateRoom(eq(1L), eq(1L), eq("Новое название"), isNull()))
+                .thenReturn(updated);
+
+        String body = """
+                {"name": "Новое название"}
+                """;
+
+        // act + assert
+        mockMvc.perform(patch("/api/v1/rooms/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Новое название"));
+    }
+
+    @Test
+    void should_update_display_order_via_patch() throws Exception {
+        // arrange
+        Room updated = mockRoom(1L, 10L, "Кухня");
+
+        when(roomService.updateRoom(eq(1L), eq(1L), isNull(), eq(5)))
+                .thenReturn(updated);
+
+        String body = """
+                {"displayOrder": 5}
+                """;
+
+        // act + assert
+        mockMvc.perform(patch("/api/v1/rooms/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void should_return_404_when_room_not_found_on_update() throws Exception {
+        // arrange
+        when(roomService.updateRoom(eq(1L), eq(99L), any(), any()))
+                .thenThrow(new EntityNotFoundException("Room not found: 99"));
+
+        String body = """
+                {"name": "Новое название"}
+                """;
+
+        // act + assert
+        mockMvc.perform(patch("/api/v1/rooms/99")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // ---------- DELETE /api/v1/rooms/{id} ----------
+
+    @Test
+    void should_delete_empty_room_and_return_204() throws Exception {
+        // arrange
+        doNothing().when(roomService).deleteRoom(1L, 1L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/rooms/1"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void should_return_409_when_room_not_empty_on_delete() throws Exception {
+        // arrange
+        doThrow(new RoomNotEmptyException("Комната содержит 2 активных растений. Перенесите их перед удалением."))
+                .when(roomService).deleteRoom(1L, 1L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/rooms/1"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("ROOM_NOT_EMPTY"));
+    }
+
+    @Test
+    void should_return_404_when_room_not_found_on_delete() throws Exception {
+        // arrange
+        doThrow(new EntityNotFoundException("Room not found: 99"))
+                .when(roomService).deleteRoom(1L, 99L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/rooms/99"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+}


### PR DESCRIPTION
Closes #283

## Что сделано

- **Flyway V47**: добавлен nullable `location_id` в таблицу `rooms` (FK → `locations`, ON DELETE SET NULL) + индекс `idx_rooms_location_id`
- **Flyway V48**: idempotent-гарантия nullable в окружениях, где V47 могла быть применена с NOT NULL
- **Room entity**: добавлено поле `location` (`@ManyToOne`, nullable) для связи с локацией
- **RoomRepository**: новые методы по `locationId` (findAll, findByIdAndUserId, count, existsByName)
- **PlantRepository**: добавлен `countByRoomIdAndArchivedAtIsNull` для проверки непустой комнаты
- **RoomService**: бизнес-логика CRUD — создание с проверкой дублей и лимитов, PATCH, DELETE с 409 при непустой комнате
- **RoomNotEmptyException**: исключение уровня api для 409 ROOM_NOT_EMPTY
- **RoomController**: реализует `RoomsApi` (сгенерированный из OpenAPI), тонкий слой
- **ApiExceptionHandler**: маппинг `RoomNotEmptyException` → 409 ROOM_NOT_EMPTY
- **OpenAPI**: новый файл `resources/rooms.yaml`, пути и схемы зарегистрированы в `openapi.yaml`
- **Тесты**: `RoomControllerTest` (15 тестов) — happy + edge + failure для всех 4 операций

## Миграции

- `V47__add_location_id_to_rooms.sql` — nullable location_id с FK
- `V48__rooms_location_id_drop_not_null.sql` — idempotent DROP NOT NULL (защита от reuse-контейнеров)

## Backward-compat риски

safe — `location_id` nullable, существующие записи из Telegram-бота остаются с NULL. Команды Telegram-бота не затронуты.

## Тесты

`RoomControllerTest` покрывает:
- GET список (200, пустой список, 404 на неизвестную локацию)
- POST создание (201, displayOrder, 400 blank/missing name, 400 дубль, 404 неизвестная локация)
- PATCH обновление (200 name, 200 displayOrder, 404)
- DELETE (204, 409 ROOM_NOT_EMPTY, 404)

Два существующих теста (`PlantScheduleServiceTest`, `PlantServiceTest`) падают из-за pre-existing timezone/clock bug — не связаны с этим PR, воспроизводятся и на develop.

## Чек

- [x] `mvn verify` зелёное (кроме 2 pre-existing failures в timezone-тестах, воспроизводятся на develop)
- [x] ArchUnit: нет нарушений границ слоёв
- [x] RoomController → RoomsApi (сгенерированный)
- [x] Документировано в `/v3/api-docs` (rooms.yaml добавлен в openapi.yaml)
