### PR TITLE
fix(test): SpeciesSeedTest ожидает 140 видов после V49 (#298) — чинит красный develop

### DIFF
--- a/src/test/java/com/plantcare/bot/migration/SpeciesSeedTest.java
+++ b/src/test/java/com/plantcare/bot/migration/SpeciesSeedTest.java
@@ -16,7 +16,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class SpeciesSeedTest extends IntegrationTestBase {
 
-    private static final int EXPECTED_SEEDED_SPECIES = 30;
+    // V2 сидит 30 видов + V49 (#298) добавляет 110 идемпотентных (INSERT ... WHERE NOT EXISTS) = 140.
+    private static final int EXPECTED_SEEDED_SPECIES = 140;
 
     @Autowired
     private JdbcTemplate jdbc;


### PR DESCRIPTION
## Проблема
develop красный: `SpeciesSeedTest.allSpeciesSeeded:27 expected: 30 but was: 140`. Не связано с Redis/#281 — это от #298.

## Причина
#298 (`V49__seed_species_catalog`) добавил **110** идемпотентных `INSERT ... WHERE NOT EXISTS`; 30 (V2) + 110 = **140**. Тест с захардкоженным `30` не обновили. #298 влился без build-верификации (та же первопричина, что чинит #299).

## Фикс
`EXPECTED_SEEDED_SPECIES`: 30 → 140. Число детерминировано (V49 идемпотентна — пересчитал INSERT-ы).

## Замечание (вне этого PR)
Коммент в V49 говорит «+100 → 130», но реально 110 INSERT-ов → 140. Расхождение комментария стоит поправить отдельно.

## Контекст
Это последний красный тест после серии Redis-фиксов. Мой #281-фикс (#301) уже убрал 3 контекст-ошибки; оставалась только эта чужая ассерта от #298.

auto-merge НЕ включён — мержить по зелёному `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)