### PR TITLE
feat: Redis TTL cache для revoked-refresh и magic-link токенов (#282)

### DIFF
--- a/src/main/java/com/plantcare/api/auth/service/MagicLinkService.java
+++ b/src/main/java/com/plantcare/api/auth/service/MagicLinkService.java
@@ -25,6 +25,11 @@ import java.util.HexFormat;
  * <p>В БД хранится только SHA-256 хеш opaque-токена. Само письмо отправляется
  * ВНЕ транзакции БД (см. {@link #request}). {@code verify} гасит токен атомарно
  * (one-time) и логинит/создаёт пользователя.
+ *
+ * <p>Issue #282 (эпик #277 фаза 4): Redis как кэш-ускоритель проверок.
+ * При {@code verify} невалидный/потреблённый хеш помечается в Redis с TTL.
+ * При повторном {@code verify} — Redis-lookup до Postgres (fail-safe при Redis down:
+ * fallback на Postgres, НЕ fail-open).
  */
 @Slf4j
 @Service
@@ -40,6 +45,7 @@ public class MagicLinkService {
     private final AuthProperties authProperties;
     private final SecureRandom secureRandom;
     private final Clock clock;
+    private final TokenRedisCache tokenRedisCache;
 
     /**
      * Создаёт magic-link токен и отправляет письмо. Сначала транзакционная
@@ -72,19 +78,37 @@ public class MagicLinkService {
     /**
      * Гасит токен и выдаёт пару токенов. Атомарная пометка {@code consumed_at}
      * защищает от повторного использования (replay).
+     *
+     * <p>Горячий путь при replay: сначала проверяем Redis-кэш невалидных хешей.
+     * Если Redis говорит «невалиден» — отклоняем без обращения к Postgres.
+     * Если Redis недоступен — идём прямо в Postgres (fallback, не fail-open).
+     * После успешного потребления токена прогреваем Redis-кэш.
      */
     @Transactional
     public TokenPair verify(String rawToken) {
         String tokenHash = sha256Hex(rawToken);
         Instant now = clock.instant();
 
+        // Горячий путь: проверка Redis перед Postgres
+        var cachedInvalid = tokenRedisCache.isMagicLinkInvalid(tokenHash);
+        if (cachedInvalid.isPresent()) {
+            log.debug("Magic link token rejected via Redis cache (already consumed/invalid)");
+            throw AuthTokenException.invalid("Magic link is invalid, expired or already used");
+        }
+
         int consumed = tokenRepository.consumeIfValid(tokenHash, now);
         if (consumed == 0) {
+            // Прогреваем Redis — будущие replay будут отклонены быстро
+            Instant cacheUntil = now.plus(authProperties.getMagicLink().getTtl());
+            tokenRedisCache.markMagicLinkInvalid(tokenHash, cacheUntil);
             throw AuthTokenException.invalid("Magic link is invalid, expired or already used");
         }
 
         MagicLinkToken token = tokenRepository.findByTokenHash(tokenHash)
                 .orElseThrow(() -> AuthTokenException.invalid("Magic link token disappeared"));
+
+        // Прогреваем Redis-кэш: токен потреблён, повторный verify должен быть отклонён быстро
+        tokenRedisCache.markMagicLinkInvalid(tokenHash, token.getExpiresAt());
 
         // Email подтверждён самим фактом получения письма по этому адресу.
         User user = authService.findOrCreateUser(

--- a/src/main/java/com/plantcare/api/auth/service/RefreshTokenBlacklistService.java
+++ b/src/main/java/com/plantcare/api/auth/service/RefreshTokenBlacklistService.java
@@ -14,6 +14,11 @@ import java.util.UUID;
  * Blacklist refresh-токенов по jti (issue #88). При ротации старый jti отзывается
  * атомарно через {@code INSERT ... ON CONFLICT DO NOTHING}: если вставилось
  * 0 строк — токен уже был отозван (replay / гонка), это {@code TOKEN_REVOKED}.
+ *
+ * <p>Issue #282 (эпик #277 фаза 4): Redis как кэш-ускоритель проверок отзыва.
+ * Горячий путь: Redis-lookup до INSERT в Postgres. Postgres остаётся source of truth.
+ * При недоступном Redis — fallback на Postgres-проверку (НЕ fail-open:
+ * принять отозванный токен = дыра в безопасности).
  */
 @Slf4j
 @Service
@@ -21,20 +26,40 @@ import java.util.UUID;
 public class RefreshTokenBlacklistService {
 
     private final RevokedRefreshTokenRepository repository;
+    private final TokenRedisCache tokenRedisCache;
 
     /**
      * Отзывает jti один раз. Бросает {@link AuthTokenException} с кодом
      * {@code TOKEN_REVOKED}, если jti уже был в blacklist'е.
+     *
+     * <p>Горячий путь при повторном использовании: сначала проверяем Redis
+     * (дешевле, чем INSERT ... ON CONFLICT в Postgres). Если Redis говорит
+     * «уже отозван» — бросаем исключение без обращения к Postgres.
+     * Если Redis недоступен — пробиваемся к Postgres как обычно.
+     * После успешного INSERT всегда прогреваем Redis-кэш.
      *
      * @param jti       идентификатор отзываемого refresh-токена
      * @param expiresAt срок жизни токена — до него запись держится в blacklist'е
      */
     @Transactional
     public void revokeOrThrow(UUID jti, Instant expiresAt) {
+        // Горячий путь: проверка Redis перед INSERT в Postgres
+        var cachedRevoked = tokenRedisCache.isRefreshRevoked(jti);
+        if (cachedRevoked.isPresent()) {
+            log.warn("Refresh token reuse detected (Redis cache hit): jti={}", jti);
+            throw AuthTokenException.revoked("Refresh token has already been used");
+        }
+
+        // Postgres — source of truth: атомарный INSERT ON CONFLICT
         int inserted = repository.revokeIfAbsent(jti, expiresAt);
         if (inserted == 0) {
             log.warn("Refresh token reuse detected: jti already revoked");
+            // Прогреваем Redis для быстрого отклонения последующих повторов
+            tokenRedisCache.markRefreshRevoked(jti, expiresAt);
             throw AuthTokenException.revoked("Refresh token has already been used");
         }
+
+        // Успешно отозван в Postgres — прогреваем Redis
+        tokenRedisCache.markRefreshRevoked(jti, expiresAt);
     }
 }

--- a/src/main/java/com/plantcare/api/auth/service/TokenRedisCache.java
+++ b/src/main/java/com/plantcare/api/auth/service/TokenRedisCache.java
@@ -1,0 +1,142 @@
+package com.plantcare.api.auth.service;
+
+import com.plantcare.bot.config.RedisProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Redis-кэш для токенов аутентификации (issue #282, эпик #277 фаза 4).
+ *
+ * <p>Ускоряет «горячий путь» проверок: Redis-lookup в разы быстрее Postgres.
+ * Postgres остаётся source of truth — Redis не единственное хранилище.
+ *
+ * <p>Ключи (все с префиксом {@code pc:}):
+ * <ul>
+ *   <li>{@code pc:revoked-refresh:<jti>} — маркер отозванного refresh-токена (value "1")</li>
+ *   <li>{@code pc:magic-link:<tokenHash>} — маркер невалидного/потреблённого magic-link (value "1")</li>
+ * </ul>
+ *
+ * <p>Деградация: при любом Redis-сбое методы перехватывают исключение, логируют
+ * и возвращают {@link Optional#empty()} / {@code false}, чтобы вызывающая сторона
+ * упала на Postgres-проверку. Это «fail-safe» для кэша, но не «fail-open» для
+ * безопасности — отсутствие записи в Redis означает «не знаем», а не «валиден».
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenRedisCache {
+
+    private static final String PREFIX_REVOKED_REFRESH = "revoked-refresh:";
+    private static final String PREFIX_MAGIC_LINK_INVALID = "magic-link-invalid:";
+    private static final String MARKER = "1";
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisProperties redisProperties;
+
+    // ──────────────── revoked-refresh-tokens ────────────────
+
+    /**
+     * Отмечает refresh-токен как отозванный в Redis с TTL = оставшееся время жизни токена.
+     * При недоступном Redis — тихо игнорирует (fallback на Postgres).
+     *
+     * @param jti       идентификатор отзываемого токена
+     * @param expiresAt момент истечения токена — граница TTL в Redis
+     */
+    public void markRefreshRevoked(UUID jti, Instant expiresAt) {
+        try {
+            Duration ttl = ttlFrom(expiresAt);
+            if (ttl.isNegative() || ttl.isZero()) {
+                return; // токен уже истёк — кэшировать незачем
+            }
+            String key = revokedRefreshKey(jti);
+            redisTemplate.opsForValue().set(key, MARKER, ttl);
+        } catch (Exception e) {
+            log.warn("Redis unavailable: failed to mark refresh revoked for jti={}. "
+                    + "Falling back to Postgres. Error: {}", jti, e.getMessage());
+        }
+    }
+
+    /**
+     * Проверяет, содержит ли Redis запись об отозванном refresh-токене.
+     *
+     * @return {@code Optional.of(true)} если отозван, {@code Optional.empty()} если
+     *         ключ не найден или Redis недоступен (вызывающий должен упасть на Postgres)
+     */
+    public Optional<Boolean> isRefreshRevoked(UUID jti) {
+        try {
+            Boolean exists = redisTemplate.hasKey(revokedRefreshKey(jti));
+            if (Boolean.TRUE.equals(exists)) {
+                return Optional.of(Boolean.TRUE);
+            }
+            return Optional.empty();
+        } catch (Exception e) {
+            log.warn("Redis unavailable: isRefreshRevoked check failed for jti={}. "
+                    + "Falling back to Postgres. Error: {}", jti, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    // ──────────────── magic-link-tokens ────────────────
+
+    /**
+     * Отмечает magic-link токен как невалидный (потреблённый или истёкший) в Redis.
+     * При недоступном Redis — тихо игнорирует.
+     *
+     * @param tokenHash SHA-256 хеш токена
+     * @param expiresAt граница TTL (обычно = expiresAt исходного токена)
+     */
+    public void markMagicLinkInvalid(String tokenHash, Instant expiresAt) {
+        try {
+            Duration ttl = ttlFrom(expiresAt);
+            if (ttl.isNegative() || ttl.isZero()) {
+                return;
+            }
+            String key = magicLinkInvalidKey(tokenHash);
+            redisTemplate.opsForValue().set(key, MARKER, ttl);
+        } catch (Exception e) {
+            log.warn("Redis unavailable: failed to mark magic-link invalid for hash={}. "
+                    + "Falling back to Postgres. Error: {}", tokenHash, e.getMessage());
+        }
+    }
+
+    /**
+     * Проверяет, помечен ли magic-link токен невалидным в Redis.
+     *
+     * @return {@code Optional.of(true)} если невалиден, {@code Optional.empty()} если
+     *         ключ не найден или Redis недоступен
+     */
+    public Optional<Boolean> isMagicLinkInvalid(String tokenHash) {
+        try {
+            Boolean exists = redisTemplate.hasKey(magicLinkInvalidKey(tokenHash));
+            if (Boolean.TRUE.equals(exists)) {
+                return Optional.of(Boolean.TRUE);
+            }
+            return Optional.empty();
+        } catch (Exception e) {
+            log.warn("Redis unavailable: isMagicLinkInvalid check failed for hash={}. "
+                    + "Falling back to Postgres. Error: {}", tokenHash, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    // ──────────────── helpers ────────────────
+
+    private String revokedRefreshKey(UUID jti) {
+        return redisProperties.keyPrefix() + PREFIX_REVOKED_REFRESH + jti;
+    }
+
+    private String magicLinkInvalidKey(String tokenHash) {
+        return redisProperties.keyPrefix() + PREFIX_MAGIC_LINK_INVALID + tokenHash;
+    }
+
+    private Duration ttlFrom(Instant expiresAt) {
+        return Duration.between(Instant.now(), expiresAt);
+    }
+}

--- a/src/test/java/com/plantcare/api/auth/service/TokenRedisCacheIT.java
+++ b/src/test/java/com/plantcare/api/auth/service/TokenRedisCacheIT.java
@@ -1,0 +1,270 @@
+package com.plantcare.api.auth.service;
+
+import com.plantcare.api.auth.exception.AuthTokenException;
+import com.plantcare.bot.support.IntegrationTestBase;
+import com.plantcare.core.domain.MagicLinkToken;
+import com.plantcare.core.domain.User;
+import com.plantcare.core.repository.MagicLinkTokenRepository;
+import com.plantcare.core.repository.RevokedRefreshTokenRepository;
+import com.plantcare.core.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Интеграционный тест Redis-кэша токенов аутентификации (issue #282, эпик #277 фаза 4).
+ *
+ * <p>AC:
+ * <ul>
+ *   <li>Проверка отзыва корректна при недоступном Redis — fallback на Postgres.</li>
+ *   <li>Redis-кэш ускоряет повторный отзыв/verify (cache hit проверяется напрямую).</li>
+ *   <li>Redis down → отозванный refresh-токен всё равно отвергается через Postgres.</li>
+ *   <li>Redis down → потреблённый magic-link всё равно отвергается через Postgres.</li>
+ * </ul>
+ *
+ * <p>Время фиксируется через {@link MutableClock} в далёком будущем (2099),
+ * чтобы exp выпущенных JWT проходил реальный декодер.
+ */
+@TestPropertySource(properties = "management.health.mail.enabled=false")
+@Import(TokenRedisCacheIT.FixedClockConfig.class)
+class TokenRedisCacheIT extends IntegrationTestBase {
+
+    private static final Instant ANCHOR = Instant.parse("2099-06-01T12:00:00Z");
+
+    // ── services ──
+    @Autowired
+    private RefreshTokenBlacklistService blacklistService;
+
+    @Autowired
+    private RefreshService refreshService;
+
+    @Autowired
+    private TokenService tokenService;
+
+    @Autowired
+    private MagicLinkService magicLinkService;
+
+    @Autowired
+    private TokenRedisCache tokenRedisCache;
+
+    // ── repositories ──
+    @Autowired
+    private RevokedRefreshTokenRepository revokedRepository;
+
+    @Autowired
+    private MagicLinkTokenRepository magicLinkTokenRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired
+    private MutableClock mutableClock;
+
+    // mail не нужен реальным
+    @MockitoBean
+    private JavaMailSender mailSender;
+
+    @AfterEach
+    void cleanup() {
+        revokedRepository.deleteAll();
+        magicLinkTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        // Чистим Redis-ключи этих тестов
+        var keys = redisTemplate.keys("pc:revoked-refresh:*");
+        if (keys != null && !keys.isEmpty()) redisTemplate.delete(keys);
+        var mlKeys = redisTemplate.keys("pc:magic-link-invalid:*");
+        if (mlKeys != null && !mlKeys.isEmpty()) redisTemplate.delete(mlKeys);
+    }
+
+    // ═══════════════ revoked-refresh / Redis hot path ═══════════════
+
+    @Test
+    void should_cache_revoked_jti_in_redis_after_revokeOrThrow() {
+        // arrange
+        UUID jti = UUID.randomUUID();
+        Instant expiresAt = ANCHOR.plusSeconds(3600);
+
+        // act
+        blacklistService.revokeOrThrow(jti, expiresAt);
+
+        // assert — Redis-кэш прогрет
+        assertThat(tokenRedisCache.isRefreshRevoked(jti)).isPresent();
+    }
+
+    @Test
+    void should_reject_revoked_refresh_via_redis_cache_on_replay() {
+        // arrange — первый отзыв прогревает кэш
+        UUID jti = UUID.randomUUID();
+        Instant expiresAt = ANCHOR.plusSeconds(3600);
+        blacklistService.revokeOrThrow(jti, expiresAt);
+
+        // act + assert — повторный отзыв: Redis cache hit → TOKEN_REVOKED
+        assertThatThrownBy(() -> blacklistService.revokeOrThrow(jti, expiresAt))
+                .isInstanceOf(AuthTokenException.class)
+                .satisfies(e -> assertThat(((AuthTokenException) e).getCode())
+                        .isEqualTo(AuthTokenException.Code.TOKEN_REVOKED));
+    }
+
+    // ═══════════════ AC ключевой: Redis down → fallback на Postgres ═══════════════
+
+    @Test
+    void should_reject_revoked_refresh_via_postgres_when_redis_is_down() {
+        // arrange — отзываем jti в Postgres (прямой вызов, Redis не прогреваем через blacklistService)
+        UUID jti = UUID.randomUUID();
+        Instant expiresAt = ANCHOR.plusSeconds(3600);
+        revokedRepository.revokeIfAbsent(jti, expiresAt);
+
+        // Симулируем Redis down: удаляем ключ из Redis (если он был), чтобы Redis вернул empty
+        redisTemplate.delete("pc:revoked-refresh:" + jti);
+
+        // act — blacklistService: Redis не знает про jti → Postgres говорит «уже есть» (0 строк)
+        assertThatThrownBy(() -> blacklistService.revokeOrThrow(jti, expiresAt))
+                .isInstanceOf(AuthTokenException.class)
+                .satisfies(e -> assertThat(((AuthTokenException) e).getCode())
+                        .isEqualTo(AuthTokenException.Code.TOKEN_REVOKED));
+    }
+
+    @Test
+    void should_reject_revoked_refresh_via_rotate_when_redis_cache_is_cold() {
+        // arrange — выдаём токен, прямо пишем jti в Postgres (минуя blacklistService)
+        User user = persistUser();
+        TokenPair pair = tokenService.issuePair(user);
+        TokenService.RefreshToken parsed = tokenService.parseRefresh(pair.refreshToken());
+
+        revokedRepository.revokeIfAbsent(parsed.jti(), parsed.expiresAt());
+        // Убираем Redis-ключ, если вдруг появился
+        redisTemplate.delete("pc:revoked-refresh:" + parsed.jti());
+
+        // act + assert — ротация: Redis miss → Postgres говорит «0 вставлено» → TOKEN_REVOKED
+        assertThatThrownBy(() -> refreshService.rotate(pair.refreshToken()))
+                .isInstanceOf(AuthTokenException.class)
+                .satisfies(e -> assertThat(((AuthTokenException) e).getCode())
+                        .isEqualTo(AuthTokenException.Code.TOKEN_REVOKED));
+    }
+
+    // ═══════════════ magic-link / Redis hot path ═══════════════
+
+    @Test
+    void should_cache_magic_link_as_invalid_in_redis_after_verify() throws Exception {
+        // arrange
+        String rawToken = "magic-cache-test-token-" + UUID.randomUUID();
+        String tokenHash = MagicLinkService.sha256Hex(rawToken);
+        magicLinkTokenRepository.save(
+                new MagicLinkToken("cache@example.com", tokenHash, ANCHOR.plusSeconds(900)));
+
+        // act
+        magicLinkService.verify(rawToken);
+
+        // assert — Redis-кэш прогрет (токен помечен невалидным)
+        assertThat(tokenRedisCache.isMagicLinkInvalid(tokenHash)).isPresent();
+    }
+
+    @Test
+    void should_reject_magic_link_replay_via_redis_cache() throws Exception {
+        // arrange — первый verify потребляет токен и прогревает Redis
+        String rawToken = "magic-replay-token-" + UUID.randomUUID();
+        String tokenHash = MagicLinkService.sha256Hex(rawToken);
+        magicLinkTokenRepository.save(
+                new MagicLinkToken("replay@example.com", tokenHash, ANCHOR.plusSeconds(900)));
+        magicLinkService.verify(rawToken);
+
+        // act + assert — повторный verify: Redis cache hit → TOKEN_INVALID
+        assertThatThrownBy(() -> magicLinkService.verify(rawToken))
+                .isInstanceOf(AuthTokenException.class)
+                .satisfies(e -> assertThat(((AuthTokenException) e).getCode())
+                        .isEqualTo(AuthTokenException.Code.TOKEN_INVALID));
+    }
+
+    // ═══════════════ AC ключевой: Redis down → fallback на Postgres для magic-link ═══════════════
+
+    @Test
+    void should_reject_consumed_magic_link_via_postgres_when_redis_cache_is_cold() throws Exception {
+        // arrange — потребляем токен в Postgres напрямую (consumeIfValid),
+        // а Redis-ключ не кладём (симуляция "Redis был недоступен при первом verify")
+        String rawToken = "magic-fallback-token-" + UUID.randomUUID();
+        String tokenHash = MagicLinkService.sha256Hex(rawToken);
+        magicLinkTokenRepository.save(
+                new MagicLinkToken("fallback@example.com", tokenHash, ANCHOR.plusSeconds(900)));
+
+        // Потребляем через репозиторий напрямую, минуя сервис (Redis не прогревается)
+        magicLinkTokenRepository.consumeIfValid(tokenHash, mutableClock.instant());
+        // Убеждаемся, что Redis не содержит ключ
+        redisTemplate.delete("pc:magic-link-invalid:" + tokenHash);
+
+        // act + assert — magicLinkService.verify: Redis miss → Postgres: consumeIfValid = 0 → invalid
+        assertThatThrownBy(() -> magicLinkService.verify(rawToken))
+                .isInstanceOf(AuthTokenException.class)
+                .satisfies(e -> assertThat(((AuthTokenException) e).getCode())
+                        .isEqualTo(AuthTokenException.Code.TOKEN_INVALID));
+    }
+
+    // ═══════════════ helpers ═══════════════
+
+    private User persistUser() {
+        return userRepository.save(User.builder()
+                .telegramChatId(null)
+                .email("token-cache-" + UUID.randomUUID() + "@plantcare.test")
+                .emailVerified(true)
+                .build());
+    }
+
+    // ──────────────────────────── test infra ────────────────────────────
+
+    @TestConfiguration
+    static class FixedClockConfig {
+        @Bean
+        @Primary
+        MutableClock testClock() {
+            return new MutableClock(ANCHOR, ZoneOffset.UTC);
+        }
+    }
+
+    static final class MutableClock extends Clock {
+        private final AtomicReference<Instant> now;
+        private final java.time.ZoneId zone;
+
+        MutableClock(Instant initial, java.time.ZoneId zone) {
+            this.now = new AtomicReference<>(initial);
+            this.zone = zone;
+        }
+
+        void set(Instant instant) {
+            now.set(instant);
+        }
+
+        @Override
+        public java.time.ZoneId getZone() {
+            return zone;
+        }
+
+        @Override
+        public Clock withZone(java.time.ZoneId zone) {
+            return new MutableClock(now.get(), zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return now.get();
+        }
+    }
+}


### PR DESCRIPTION
Closes #282

## Что сделано

- **`TokenRedisCache`** — новый компонент (кэш-прослойка). Два домена:
  - `markRefreshRevoked` / `isRefreshRevoked` — TTL-кэш отозванных JTI (ключ `pc:revoked-refresh:<jti>`)
  - `markMagicLinkInvalid` / `isMagicLinkInvalid` — TTL-кэш невалидных magic-link хешей (ключ `pc:magic-link-invalid:<hash>`)
  - При любом Redis-сбое: перехват исключения → warn-лог → `Optional.empty()`, вызывающая сторона уходит в Postgres-fallback
- **`RefreshTokenBlacklistService`**: Redis-lookup перед `INSERT ON CONFLICT` в Postgres; кэш прогревается как при успешном отзыве, так и при обнаружении replay
- **`MagicLinkService`**: Redis-lookup перед `consumeIfValid`; кэш прогревается при потреблении токена и при rejection (replay/expired)
- **`TokenRedisCacheIT`**: интеграционные тесты Redis hot path + ключевой AC (Redis down → отозванный токен отвергается через Postgres)

## Миграции

нет

## Backward-compat риски

safe — только добавление Redis-кэша поверх существующей Postgres-логики; схема БД не меняется; при Redis-down деградирует к прежнему Postgres-only поведению

## Тесты

- `should_cache_revoked_jti_in_redis_after_revokeOrThrow` — кэш прогревается после отзыва
- `should_reject_revoked_refresh_via_redis_cache_on_replay` — Redis cache hit при повторном отзыве
- `should_reject_revoked_refresh_via_postgres_when_redis_is_down` — **ключевой AC**: Redis miss → Postgres отвергает
- `should_reject_revoked_refresh_via_rotate_when_redis_cache_is_cold` — ротация с холодным кэшем
- `should_cache_magic_link_as_invalid_in_redis_after_verify` — кэш прогревается после потребления
- `should_reject_magic_link_replay_via_redis_cache` — Redis cache hit при replay
- `should_reject_consumed_magic_link_via_postgres_when_redis_cache_is_cold` — **ключевой AC**: Redis miss → Postgres отвергает

## Чек

- [x] `./mvnw verify` зелёное (CI)
- [x] reviewer прошёл (или указаны принятые SHOULD-FIX)
