### PR TITLE
fix(config): убрать пустой дефолт spring.data.redis.url (чинит красный develop, 488 ошибок)

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,6 +1,12 @@
 spring:
   jpa:
     show-sql: false
+  # Issue #278, эпик #277 фаза 0: на проде Redis-подключение через REDIS_URL
+  # (Railway reference variable на внутренний адрес сервиса, redis://...:6379).
+  # REQUIRED: если REDIS_URL не задан, старт упадёт fail-fast (Redis включён всегда).
+  data:
+    redis:
+      url: ${REDIS_URL}
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,14 +49,13 @@ spring:
             enable: ${MAIL_SMTP_STARTTLS:false}
 
   # Issue #278, эпик #277 фаза 0: Redis (Lettuce).
-  # На Railway REDIS_URL инжектится как reference variable из Redis-сервиса.
-  # Внутренняя сеть Railway: app ↔ Redis по приватному хосту *.railway.internal.
-  # Пустой дефолт: при отсутствии REDIS_URL Spring Boot использует host/port ниже.
+  # Базовый/dev/test-профиль использует host/port (по умолчанию localhost:6379).
+  # ВАЖНО: НЕ задавать здесь spring.data.redis.url с пустым дефолтом —
+  # пустая строка url ломает парсер Lettuce (RedisUrlSyntaxException: Invalid Redis URL '')
+  # и роняет загрузку ApplicationContext во всех тестах. На проде URL приходит из
+  # REDIS_URL (Railway reference variable) — см. application-prod.yml.
   data:
     redis:
-      url: ${REDIS_URL:}
-      # Ниже — ручные параметры для случаев, когда REDIS_URL не задан (dev-локалка).
-      # При наличии url эти значения игнорируются.
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
 


### PR DESCRIPTION
## Проблема
develop красный (488 ошибок `Failed to load ApplicationContext`) с мержа #287 (#278 Redis-инфра).

## Корень
`spring.data.redis.url: ${REDIS_URL:}` — пустой дефолт. При незаданном `REDIS_URL` Spring получает `url=''` → `RedisUrlSyntaxException: Invalid Redis URL ''` в `LettuceConnectionConfiguration` → `redisConnectionFactory` + `redisHealthContributor` не создаются → каждый @SpringBootTest-контекст падает.

## Фикс
- **base `application.yml`**: убран `url`, оставлен `host`/`port` (localhost:6379) для dev/test — `RedisConnectionFactory` ленивый, контекст грузится без живого Redis.
- **`application-prod.yml`**: `spring.data.redis.url: ${REDIS_URL}` (REQUIRED) — на проде Railway инжектит `REDIS_URL`.

## Верификация
Локально не собрать (в `~/.m2` нет POM-дескрипторов транзитива redis-starter — netty-parent/reactor-core pom — а Maven Central недоступен). Фикс — известный паттерн; **верифицирует CI**.

Мерж — за человеком.

🤖 Generated with [Claude Code](https://claude.com/claude-code)