### PR TITLE
fix(test): throws Exception в TwoLevelCacheIT.cleanup() (чинит красный develop)

### DIFF
--- a/src/test/java/com/plantcare/core/cache/TwoLevelCacheIT.java
+++ b/src/test/java/com/plantcare/core/cache/TwoLevelCacheIT.java
@@ -14,6 +14,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.test.context.TestPropertySource;
 
 import java.time.Duration;
 import java.util.List;
@@ -36,6 +37,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * listener-контейнер). «Инстанс B» — вручную собранный второй менеджер с собственным
  * listener поверх того же Redis, моделирует второй под приложения.
  */
+// two-level выключен в общем test-профиле (application-test.yml, #281) — здесь Redis
+// поднят через IntegrationTestBase, поэтому включаем two-level обратно для этого теста.
+@TestPropertySource(properties = "app.cache.two-level.enabled=true")
 class TwoLevelCacheIT extends IntegrationTestBase {
 
     private static final String CACHE = "species-detail";

--- a/src/test/java/com/plantcare/core/cache/TwoLevelCacheIT.java
+++ b/src/test/java/com/plantcare/core/cache/TwoLevelCacheIT.java
@@ -56,7 +56,7 @@ class TwoLevelCacheIT extends IntegrationTestBase {
     private RedisMessageListenerContainer instanceBContainer;
 
     @AfterEach
-    void cleanup() {
+    void cleanup() throws Exception {
         redisTemplate.delete(redisProperties.keyPrefix() + "cache:" + CACHE);
         cacheManager.getCache(CACHE).clear();
         if (instanceBContainer != null) {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,3 +1,14 @@
+# Issue #281: в общем test-профиле two-level cache ВЫКЛЮЧЕН — большинство
+# @SpringBootTest(@ActiveProfiles("test")) не поднимают Redis (нет Testcontainer),
+# а Redis Pub/Sub listener-контейнер при two-level=true жёстко падает на старте
+# (Unable to connect to Redis) и роняет ApplicationContext. Фоллбэк-Caffeine их
+# полностью устраивает. Тест самой two-level-фичи (TwoLevelCacheIT) поднимает Redis
+# и включает two-level локально через @TestPropertySource.
+app:
+  cache:
+    two-level:
+      enabled: false
+
 spring:
   jpa:
     hibernate:


### PR DESCRIPTION
## Проблема
develop красный после #297 (#281): `COMPILATION ERROR — TwoLevelCacheIT.java:63 unreported exception java.lang.Exception`.

## Причина
`@AfterEach cleanup()` вызывает `instanceBContainer.destroy()` (`RedisMessageListenerContainer` → `DisposableBean.destroy()` бросает checked `Exception`), но метод его не объявлял. #297 собирался вслепую (Maven Central недоступен в окружении), поэтому не поймал.

## Фикс
`void cleanup() throws Exception`. Остальные checked-вызовы (afterPropertiesSet/destroy на Lettuce-типах) javac не флагнул — они без checked-throws; единственная ошибка — стр.63.

## Верификация
Это **первый PR→develop, который проверит job `build`** (после мержа #299, добавившего develop в pull_request-триггеры). Дождаться зелёного build перед мержем.

auto-merge НЕ включён.

🤖 Generated with [Claude Code](https://claude.com/claude-code)