### PR TITLE
fix(test): импорт RedisHealthIndicator → actuate.data.redis (чинит красный develop)

### DIFF
--- a/src/test/java/com/plantcare/bot/config/RedisConnectionIT.java
+++ b/src/test/java/com/plantcare/bot/config/RedisConnectionIT.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
-import org.springframework.boot.actuate.redis.RedisHealthIndicator;
+import org.springframework.boot.actuate.data.redis.RedisHealthIndicator;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 


### PR DESCRIPTION
## Проблема
develop красный с мержа #287 (#278): `RedisConnectionIT.java:8 package org.springframework.boot.actuate.redis does not exist` → COMPILATION ERROR, сборка падает.

## Причина
Воркер #278 не собирал локально (неполный кэш Maven — нет транзитива netty/reactor у redis-starter), поэтому не поймал неверный импорт. В Spring Boot 3.5.x `RedisHealthIndicator` лежит в `org.springframework.boot.actuate.**data.**redis` (проверено по `spring-boot-actuator-3.5.14.jar`), а не `...actuate.redis`.

## Фикс
Один импорт: `actuate.redis` → `actuate.data.redis`. Логика теста не меняется.

Локально не верифицировал (та же стена Maven Central — нет netty/reactor); фикс выверен по реальному jar, верифицирует CI.

Мерж — за человеком.

🤖 Generated with [Claude Code](https://claude.com/claude-code)