### PR TITLE
fix(arch): RedisProperties → core (чинит красный develop, ArchUnit api∌bot)

### DIFF
--- a/src/main/java/com/plantcare/api/auth/service/TokenRedisCache.java
+++ b/src/main/java/com/plantcare/api/auth/service/TokenRedisCache.java
@@ -1,6 +1,6 @@
 package com.plantcare.api.auth.service;
 
-import com.plantcare.bot.config.RedisProperties;
+import com.plantcare.core.config.RedisProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;

--- a/src/main/java/com/plantcare/bot/config/RedisConfig.java
+++ b/src/main/java/com/plantcare/bot/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.plantcare.bot.config;
 
+import com.plantcare.core.config.RedisProperties;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/plantcare/core/config/RedisProperties.java
+++ b/src/main/java/com/plantcare/core/config/RedisProperties.java
@@ -1,4 +1,4 @@
-package com.plantcare.bot.config;
+package com.plantcare.core.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/src/test/java/com/plantcare/bot/config/RedisConnectionIT.java
+++ b/src/test/java/com/plantcare/bot/config/RedisConnectionIT.java
@@ -1,6 +1,7 @@
 package com.plantcare.bot.config;
 
 import com.plantcare.bot.support.IntegrationTestBase;
+import com.plantcare.core.config.RedisProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;


### PR DESCRIPTION
## Проблема
develop красный после #294 (#282): `LayeredArchitectureTest` — `TokenRedisCache` (api) зависит от `com.plantcare.bot.config.RedisProperties` (bot) → нарушение правила **api ∌ bot/admin** (#127), 4 ссылки.

## Корень
Ошибка размещения из #278: `RedisProperties` — общая инфраструктура, но положена в `bot.config`. Теперь на неё опираются и bot (RedisConfig), и api (TokenRedisCache, #282).

## Фикс
`RedisProperties`: `bot.config` → **`core.config`** (туда могут зависеть все слои доставки). Обновлены импорты: RedisConfig (bot), TokenRedisCache (api), RedisConnectionIT (test). Логика не меняется. Заодно снимает такое же будущее нарушение для #280 (rate-limit в api).

## ⚠️ auto-merge НЕ включён
Мержить руками **по зелёному CI** — required-гейт «Java CI with Maven» на #294 не сработал (PR слился, пока build был in_progress; вероятно required-контекст задан как имя workflow, а чек репортится под именем job 'build'). Глянь зелёный статус глазами перед мержем.

🤖 Generated with [Claude Code](https://claude.com/claude-code)