### PR TITLE
feat(cache): two-level Caffeine L1 + Redis L2 для справочников (#281)

### DIFF
--- a/src/main/java/com/plantcare/core/cache/CacheInvalidationListener.java
+++ b/src/main/java/com/plantcare/core/cache/CacheInvalidationListener.java
@@ -1,0 +1,68 @@
+package com.plantcare.core.cache;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+/**
+ * Issue #281, эпик #277 фаза 3: слушатель Redis Pub/Sub-канала инвалидации кеша.
+ *
+ * <p>Когда любой инстанс выполняет {@code evict}/{@code clear} двухуровневого кеша, он
+ * публикует {@link CacheInvalidationMessage}. Этот листенер на остальных инстансах ловит
+ * сообщение и чистит соответствующий <b>локальный L1</b> (L2 общий — его уже обновил
+ * инстанс-источник). Так инвалидация в одном инстансе становится видна другим.
+ *
+ * <p>Собственное эхо (сообщения с тем же {@code originId}) отбрасывается: свой L1 уже
+ * почищен синхронно в {@link TwoLevelCache#evict}/{@link TwoLevelCache#clear}.
+ *
+ * <p>Любая ошибка разбора/обработки логируется и проглатывается — сбой инвалидации не должен
+ * ронять листенер-контейнер (худший случай — L1 живёт до истечения собственного TTL).
+ */
+@Slf4j
+public class CacheInvalidationListener implements MessageListener {
+
+    private final TwoLevelCacheManager cacheManager;
+    private final RedisSerializer<CacheInvalidationMessage> messageSerializer;
+
+    public CacheInvalidationListener(
+            TwoLevelCacheManager cacheManager,
+            RedisSerializer<CacheInvalidationMessage> messageSerializer) {
+        this.cacheManager = cacheManager;
+        this.messageSerializer = messageSerializer;
+    }
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            CacheInvalidationMessage msg = messageSerializer.deserialize(message.getBody());
+            if (msg == null) {
+                log.debug("Ignoring empty cache invalidation message");
+                return;
+            }
+
+            // отсекаем собственное эхо
+            if (cacheManager.getOriginId().equals(msg.originId())) {
+                return;
+            }
+
+            TwoLevelCache cache = cacheManager.findExisting(msg.cacheName());
+            if (cache == null) {
+                // на этом инстансе такой кеш ещё не создан — чистить нечего
+                return;
+            }
+
+            if (msg.isClear()) {
+                cache.clearL1Local();
+                log.debug("L1 cleared (cache={}) by remote invalidation from {}",
+                        msg.cacheName(), msg.originId());
+            } else {
+                cache.evictL1Local(msg.key());
+                log.debug("L1 evicted (cache={}, key={}) by remote invalidation from {}",
+                        msg.cacheName(), msg.key(), msg.originId());
+            }
+        } catch (Exception e) {
+            log.warn("Failed to process cache invalidation message: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/plantcare/core/cache/CacheInvalidationMessage.java
+++ b/src/main/java/com/plantcare/core/cache/CacheInvalidationMessage.java
@@ -1,0 +1,37 @@
+package com.plantcare.core.cache;
+
+import java.io.Serializable;
+
+/**
+ * Issue #281, эпик #277 фаза 3: сообщение инвалидации, рассылаемое по Redis Pub/Sub.
+ *
+ * <p>Когда инстанс выполняет {@code evict}/{@code clear} двухуровневого кеша, он публикует
+ * это сообщение в общий канал. Остальные инстансы получают его и чистят свой локальный L1,
+ * чтобы не отдавать устаревшие данные.
+ *
+ * @param originId уникальный id инстанса-отправителя; получатель отбрасывает собственное
+ *                 эхо (свои же сообщения), чтобы не чистить L1 повторно зря
+ * @param cacheName имя справочника-кеша, чей L1 нужно почистить
+ * @param key       конкретный ключ для точечного evict; {@code null} означает clear всего кеша
+ */
+public record CacheInvalidationMessage(
+        String originId,
+        String cacheName,
+        String key
+) implements Serializable {
+
+    /** Точечная инвалидация одной записи. */
+    public static CacheInvalidationMessage evict(String originId, String cacheName, String key) {
+        return new CacheInvalidationMessage(originId, cacheName, key);
+    }
+
+    /** Полная очистка кеша (key == null). */
+    public static CacheInvalidationMessage clear(String originId, String cacheName) {
+        return new CacheInvalidationMessage(originId, cacheName, null);
+    }
+
+    /** {@code true}, если сообщение про полную очистку кеша (без конкретного ключа). */
+    public boolean isClear() {
+        return key == null;
+    }
+}

--- a/src/main/java/com/plantcare/core/cache/TwoLevelCache.java
+++ b/src/main/java/com/plantcare/core/cache/TwoLevelCache.java
@@ -1,0 +1,220 @@
+package com.plantcare.core.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.lang.Nullable;
+import org.springframework.cache.support.AbstractValueAdaptingCache;
+import org.springframework.cache.support.NullValue;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+
+/**
+ * Issue #281, эпик #277 фаза 3: двухуровневый Spring {@link org.springframework.cache.Cache}
+ * поверх Caffeine L1 (локальный) и Redis L2 (общий между инстансами).
+ *
+ * <p>Чтение: L1 → L2 → загрузчик (БД). Попадание в L2 прогревает L1. Запись идёт в оба уровня.
+ *
+ * <p>L2-хранилище — Redis-хеш {@code <keyPrefix>cache:<name>} с полем = строковый ключ записи.
+ * Это делает {@code clear()} одним {@code DEL}, а {@code evict(key)} — одним {@code HDEL}.
+ * TTL L2 ставится/обновляется на хеше при каждой записи (expireAfterWrite-семантика).
+ *
+ * <p><b>Fail-open:</b> любая ошибка Redis (недоступность, таймаут, сериализация) перехватывается,
+ * логируется и трактуется как промах L2 — чтение деградирует на L1 + загрузчик (БД), корректность
+ * сохраняется, медленнее. Redis никогда не роняет операцию кеша.
+ *
+ * <p>{@code evict}/{@code clear} дополнительно публикуют сообщение инвалидации (через
+ * {@code invalidationPublisher}), чтобы остальные инстансы почистили свой L1.
+ */
+@Slf4j
+public class TwoLevelCache extends AbstractValueAdaptingCache {
+
+    private final String name;
+    private final Cache<Object, Object> l1;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final String redisHashKey;
+    private final Duration l2Ttl;
+    private final Consumer<CacheInvalidationMessage> invalidationPublisher;
+    private final String originId;
+
+    /**
+     * @param name                  имя кеша (справочника)
+     * @param l1                    локальный Caffeine-кеш
+     * @param redisTemplate         шаблон для L2; {@code null} → L2 отключён (только L1, фоллбэк)
+     * @param keyPrefix             namespacing-префикс ключей Redis (например {@code pc:})
+     * @param l2Ttl                 TTL хеша L2
+     * @param invalidationPublisher публикатор сообщений инвалидации в общий канал
+     * @param originId              id текущего инстанса (для отсечения собственного эха)
+     */
+    public TwoLevelCache(
+            String name,
+            Cache<Object, Object> l1,
+            @Nullable RedisTemplate<String, Object> redisTemplate,
+            String keyPrefix,
+            Duration l2Ttl,
+            Consumer<CacheInvalidationMessage> invalidationPublisher,
+            String originId) {
+        super(true); // allowNullValues — кешируем «отсутствие» как NullValue
+        this.name = name;
+        this.l1 = l1;
+        this.redisTemplate = redisTemplate;
+        this.redisHashKey = keyPrefix + "cache:" + name;
+        this.l2Ttl = l2Ttl;
+        this.invalidationPublisher = invalidationPublisher;
+        this.originId = originId;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Object getNativeCache() {
+        return l1;
+    }
+
+    /**
+     * Возвращает «сырое» (ещё не развёрнутое из {@link NullValue}) значение по ключу:
+     * сначала L1, затем L2 (с прогревом L1), иначе {@code null} (промах).
+     */
+    @Override
+    protected Object lookup(Object key) {
+        Object l1Value = l1.getIfPresent(key);
+        if (l1Value != null) {
+            return l1Value;
+        }
+
+        Object l2Value = readFromL2(key);
+        if (l2Value != null) {
+            // прогреваем L1 из L2
+            l1.put(key, l2Value);
+            return l2Value;
+        }
+
+        return null;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T get(Object key, Callable<T> valueLoader) {
+        Object existing = lookup(key);
+        if (existing != null) {
+            return (T) fromStoreValue(existing);
+        }
+
+        // загружаем из БД и кладём в оба уровня
+        T loaded;
+        try {
+            loaded = valueLoader.call();
+        } catch (Exception e) {
+            throw new org.springframework.cache.Cache.ValueRetrievalException(key, valueLoader, e);
+        }
+        put(key, loaded);
+        return loaded;
+    }
+
+    @Override
+    public void put(Object key, @Nullable Object value) {
+        Object storeValue = toStoreValue(value);
+        l1.put(key, storeValue);
+        writeToL2(key, storeValue);
+    }
+
+    @Override
+    public void evict(Object key) {
+        l1.invalidate(key);
+        evictFromL2(key);
+        publish(CacheInvalidationMessage.evict(originId, name, String.valueOf(key)));
+    }
+
+    @Override
+    public void clear() {
+        l1.invalidateAll();
+        clearL2();
+        publish(CacheInvalidationMessage.clear(originId, name));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Локальная (L1-only) инвалидация — вызывается листенером Pub/Sub при получении
+    // сообщения от ДРУГОГО инстанса. НЕ трогает L2 и НЕ публикует повторно (без эха).
+    // ──────────────────────────────────────────────────────────────────────
+
+    /** Чистит только L1 по ключу — реакция на внешнее сообщение инвалидации. */
+    public void evictL1Local(Object key) {
+        l1.invalidate(key);
+    }
+
+    /** Чистит весь L1 — реакция на внешнее сообщение clear. */
+    public void clearL1Local() {
+        l1.invalidateAll();
+    }
+
+    // ──────────────────────────── L2 (Redis) ────────────────────────────
+
+    @Nullable
+    private Object readFromL2(Object key) {
+        if (redisTemplate == null) {
+            return null;
+        }
+        try {
+            return redisTemplate.opsForHash().get(redisHashKey, fieldOf(key));
+        } catch (Exception e) {
+            log.warn("Redis L2 unavailable on read (cache={}, key={}): {}. "
+                    + "Degrading to L1+DB.", name, key, e.getMessage());
+            return null;
+        }
+    }
+
+    private void writeToL2(Object key, Object storeValue) {
+        if (redisTemplate == null) {
+            return;
+        }
+        try {
+            redisTemplate.opsForHash().put(redisHashKey, fieldOf(key), storeValue);
+            // expireAfterWrite-семантика: обновляем TTL хеша на каждой записи
+            redisTemplate.expire(redisHashKey, l2Ttl);
+        } catch (Exception e) {
+            log.warn("Redis L2 unavailable on write (cache={}, key={}): {}. "
+                    + "Value kept in L1 only.", name, key, e.getMessage());
+        }
+    }
+
+    private void evictFromL2(Object key) {
+        if (redisTemplate == null) {
+            return;
+        }
+        try {
+            redisTemplate.opsForHash().delete(redisHashKey, fieldOf(key));
+        } catch (Exception e) {
+            log.warn("Redis L2 unavailable on evict (cache={}, key={}): {}.", name, key, e.getMessage());
+        }
+    }
+
+    private void clearL2() {
+        if (redisTemplate == null) {
+            return;
+        }
+        try {
+            redisTemplate.delete(redisHashKey);
+        } catch (Exception e) {
+            log.warn("Redis L2 unavailable on clear (cache={}): {}.", name, e.getMessage());
+        }
+    }
+
+    private void publish(CacheInvalidationMessage message) {
+        try {
+            invalidationPublisher.accept(message);
+        } catch (Exception e) {
+            log.warn("Failed to publish cache invalidation (cache={}, key={}): {}.",
+                    message.cacheName(), message.key(), e.getMessage());
+        }
+    }
+
+    /** Поле хеша должно быть строкой — Spring-ключи могут быть произвольными объектами. */
+    private static String fieldOf(Object key) {
+        return String.valueOf(key);
+    }
+}

--- a/src/main/java/com/plantcare/core/cache/TwoLevelCacheManager.java
+++ b/src/main/java/com/plantcare/core/cache/TwoLevelCacheManager.java
@@ -1,0 +1,136 @@
+package com.plantcare.core.cache;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.plantcare.core.config.RedisProperties;
+import com.plantcare.core.config.TwoLevelCacheProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.lang.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Issue #281, эпик #277 фаза 3: {@link CacheManager} двухуровневых кешей справочников.
+ *
+ * <p>На каждый справочник — один {@link TwoLevelCache} (Caffeine L1 + Redis L2). Менеджер
+ * создаёт кеши лениво по имени (как {@code CaffeineCacheManager}), владеет общим
+ * {@code originId} инстанса и публикует сообщения инвалидации в Redis Pub/Sub-канал —
+ * чтобы {@code evict}/{@code clear} в одном инстансе чистили L1 на остальных.
+ *
+ * <p>Публикация в Redis обёрнута в try/catch (fail-open): недоступность Redis не должна
+ * ронять операцию кеша, локальные L1/L2 уже обновлены к моменту публикации.
+ */
+@Slf4j
+public class TwoLevelCacheManager implements CacheManager {
+
+    private final ConcurrentMap<String, Cache> caches = new ConcurrentHashMap<>();
+
+    private final TwoLevelCacheProperties properties;
+    private final RedisProperties redisProperties;
+    /** {@code null} → L2/Pub-Sub отключены (но менеджер всё равно работает как чистый L1). */
+    @Nullable
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    /** Стабильный на время жизни процесса id инстанса — отсекает собственное эхо инвалидации. */
+    private final String originId = UUID.randomUUID().toString();
+
+    /**
+     * Выделенный типизированный сериализатор сообщений инвалидации. Не зависит от
+     * default-typing режима основного {@code RedisTemplate} (где record как final-тип не
+     * получил бы {@code @class}-маркер и десериализовался бы в Map). Тот же сериализатор
+     * использует {@link CacheInvalidationListener} на принимающей стороне.
+     */
+    private static final RedisSerializer<CacheInvalidationMessage> MESSAGE_SERIALIZER =
+            new Jackson2JsonRedisSerializer<>(CacheInvalidationMessage.class);
+
+    /** Сериализатор сообщений инвалидации — для переиспользования листенером. */
+    public static RedisSerializer<CacheInvalidationMessage> messageSerializer() {
+        return MESSAGE_SERIALIZER;
+    }
+
+    public TwoLevelCacheManager(
+            TwoLevelCacheProperties properties,
+            RedisProperties redisProperties,
+            @Nullable RedisTemplate<String, Object> redisTemplate,
+            Collection<String> cacheNames) {
+        this.properties = properties;
+        this.redisProperties = redisProperties;
+        this.redisTemplate = redisTemplate;
+        for (String name : cacheNames) {
+            caches.put(name, createCache(name));
+        }
+    }
+
+    /** Id текущего инстанса — листенер сверяет его, чтобы не обрабатывать своё эхо. */
+    public String getOriginId() {
+        return originId;
+    }
+
+    @Override
+    @Nullable
+    public Cache getCache(String name) {
+        return caches.computeIfAbsent(name, this::createCache);
+    }
+
+    @Override
+    public Collection<String> getCacheNames() {
+        return List.copyOf(caches.keySet());
+    }
+
+    /**
+     * Возвращает кеш по имени без создания нового (используется листенером инвалидации:
+     * чистить L1 имеет смысл только у уже существующего кеша).
+     */
+    @Nullable
+    TwoLevelCache findExisting(String name) {
+        Cache cache = caches.get(name);
+        return (cache instanceof TwoLevelCache tlc) ? tlc : null;
+    }
+
+    private Cache createCache(String name) {
+        var l1 = Caffeine.newBuilder()
+                .expireAfterWrite(properties.l1Ttl())
+                .maximumSize(properties.l1MaxSize())
+                .build();
+
+        return new TwoLevelCache(
+                name,
+                l1,
+                redisTemplate,
+                redisProperties.keyPrefix(),
+                properties.l2Ttl(),
+                this::publishInvalidation,
+                originId);
+    }
+
+    /**
+     * Публикует сообщение инвалидации в общий Redis-канал. Fail-open: ошибка Redis
+     * логируется и проглатывается — локальные уровни уже консистентны.
+     */
+    private void publishInvalidation(CacheInvalidationMessage message) {
+        if (redisTemplate == null) {
+            return;
+        }
+        try {
+            byte[] payload = MESSAGE_SERIALIZER.serialize(message);
+            redisTemplate.execute((org.springframework.data.redis.core.RedisCallback<Void>) connection -> {
+                connection.publish(
+                        properties.invalidationChannel().getBytes(java.nio.charset.StandardCharsets.UTF_8),
+                        payload);
+                return null;
+            });
+        } catch (Exception e) {
+            log.warn("Failed to publish cache invalidation to channel {} (cache={}): {}. "
+                            + "Other instances may serve stale L1 until their TTL expires.",
+                    properties.invalidationChannel(), message.cacheName(), e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/plantcare/core/config/CacheConfig.java
+++ b/src/main/java/com/plantcare/core/config/CacheConfig.java
@@ -1,21 +1,105 @@
 package com.plantcare.core.config;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.plantcare.core.cache.CacheInvalidationListener;
+import com.plantcare.core.cache.TwoLevelCacheManager;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Issue #281, эпик #277 фаза 3: конфигурация кеша справочников.
+ *
+ * <p>Два режима:
+ * <ul>
+ *   <li><b>two-level</b> (дефолт, {@code app.cache.two-level.enabled=true}) — Caffeine L1 +
+ *       Redis L2 c кросс-инстансной инвалидацией через Pub/Sub. Менеджер —
+ *       {@link TwoLevelCacheManager}.</li>
+ *   <li><b>фоллбэк</b> ({@code enabled=false}) — чистый локальный Caffeine
+ *       ({@link CaffeineCacheManager}), как до issue #281. Redis не задействован.</li>
+ * </ul>
+ *
+ * <p>Имена кешей не меняются ({@code species-list}, {@code species-detail}, {@code care-types}),
+ * поэтому существующие {@code @Cacheable}/{@code @CacheEvict} в сервисах работают через любой
+ * из менеджеров без правок.
+ */
+@Slf4j
 @Configuration
 @EnableCaching
+@EnableConfigurationProperties(TwoLevelCacheProperties.class)
 public class CacheConfig {
 
+    /** Справочники, кешируемые приложением. Совпадает с прежним списком в {@code CaffeineCacheManager}. */
+    static final List<String> CACHE_NAMES = List.of("species-list", "species-detail", "care-types");
+
+    // ────────────────────────── two-level (Caffeine L1 + Redis L2) ──────────────────────────
+
+    /**
+     * Основной менеджер: двухуровневый кеш. Активен, когда {@code app.cache.two-level.enabled}
+     * не задан (дефолт) или {@code true}.
+     */
     @Bean
-    public CacheManager cacheManager() {
-        CaffeineCacheManager manager = new CaffeineCacheManager("species-list", "species-detail", "care-types");
+    @ConditionalOnProperty(prefix = "app.cache.two-level", name = "enabled", havingValue = "true", matchIfMissing = true)
+    public CacheManager twoLevelCacheManager(
+            TwoLevelCacheProperties properties,
+            RedisProperties redisProperties,
+            RedisTemplate<String, Object> redisTemplate) {
+
+        log.info("Cache: two-level mode (Caffeine L1 + Redis L2), l1Ttl={}, l2Ttl={}, channel={}",
+                properties.l1Ttl(), properties.l2Ttl(), properties.invalidationChannel());
+
+        return new TwoLevelCacheManager(properties, redisProperties, redisTemplate, CACHE_NAMES);
+    }
+
+    /**
+     * Контейнер-слушатель Redis Pub/Sub-канала инвалидации. Поднимается только в two-level-режиме.
+     * Регистрирует {@link CacheInvalidationListener}, который чистит локальный L1 по сообщениям
+     * от других инстансов.
+     */
+    @Bean
+    @ConditionalOnProperty(prefix = "app.cache.two-level", name = "enabled", havingValue = "true", matchIfMissing = true)
+    public RedisMessageListenerContainer cacheInvalidationListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            CacheManager twoLevelCacheManager,
+            TwoLevelCacheProperties properties) {
+
+        var listener = new CacheInvalidationListener(
+                (TwoLevelCacheManager) twoLevelCacheManager,
+                TwoLevelCacheManager.messageSerializer());
+
+        var container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(listener, new ChannelTopic(properties.invalidationChannel()));
+
+        log.info("Cache invalidation listener subscribed to channel {}", properties.invalidationChannel());
+        return container;
+    }
+
+    // ────────────────────────── фоллбэк (чистый Caffeine) ──────────────────────────
+
+    /**
+     * Фоллбэк-менеджер: локальный Caffeine без Redis. Активен при
+     * {@code app.cache.two-level.enabled=false}. Поведение совпадает с прежним
+     * (до issue #281): TTL 1 час, без общего L2 и кросс-инстансной инвалидации.
+     */
+    @Bean
+    @ConditionalOnProperty(prefix = "app.cache.two-level", name = "enabled", havingValue = "false")
+    public CacheManager caffeineCacheManager() {
+        log.info("Cache: fallback mode (local Caffeine only, no Redis L2)");
+
+        var manager = new CaffeineCacheManager(CACHE_NAMES.toArray(String[]::new));
         manager.setCaffeine(Caffeine.newBuilder().expireAfterWrite(1, TimeUnit.HOURS));
         return manager;
     }

--- a/src/main/java/com/plantcare/core/config/TwoLevelCacheProperties.java
+++ b/src/main/java/com/plantcare/core/config/TwoLevelCacheProperties.java
@@ -1,0 +1,64 @@
+package com.plantcare.core.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+/**
+ * Issue #281, эпик #277 фаза 3: настройки двухуровневого кеша справочников
+ * (Caffeine L1 + Redis L2).
+ *
+ * <p>Профиль чтения: L1 (локальный, быстрый) → L2 (общий между инстансами) → БД.
+ * Инвалидация в одном инстансе рассылается по всем через Redis Pub/Sub-канал
+ * {@link #invalidationChannel()}.
+ *
+ * <p>Все значения имеют безопасные дефолты для локального запуска; на проде
+ * переопределяются env-переменными (Railway).
+ */
+@ConfigurationProperties(prefix = "app.cache.two-level")
+public record TwoLevelCacheProperties(
+
+        /**
+         * Главный выключатель. {@code false} — фоллбэк на чистый локальный Caffeine
+         * (поведение до issue #281), Redis L2 и Pub/Sub не используются.
+         * Дефолт: {@code true}.
+         */
+        Boolean enabled,
+
+        /**
+         * TTL записей в локальном L1 (Caffeine, expireAfterWrite). По умолчанию короче L2:
+         * L1 быстро устаревает, но согласованность держит L2 и инвалидация по Pub/Sub.
+         * Дефолт: 5 минут.
+         */
+        Duration l1Ttl,
+
+        /**
+         * Максимальный размер L1 (maximumSize Caffeine) на каждый справочник.
+         * Дефолт: 10000 записей.
+         */
+        Long l1MaxSize,
+
+        /**
+         * TTL записей в общем L2 (Redis). По умолчанию длиннее L1.
+         * Дефолт: 1 час.
+         */
+        Duration l2Ttl,
+
+        /**
+         * Имя Redis Pub/Sub-канала для рассылки сообщений инвалидации между инстансами.
+         * Дефолт: {@code pc:cache:invalidate}.
+         */
+        String invalidationChannel
+
+) {
+
+    public TwoLevelCacheProperties {
+        if (enabled == null) enabled = Boolean.TRUE;
+        if (l1Ttl == null) l1Ttl = Duration.ofMinutes(5);
+        if (l1MaxSize == null || l1MaxSize <= 0) l1MaxSize = 10_000L;
+        if (l2Ttl == null) l2Ttl = Duration.ofHours(1);
+        if (invalidationChannel == null || invalidationChannel.isBlank()) {
+            invalidationChannel = "pc:cache:invalidate";
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,6 +69,18 @@ app:
     command-timeout: ${REDIS_COMMAND_TIMEOUT:PT1S}
     key-prefix: ${REDIS_KEY_PREFIX:pc:}
 
+  # Issue #281, эпик #277 фаза 3: двухуровневый кеш справочников (Caffeine L1 + Redis L2).
+  # enabled=false → фоллбэк на чистый локальный Caffeine (поведение до #281), Redis не задействован.
+  # Кросс-инстансная инвалидация L1 — через Redis Pub/Sub-канал invalidation-channel.
+  # Любая ошибка Redis → промах L2 → деградация на L1 + БД (fail-open), корректность сохраняется.
+  cache:
+    two-level:
+      enabled: ${CACHE_TWO_LEVEL_ENABLED:true}
+      l1-ttl: ${CACHE_L1_TTL:PT5M}
+      l1-max-size: ${CACHE_L1_MAX_SIZE:10000}
+      l2-ttl: ${CACHE_L2_TTL:PT1H}
+      invalidation-channel: ${CACHE_INVALIDATION_CHANNEL:pc:cache:invalidate}
+
   # Issue #79: публичная подписка на .ics календарь.
   calendar:
     base-url: ${CALENDAR_BASE_URL:https://example.com}

--- a/src/test/java/com/plantcare/core/cache/TwoLevelCacheIT.java
+++ b/src/test/java/com/plantcare/core/cache/TwoLevelCacheIT.java
@@ -1,0 +1,193 @@
+package com.plantcare.core.cache;
+
+import com.plantcare.bot.support.IntegrationTestBase;
+import com.plantcare.core.config.RedisProperties;
+import com.plantcare.core.config.TwoLevelCacheProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Интеграционный тест двухуровневого кеша (issue #281, эпик #277 фаза 3).
+ *
+ * <p>AC:
+ * <ul>
+ *   <li>Инвалидация (clear/evict) в одном инстансе видна другим — через Redis Pub/Sub
+ *       чистится локальный L1 у остальных.</li>
+ *   <li>Падение Redis не ломает чтение справочников — fail-open на L1 + загрузчик (БД).</li>
+ *   <li>Прогрев L1 из общего L2 (попадание в Redis наполняет локальный Caffeine).</li>
+ * </ul>
+ *
+ * <p>«Инстанс A» — реальный, поднятый Spring-контекстом ({@link CacheManager} +
+ * listener-контейнер). «Инстанс B» — вручную собранный второй менеджер с собственным
+ * listener поверх того же Redis, моделирует второй под приложения.
+ */
+class TwoLevelCacheIT extends IntegrationTestBase {
+
+    private static final String CACHE = "species-detail";
+    private static final String CHANNEL = "pc:cache:invalidate";
+
+    @Autowired
+    private CacheManager cacheManager; // инстанс A (из контекста)
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired
+    private RedisProperties redisProperties;
+
+    @Autowired
+    private RedisConnectionFactory connectionFactory;
+
+    private RedisMessageListenerContainer instanceBContainer;
+
+    @AfterEach
+    void cleanup() {
+        redisTemplate.delete(redisProperties.keyPrefix() + "cache:" + CACHE);
+        cacheManager.getCache(CACHE).clear();
+        if (instanceBContainer != null) {
+            instanceBContainer.destroy();
+            instanceBContainer = null;
+        }
+    }
+
+    // ═══════════════ cross-instance invalidation ═══════════════
+
+    @Test
+    void should_clear_l1_on_other_instance_when_one_instance_clears() throws Exception {
+        // arrange — инстанс A кладёт значение (греет свой L1 и общий L2)
+        Cache cacheA = cacheManager.getCache(CACHE);
+        cacheA.put(1L, "alpha");
+        assertThat(cacheA.get(1L, TwoLevelCacheIT::failLoader)).isEqualTo("alpha");
+
+        // act — другой инстанс (B) делает clear того же кеша
+        TwoLevelCacheManager managerB = newInstanceB(props());
+        managerB.getCache(CACHE).clear();
+
+        // assert — clear от B по Pub/Sub почистил L1 инстанса A; L2 тоже очищен (DEL хеша),
+        // поэтому при следующем чтении сработает загрузчик (БД), а не cache hit.
+        AtomicInteger loaderCalls = new AtomicInteger();
+        String value = awaitGet(cacheA, 1L, () -> {
+            loaderCalls.incrementAndGet();
+            return "reloaded";
+        }, "reloaded");
+
+        assertThat(value).isEqualTo("reloaded");
+        assertThat(loaderCalls.get()).isPositive();
+    }
+
+    // ═══════════════ L1 warm-up from shared L2 ═══════════════
+
+    @Test
+    void should_warm_l1_from_shared_l2_written_by_other_instance() {
+        // arrange — инстанс B пишет в общий L2
+        TwoLevelCacheManager managerB = newInstanceB(props());
+        managerB.getCache(CACHE).put(42L, "from-B");
+
+        // act — инстанс A читает тот же ключ; своего L1 ещё нет, значение должно прийти из L2
+        Cache cacheA = cacheManager.getCache(CACHE);
+        AtomicInteger loaderCalls = new AtomicInteger();
+        String value = cacheA.get(42L, () -> {
+            loaderCalls.incrementAndGet();
+            return "from-DB";
+        });
+
+        // assert — взяли из общего L2, загрузчик (БД) не понадобился
+        assertThat(value).isEqualTo("from-B");
+        assertThat(loaderCalls.get()).isZero();
+    }
+
+    // ═══════════════ fail-open: Redis недоступен ═══════════════
+
+    @Test
+    void should_serve_reads_from_l1_and_db_when_redis_is_down() {
+        // arrange — кеш с заведомо «мёртвым» Redis (несуществующий порт)
+        var deadFactory = new LettuceConnectionFactory("127.0.0.1", 6390);
+        deadFactory.afterPropertiesSet();
+        deadFactory.start();
+        var deadTemplate = new RedisTemplate<String, Object>();
+        deadTemplate.setConnectionFactory(deadFactory);
+        deadTemplate.setKeySerializer(RedisSerializer.string());
+        deadTemplate.setValueSerializer(redisTemplate.getValueSerializer());
+        deadTemplate.afterPropertiesSet();
+
+        var managerDown = new TwoLevelCacheManager(props(), redisProperties, deadTemplate, List.of(CACHE));
+        Cache cache = managerDown.getCache(CACHE);
+
+        // act — put (L2 упадёт молча, L1 запишется), затем два чтения
+        cache.put(7L, "value-7");
+        AtomicInteger loaderCalls = new AtomicInteger();
+        String fromL1 = cache.get(7L, () -> {
+            loaderCalls.incrementAndGet();
+            return "from-DB";
+        });
+        String fromDb = cache.get(8L, () -> {  // нет в L1, L2 недоступен → загрузчик
+            loaderCalls.incrementAndGet();
+            return "loaded-8";
+        });
+
+        // assert — Redis down не сломал кеш: L1 hit + загрузчик отработали корректно
+        assertThat(fromL1).isEqualTo("value-7");    // взято из L1, без загрузчика
+        assertThat(fromDb).isEqualTo("loaded-8");   // L2 промах → БД
+        assertThat(loaderCalls.get()).isEqualTo(1); // загрузчик вызван только для отсутствующего ключа
+
+        deadFactory.destroy();
+    }
+
+    // ═══════════════ helpers ═══════════════
+
+    private static TwoLevelCacheProperties props() {
+        return new TwoLevelCacheProperties(true, Duration.ofMinutes(5), 1000L,
+                Duration.ofHours(1), CHANNEL);
+    }
+
+    /** Собирает второй «инстанс» (менеджер + его listener) поверх того же Redis. */
+    private TwoLevelCacheManager newInstanceB(TwoLevelCacheProperties props) {
+        var managerB = new TwoLevelCacheManager(props, redisProperties, redisTemplate, List.of(CACHE));
+
+        var listenerB = new CacheInvalidationListener(managerB, TwoLevelCacheManager.messageSerializer());
+        instanceBContainer = new RedisMessageListenerContainer();
+        instanceBContainer.setConnectionFactory(connectionFactory);
+        instanceBContainer.addMessageListener(listenerB, new ChannelTopic(props.invalidationChannel()));
+        instanceBContainer.afterPropertiesSet();
+        instanceBContainer.start();
+        return managerB;
+    }
+
+    /**
+     * Pub/Sub-доставка асинхронна — поллим короткими интервалами до ожидаемого значения
+     * (или таймаута). Загрузчик кладёт значение в кеш, поэтому ждём именно момент,
+     * когда L1 уже почищен и загрузчик отработал.
+     */
+    private static <T> T awaitGet(Cache cache, Object key, java.util.concurrent.Callable<T> loader, T expected)
+            throws Exception {
+        long deadline = System.currentTimeMillis() + 5_000;
+        T last = null;
+        while (System.currentTimeMillis() < deadline) {
+            last = cache.get(key, loader);
+            if (expected.equals(last)) {
+                return last;
+            }
+            Thread.sleep(50);
+        }
+        return last;
+    }
+
+    private static Object failLoader() {
+        throw new AssertionError("loader must not be called — value expected in cache");
+    }
+}


### PR DESCRIPTION
## Что сделано

Фаза 3 эпика #277. Справочники переведены с per-instance Caffeine на **двухуровневый кеш**: локальный Caffeine **L1** + общий Redis **L2** (разделяемый между инстансами).

- **`core/cache/TwoLevelCache`** — Spring `Cache` поверх Caffeine L1 + Redis L2. L2-хранилище — Redis-хеш `pc:cache:<name>` на справочник (`clear` = `DEL`, `evict(key)` = `HDEL`). Чтение **L1 → L2 → загрузчик (БД)**; попадание в L2 прогревает L1. TTL L2 обновляется на хеше при каждой записи (expireAfterWrite-семантика).
- **`core/cache/TwoLevelCacheManager`** — `CacheManager`, один two-level кеш на справочник; `evict`/`clear` публикуют сообщение инвалидации в Redis Pub/Sub-канал. Владеет стабильным `originId` инстанса.
- **`core/cache/CacheInvalidationListener` + `CacheInvalidationMessage`** — Pub/Sub: инвалидация в одном инстансе чистит **L1** у остальных (L2 общий — его уже обновил источник). `originId` отсекает собственное эхо. Сообщения сериализуются **выделенным типизированным** `Jackson2JsonRedisSerializer` — не зависит от default-typing основного `RedisTemplate` (record как final-тип не получил бы `@class`-маркер).
- **`core/config/CacheConfig`** переписан на two-level с **фоллбэком** на чистый Caffeine при `app.cache.two-level.enabled=false` (поведение до #281). Добавлен `TwoLevelCacheProperties` (TTL L1/L2, размер L1, channel) и секция `app.cache.two-level` в `application.yml`.
- Существующие `@Cacheable`/`@CacheEvict` справочников (`species-list`, `species-detail`, `care-types`) **не тронуты** — имена кешей те же, работают через новый менеджер.

## Fail-open

Любая ошибка Redis (недоступность / таймаут / сериализация) перехватывается, логируется и трактуется как **промах L2** → чтение деградирует на **L1 + БД**, корректность сохраняется (медленнее). Запись в L2 при сбое тихо пропускается (значение остаётся в L1). Публикация инвалидации при недоступном Redis тоже не роняет операцию кеша — локальные уровни уже консистентны. Redis никогда не роняет операцию кеша.

## Тесты

`TwoLevelCacheIT` (Testcontainers Redis + Postgres, через `IntegrationTestBase`):
- кросс-инстансная инвалидация: `clear` в одном инстансе чистит L1 у другого через Pub/Sub;
- прогрев L1 из общего L2, записанного другим инстансом;
- **fail-open**: при «мёртвом» Redis чтение обслуживается из L1 + загрузчика (БД).

## Архитектура

Весь код в `com.plantcare.core..`, зависит только от Spring / Caffeine / `core.config.RedisProperties`. Зависимостей `core → bot/admin/api` нет — `LayeredArchitectureTest` (ArchUnit) не нарушается.

## Верификация

**Локально не верифицировано** (нет доступа к Maven Central в окружении: не резолвятся транзитивные POM redis-стартера — `io.netty:netty-parent`, `reactor-core`). Это инфраструктурное ограничение окружения, не дефект кода. Код вычитан глазами на компилируемость. **Верифицирует CI** (там сеть есть). **Auto-merge НЕ включён** — мержит человек по зелёному CI.

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)