### PR TITLE
ci: запускать Java CI на PR→develop (первопричина красных develop)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ on:
   push:
     branches: [ "main", "develop", "feature", "tech" ]
   pull_request:
-    branches: [ "main", "feature" ]
+    branches: [ "main", "develop", "feature", "tech" ]
 
 jobs:
   build:


### PR DESCRIPTION
## Первопричина
Вся серия красных develop после Redis-фаз (#287/#294) — отсюда. `maven.yml`:
```yaml
on:
  push:        branches: [ main, develop, feature, tech ]
  pull_request: branches: [ main, feature ]   # ← develop отсутствует
```
Job `build` ("Java CI with Maven") **не запускается на PR в develop** — только на push после мержа.

## Что это объясняет
- **PR в develop не верифицировались** сборкой до мержа → компиляционные/ArchUnit/контекст-ошибки (#287/#289/#290/#292/#294/#295) ловились только постфактум на develop.
- **Required-чек не работал**: нельзя требовать статус-чек, который на PR не репортится → auto-merge сливал по `flyway-dup-guard` (единственный PR-чек), а `build` падал уже после мержа.

## Фикс
`pull_request.branches` приведён к push-набору `[main, develop, feature, tech]`. Теперь `build` бежит на каждом PR→develop и верифицирует ДО мержа; required-gate `build` становится рабочим.

## После мержа этого PR
1. `build` начнёт запускаться на всех открытых PR→develop (#297 и др.) — можно будет верифицировать их по-настоящему.
2. В Settings→Branches→develop стоит сделать **`build`** required (имя job-а, не workflow) — тогда auto-merge станет безопасным.

auto-merge НЕ включён — мержит человек.

🤖 Generated with [Claude Code](https://claude.com/claude-code)