### PR TITLE
fix(test): убрать пустой redis.url в IntegrationTestBase (настоящий корень 485 ошибок)

### DIFF
--- a/src/test/java/com/plantcare/bot/support/IntegrationTestBase.java
+++ b/src/test/java/com/plantcare/bot/support/IntegrationTestBase.java
@@ -64,7 +64,8 @@ public abstract class IntegrationTestBase {
         // с REDIS_URL env-переменной Railway (она пустая в тестах).
         registry.add("spring.data.redis.host", REDIS::getHost);
         registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379).toString());
-        // Явно сбрасываем url, чтобы host/port взяли приоритет
-        registry.add("spring.data.redis.url", () -> "");
+        // url НЕ задаём: пустая строка ("") ломает парсер Lettuce
+        // (RedisUrlSyntaxException: Invalid Redis URL '') и роняет контекст.
+        // В базовом профиле url отсутствует, поэтому host/port (выше) берут приоритет сами.
     }
 }


### PR DESCRIPTION
## Проблема
develop красный (485 ошибок `Invalid Redis URL ''`) после #287 (#278). #289 (импорт) и #290 (base yaml) НЕ закрыли — ошибка осталась.

## Настоящий корень
`IntegrationTestBase` через `@DynamicPropertySource` **явно инжектил** `spring.data.redis.url=""` во все тесты на этой базе:
```java
registry.add("spring.data.redis.url", () -> "");  // ← пустая строка ломает Lettuce
```
→ `RedisUrlSyntaxException: Invalid Redis URL ''` → каскад падений @SpringBootTest-контекстов.

## Фикс
Удалена эта строка. host/port уже указывают на Testcontainer Redis (выше); после #290 url в базовом профиле нет — host/port берут приоритет.

## Верификация
Локально не собрать (в `~/.m2` нет POM-дескрипторов netty-parent/reactor-core, Maven Central недоступен). Верифицирует CI.

Мерж — за человеком.

🤖 Generated with [Claude Code](https://claude.com/claude-code)