### PR TITLE
feat: distributed rate-limit на Redis (Lua на Lettuce, миграция #92 с Caffeine) (#280)

### DIFF
--- a/src/main/java/com/plantcare/admin/ratelimit/LoginRateLimiter.java
+++ b/src/main/java/com/plantcare/admin/ratelimit/LoginRateLimiter.java
@@ -1,46 +1,47 @@
 package com.plantcare.admin.ratelimit;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import com.plantcare.admin.config.AdminProperties;
 import com.plantcare.admin.config.AdminSecurityConfig;
+import com.plantcare.core.ratelimit.RedisRateLimiter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * In-memory rate limiter на Caffeine. Ключ — IP, значение — счётчик неудач.
- * TTL = window-seconds. Bucket4j для одного админа избыточен.
+ * Rate limiter админ-логина. Ключ — IP, значение — счётчик неудачных попыток,
+ * TTL = window-seconds.
+ *
+ * <p>Issue #280 (эпик #277 фаза 2): мигрирован с per-instance Caffeine на общий
+ * Redis-счётчик ({@link RedisRateLimiter}) — при нескольких инстансах лимит брутфорса
+ * админ-логина общий, а не ×N. Caffeine — L1-fallback внутри {@link RedisRateLimiter}
+ * (fail-open при недоступном Redis). Публичный API не изменился.
  */
 @Component
 @ConditionalOnExpression(AdminSecurityConfig.ADMIN_ENABLED_EXPR)
 public class LoginRateLimiter {
 
-    private final Cache<String, AtomicInteger> attempts;
-    private final int maxAttempts;
+    private static final String SCOPE = "admin-login";
 
-    public LoginRateLimiter(AdminProperties props) {
+    private final RedisRateLimiter rateLimiter;
+    private final int maxAttempts;
+    private final Duration window;
+
+    public LoginRateLimiter(AdminProperties props, RedisRateLimiter rateLimiter) {
+        this.rateLimiter = rateLimiter;
         this.maxAttempts = props.getRateLimit().getMaxAttempts();
-        this.attempts = Caffeine.newBuilder()
-                .expireAfterWrite(Duration.ofSeconds(props.getRateLimit().getWindowSeconds()))
-                .maximumSize(10_000)
-                .build();
+        this.window = Duration.ofSeconds(props.getRateLimit().getWindowSeconds());
     }
 
     public boolean isBlocked(String ip) {
-        AtomicInteger c = attempts.getIfPresent(ip);
-        return c != null && c.get() >= maxAttempts;
+        return rateLimiter.isOverLimit(SCOPE, ip, maxAttempts, window);
     }
 
     public void recordFailure(String ip) {
-        attempts.asMap()
-                .computeIfAbsent(ip, k -> new AtomicInteger(0))
-                .incrementAndGet();
+        rateLimiter.increment(SCOPE, ip, window);
     }
 
     public void reset(String ip) {
-        attempts.invalidate(ip);
+        rateLimiter.reset(SCOPE, ip);
     }
 }

--- a/src/main/java/com/plantcare/api/auth/ratelimit/GuestRateLimiter.java
+++ b/src/main/java/com/plantcare/api/auth/ratelimit/GuestRateLimiter.java
@@ -1,34 +1,37 @@
 package com.plantcare.api.auth.ratelimit;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.plantcare.core.ratelimit.RedisRateLimiter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * In-memory rate limiter для {@code POST /api/v1/auth/guest} (issue #227).
- * Не более 3 новых гостей с одного IP за час. Caffeine со sliding-window
- * через expireAfterWrite (аналогично {@link MagicLinkRateLimiter}).
+ * Rate limiter для {@code POST /api/v1/auth/guest} (issue #227).
+ * Не более N новых гостей с одного IP за окно. Учитывается только реальное
+ * создание нового гостя (не restore).
+ *
+ * <p>Issue #280 (эпик #277 фаза 2): мигрирован с per-instance Caffeine на общий
+ * Redis-счётчик ({@link RedisRateLimiter}) — при нескольких инстансах лимит общий.
+ * Caffeine — L1-fallback внутри {@link RedisRateLimiter} (fail-open). Публичный API
+ * не изменился.
  */
 @Component
 public class GuestRateLimiter {
 
-    private final Cache<String, AtomicInteger> attempts;
+    private static final String SCOPE = "guest-new";
+
+    private final RedisRateLimiter rateLimiter;
     private final int maxNew;
     private final long windowSeconds;
 
     public GuestRateLimiter(
+            RedisRateLimiter rateLimiter,
             @Value("${plantcare.auth.guest.rate-limit.max-new:3}") int maxNew,
             @Value("${plantcare.auth.guest.rate-limit.window-seconds:3600}") long windowSeconds) {
+        this.rateLimiter = rateLimiter;
         this.maxNew = maxNew;
         this.windowSeconds = windowSeconds;
-        this.attempts = Caffeine.newBuilder()
-                .expireAfterWrite(Duration.ofSeconds(windowSeconds))
-                .maximumSize(50_000)
-                .build();
     }
 
     /**
@@ -36,17 +39,14 @@ public class GuestRateLimiter {
      * Не учитывает restore-сценарий — только реальное создание нового гостя.
      */
     public boolean isBlocked(String key) {
-        AtomicInteger c = attempts.getIfPresent(key);
-        return c != null && c.get() >= maxNew;
+        return rateLimiter.isOverLimit(SCOPE, key, maxNew, Duration.ofSeconds(windowSeconds));
     }
 
     /**
      * Записывает факт создания нового гостя от ключа.
      */
     public void recordNew(String key) {
-        attempts.asMap()
-                .computeIfAbsent(key, k -> new AtomicInteger(0))
-                .incrementAndGet();
+        rateLimiter.increment(SCOPE, key, Duration.ofSeconds(windowSeconds));
     }
 
     public long getWindowSeconds() {

--- a/src/main/java/com/plantcare/api/auth/ratelimit/MagicLinkRateLimiter.java
+++ b/src/main/java/com/plantcare/api/auth/ratelimit/MagicLinkRateLimiter.java
@@ -1,45 +1,44 @@
 package com.plantcare.api.auth.ratelimit;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.plantcare.core.ratelimit.RedisRateLimiter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * In-memory rate limiter для {@code POST /api/v1/auth/email/request} (issue #88).
- * Тот же подход, что у admin-логина: Caffeine со временем жизни окна. Ключи —
- * IP и email — считаются независимо.
+ * Rate limiter для {@code POST /api/v1/auth/email/request} (issue #88).
+ * Ключи — IP и email — считаются независимо.
+ *
+ * <p>Issue #280 (эпик #277 фаза 2): мигрирован с per-instance Caffeine на общий
+ * Redis-счётчик ({@link RedisRateLimiter}) — при нескольких инстансах лимит общий,
+ * а не ×N. Caffeine сохранён как L1-fallback внутри {@link RedisRateLimiter}
+ * (fail-open при недоступном Redis). Публичный API метода не изменился.
  */
 @Component
 public class MagicLinkRateLimiter {
 
-    private final Cache<String, AtomicInteger> attempts;
+    private static final String SCOPE = "magic-link";
+
+    private final RedisRateLimiter rateLimiter;
     private final int maxAttempts;
     private final long windowSeconds;
 
     public MagicLinkRateLimiter(
+            RedisRateLimiter rateLimiter,
             @Value("${plantcare.auth.magic-link.rate-limit.max-attempts:5}") int maxAttempts,
             @Value("${plantcare.auth.magic-link.rate-limit.window-seconds:300}") long windowSeconds) {
+        this.rateLimiter = rateLimiter;
         this.maxAttempts = maxAttempts;
         this.windowSeconds = windowSeconds;
-        this.attempts = Caffeine.newBuilder()
-                .expireAfterWrite(Duration.ofSeconds(windowSeconds))
-                .maximumSize(50_000)
-                .build();
     }
 
     public boolean isBlocked(String key) {
-        AtomicInteger c = attempts.getIfPresent(key);
-        return c != null && c.get() >= maxAttempts;
+        return rateLimiter.isOverLimit(SCOPE, key, maxAttempts, Duration.ofSeconds(windowSeconds));
     }
 
     public void record(String key) {
-        attempts.asMap()
-                .computeIfAbsent(key, k -> new AtomicInteger(0))
-                .incrementAndGet();
+        rateLimiter.increment(SCOPE, key, Duration.ofSeconds(windowSeconds));
     }
 
     public long getWindowSeconds() {

--- a/src/main/java/com/plantcare/core/ratelimit/RateLimitConfig.java
+++ b/src/main/java/com/plantcare/core/ratelimit/RateLimitConfig.java
@@ -1,0 +1,14 @@
+package com.plantcare.core.ratelimit;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Issue #280, эпик #277 фаза 2: активирует {@link RateLimitProperties}
+ * для распределённого rate-limit. {@link com.plantcare.core.config.RedisProperties}
+ * активируется отдельно в {@code RedisConfig} (фаза 0) — здесь не дублируем.
+ */
+@Configuration
+@EnableConfigurationProperties(RateLimitProperties.class)
+public class RateLimitConfig {
+}

--- a/src/main/java/com/plantcare/core/ratelimit/RateLimitProperties.java
+++ b/src/main/java/com/plantcare/core/ratelimit/RateLimitProperties.java
@@ -1,0 +1,37 @@
+package com.plantcare.core.ratelimit;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Issue #280, эпик #277 фаза 2: настройки распределённого rate-limit на Redis.
+ *
+ * <p>Сам лимит (окно/количество) задаётся на каждой точке вызова (admin-login,
+ * magic-link, guest) — он живёт в соответствующих {@code @ConfigurationProperties}
+ * этих фич. Здесь только инфраструктурные тумблеры распределённого счётчика.
+ *
+ * <p>Префикс ключей берётся из {@link com.plantcare.core.config.RedisProperties#keyPrefix()}
+ * (общий namespacing), здесь не дублируется.
+ */
+@ConfigurationProperties(prefix = "app.rate-limit")
+public record RateLimitProperties(
+
+        /**
+         * Использовать ли Redis как общий (shared) счётчик. Если {@code false} —
+         * считаем только локально через Caffeine L1 (поведение до issue #280,
+         * per-instance). Дефолт {@code true}.
+         */
+        Boolean redisEnabled,
+
+        /**
+         * Максимальный размер локального L1-кэша Caffeine (fallback при недоступном
+         * Redis). Дефолт 100_000 ключей.
+         */
+        Long l1MaxKeys
+
+) {
+
+    public RateLimitProperties {
+        if (redisEnabled == null) redisEnabled = Boolean.TRUE;
+        if (l1MaxKeys == null || l1MaxKeys <= 0) l1MaxKeys = 100_000L;
+    }
+}

--- a/src/main/java/com/plantcare/core/ratelimit/RedisRateLimiter.java
+++ b/src/main/java/com/plantcare/core/ratelimit/RedisRateLimiter.java
@@ -1,0 +1,258 @@
+package com.plantcare.core.ratelimit;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.plantcare.core.config.RedisProperties;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Issue #280, эпик #277 фаза 2: распределённый fixed-window rate-limit на Redis.
+ *
+ * <p>Заменяет per-instance Caffeine-счётчики (issue #92): при нескольких инстансах
+ * приложения локальный счётчик давал реальный лимит ×N. Здесь счётчик общий — лежит
+ * в Redis, инкрементируется атомарно Lua-скриптом (INCR + EXPIRE одной командой,
+ * без гонки между INCR и установкой TTL).
+ *
+ * <p><b>Подход:</b> Lua-скрипт поверх уже подключённого Lettuce
+ * ({@code spring-boot-starter-data-redis}). Никаких bucket4j/redisson — лишних
+ * зависимостей в pom нет (решение владельца).
+ *
+ * <p><b>Деградация — fail-open.</b> Для plant-care работоспособность важнее защиты
+ * (DDoS — не основная угроза). Если Redis недоступен/таймаут/ошибка:
+ * <ul>
+ *   <li>трафик <b>пропускается</b> (запрос не блокируется);</li>
+ *   <li>счёт ведётся локально через Caffeine L1, чтобы лимит хотя бы per-instance
+ *       продолжал работать в деградированном режиме;</li>
+ *   <li>переход в degraded логируется и считается метрикой
+ *       {@value #METRIC_DEGRADED} (тег {@code reason}).</li>
+ * </ul>
+ *
+ * <p>Лежит в {@code core}, чтобы и {@code api}, и {@code admin} могли использовать
+ * общий счётчик, не нарушая границы модульного монолита (api ∌ admin/bot).
+ */
+@Slf4j
+@Component
+public class RedisRateLimiter {
+
+    /** Метрика переходов в degraded-режим (Redis недоступен). Тег {@code reason}. */
+    public static final String METRIC_DEGRADED = "ratelimit.redis.degraded";
+    /** Имя счётчика срабатываний лимита. Теги {@code scope}, {@code source}. */
+    public static final String METRIC_BLOCKED = "ratelimit.blocked";
+
+    private static final String KEY_INFIX = "rl:";
+
+    /**
+     * Атомарный fixed-window: INCR ключа, на первом инкременте ставим EXPIRE на окно.
+     * Возвращает текущее значение счётчика. TTL ставится ровно один раз за окно,
+     * поэтому окно «скользит» по первому запросу, а не сбрасывается на каждом INCR.
+     */
+    private static final RedisScript<Long> INCR_AND_EXPIRE = new DefaultRedisScript<>(
+            """
+            local current = redis.call('INCR', KEYS[1])
+            if current == 1 then
+              redis.call('EXPIRE', KEYS[1], ARGV[1])
+            end
+            return current
+            """,
+            Long.class);
+
+    private final StringRedisTemplate redisTemplate;
+    private final RedisProperties redisProperties;
+    private final RateLimitProperties rateLimitProperties;
+    private final MeterRegistry meterRegistry;
+
+    /** Локальный fallback-счётчик (L1). Значение — счётчик в окне; TTL = окно. */
+    private final Cache<String, AtomicInteger> l1;
+
+    /**
+     * Текущий режим: {@code true} = Redis считается недоступным, идём в L1.
+     * Не «жёсткий» circuit breaker — просто чтобы не логировать degraded на каждый
+     * запрос подряд (логируем только на переходе).
+     */
+    private final AtomicLong lastDegradedLogEpoch = new AtomicLong(0);
+
+    public RedisRateLimiter(StringRedisTemplate redisTemplate,
+                            RedisProperties redisProperties,
+                            RateLimitProperties rateLimitProperties,
+                            MeterRegistry meterRegistry) {
+        this.redisTemplate = redisTemplate;
+        this.redisProperties = redisProperties;
+        this.rateLimitProperties = rateLimitProperties;
+        this.meterRegistry = meterRegistry;
+        this.l1 = Caffeine.newBuilder()
+                .maximumSize(rateLimitProperties.l1MaxKeys())
+                .build();
+    }
+
+    /**
+     * Проверяет, не превышен ли лимит для ключа в текущем окне — БЕЗ инкремента.
+     *
+     * <p>Для admin-логина (счёт неудач) важно разделять «проверить» и «записать»:
+     * фильтр проверяет до BCrypt, инкремент делает failure-handler. Поэтому
+     * {@code isOverLimit} читает счётчик (GET), не трогая его.
+     *
+     * @param scope  низкокардинальный ярлык точки вызова (для метрик/логов)
+     * @param key    идентификатор субъекта (IP, email, …)
+     * @param limit  максимум запросов в окне
+     * @param window длина окна
+     * @return {@code true} если лимит уже исчерпан (надо блокировать)
+     */
+    public boolean isOverLimit(String scope, String key, int limit, Duration window) {
+        if (rateLimitProperties.redisEnabled()) {
+            try {
+                String raw = redisTemplate.opsForValue().get(redisKey(scope, key));
+                long current = raw == null ? 0L : Long.parseLong(raw);
+                boolean over = current >= limit;
+                if (over) {
+                    recordBlocked(scope, "redis");
+                }
+                return over;
+            } catch (Exception e) {
+                degraded(scope, e);
+                // fall through to L1
+            }
+        }
+        return l1IsOverLimit(scope, key, limit);
+    }
+
+    /**
+     * Атомарно инкрементирует счётчик ключа в текущем окне и возвращает, был ли
+     * лимит уже исчерпан ПЕРЕД этим инкрементом.
+     *
+     * <p>Возвращаемое значение — «этот запрос уже за пределом?»: {@code true}, если
+     * счётчик после инкремента превысил лимит. Точки вызова, которые сами решают
+     * блокировать (magic-link/guest), могут использовать это как «исчерпан?».
+     *
+     * @return {@code true} если после инкремента лимит превышен
+     */
+    public boolean incrementAndCheck(String scope, String key, int limit, Duration window) {
+        long current = increment(scope, key, window);
+        boolean over = current > limit;
+        if (over) {
+            recordBlocked(scope, rateLimitProperties.redisEnabled() ? "redis" : "l1");
+        }
+        return over;
+    }
+
+    /**
+     * Инкрементирует счётчик ключа в текущем окне, возвращает новое значение.
+     * Fail-open: при ошибке Redis считает в L1 и не бросает исключений.
+     */
+    public long increment(String scope, String key, Duration window) {
+        if (rateLimitProperties.redisEnabled()) {
+            try {
+                Long current = redisTemplate.execute(
+                        INCR_AND_EXPIRE,
+                        List.of(redisKey(scope, key)),
+                        Long.toString(Math.max(1, window.toSeconds())));
+                if (current != null) {
+                    return current;
+                }
+            } catch (Exception e) {
+                degraded(scope, e);
+                // fall through to L1
+            }
+        }
+        return l1Increment(scope, key, window);
+    }
+
+    /**
+     * Сбрасывает счётчик ключа (например, успешный admin-логин обнуляет неудачи).
+     * Fail-open: ошибка Redis не мешает — L1 чистим всегда.
+     */
+    public void reset(String scope, String key) {
+        if (rateLimitProperties.redisEnabled()) {
+            try {
+                redisTemplate.delete(redisKey(scope, key));
+            } catch (Exception e) {
+                degraded(scope, e);
+            }
+        }
+        l1.invalidate(l1Key(scope, key));
+    }
+
+    // ──────────────── L1 (Caffeine) fallback ────────────────
+
+    private boolean l1IsOverLimit(String scope, String key, int limit) {
+        AtomicInteger c = l1.getIfPresent(l1Key(scope, key));
+        if (!(c instanceof WindowedCounter wc) || wc.isExpired()) {
+            return false;
+        }
+        return wc.get() >= limit;
+    }
+
+    private long l1Increment(String scope, String key, Duration window) {
+        // Окно эмулируем вручную (Caffeine не даёт per-entry TTL без отдельной policy):
+        // храним счётчик с отметкой начала окна и пересоздаём при истечении.
+        // Для fallback-режима (Redis недоступен) достаточно грубого per-instance лимита.
+        return l1Windowed(scope, key, window).incrementAndGet();
+    }
+
+    private AtomicInteger l1Windowed(String scope, String key, Duration window) {
+        return l1.asMap().compute(l1Key(scope, key), (k, existing) -> {
+            if (existing instanceof WindowedCounter wc && !wc.isExpired()) {
+                return wc;
+            }
+            return new WindowedCounter(window.toNanos());
+        });
+    }
+
+    /** Счётчик с отметкой начала окна (для ручного истечения в L1-режиме). */
+    private static final class WindowedCounter extends AtomicInteger {
+        private final long startNanos;
+        private final long windowNanos;
+
+        private WindowedCounter(long windowNanos) {
+            super(0);
+            this.startNanos = System.nanoTime();
+            this.windowNanos = windowNanos;
+        }
+
+        private boolean isExpired() {
+            return (System.nanoTime() - startNanos) >= windowNanos;
+        }
+    }
+
+    // ──────────────── helpers ────────────────
+
+    private String redisKey(String scope, String key) {
+        return redisProperties.keyPrefix() + KEY_INFIX + scope + ":" + key;
+    }
+
+    private String l1Key(String scope, String key) {
+        return scope + ":" + key;
+    }
+
+    private void recordBlocked(String scope, String source) {
+        try {
+            meterRegistry.counter(METRIC_BLOCKED, "scope", scope, "source", source).increment();
+        } catch (Exception ignored) {
+            // метрика не должна влиять на основной поток
+        }
+    }
+
+    private void degraded(String scope, Exception e) {
+        try {
+            meterRegistry.counter(METRIC_DEGRADED, "reason", e.getClass().getSimpleName()).increment();
+        } catch (Exception ignored) {
+            // noop
+        }
+        // Логируем не на каждый запрос (Redis может быть down долго) — раз в ~30 секунд.
+        long now = System.currentTimeMillis();
+        long last = lastDegradedLogEpoch.get();
+        if (now - last > 30_000 && lastDegradedLogEpoch.compareAndSet(last, now)) {
+            log.warn("Rate-limit DEGRADED (fail-open + Caffeine L1) for scope={}: Redis unavailable: {}",
+                    scope, e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,6 +69,15 @@ app:
     command-timeout: ${REDIS_COMMAND_TIMEOUT:PT1S}
     key-prefix: ${REDIS_KEY_PREFIX:pc:}
 
+  # Issue #280, эпик #277 фаза 2: распределённый rate-limit на Redis (Lua на Lettuce).
+  # redis-enabled=false → счётчик считается только локально (Caffeine L1, per-instance,
+  # поведение до #280). При недоступном Redis — fail-open + деградация на L1 (см. RedisRateLimiter).
+  # Конкретные лимиты (окно/количество) — у точек вызова: plantcare.auth.magic-link.rate-limit,
+  # plantcare.auth.guest.rate-limit, admin.rate-limit.
+  rate-limit:
+    redis-enabled: ${RATE_LIMIT_REDIS_ENABLED:true}
+    l1-max-keys: ${RATE_LIMIT_L1_MAX_KEYS:100000}
+
   # Issue #281, эпик #277 фаза 3: двухуровневый кеш справочников (Caffeine L1 + Redis L2).
   # enabled=false → фоллбэк на чистый локальный Caffeine (поведение до #281), Redis не задействован.
   # Кросс-инстансная инвалидация L1 — через Redis Pub/Sub-канал invalidation-channel.

--- a/src/test/java/com/plantcare/core/ratelimit/RedisRateLimiterIT.java
+++ b/src/test/java/com/plantcare/core/ratelimit/RedisRateLimiterIT.java
@@ -1,0 +1,178 @@
+package com.plantcare.core.ratelimit;
+
+import com.plantcare.bot.support.IntegrationTestBase;
+import com.plantcare.core.config.RedisProperties;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Интеграционный тест распределённого rate-limit на Redis (issue #280, эпик #277 фаза 2).
+ *
+ * <p>AC:
+ * <ul>
+ *   <li>Счётчик общий на все инстансы — два разных {@link RedisRateLimiter} над одним
+ *       Redis видят один и тот же счётчик (симуляция multi-instance: два контекста,
+ *       общий store).</li>
+ *   <li>Падение Redis не роняет API — fail-open: при недоступном Redis трафик
+ *       пропускается, исключения не пробрасываются, счёт деградирует на Caffeine L1.</li>
+ *   <li>Атомарный INCR+EXPIRE: ключ получает TTL, по истечении окна счётчик сбрасывается.</li>
+ * </ul>
+ */
+class RedisRateLimiterIT extends IntegrationTestBase {
+
+    private static final String SCOPE = "test-scope";
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Autowired
+    private RedisProperties redisProperties;
+
+    @AfterEach
+    void cleanup() {
+        var keys = stringRedisTemplate.keys(redisProperties.keyPrefix() + "rl:*");
+        if (keys != null && !keys.isEmpty()) {
+            stringRedisTemplate.delete(keys);
+        }
+    }
+
+    private RedisRateLimiter newLimiter(boolean redisEnabled) {
+        return new RedisRateLimiter(
+                stringRedisTemplate,
+                redisProperties,
+                new RateLimitProperties(redisEnabled, 100_000L),
+                new SimpleMeterRegistry());
+    }
+
+    // ═══════════════ AC: общий счётчик на все инстансы ═══════════════
+
+    @Test
+    void should_share_counter_across_two_instances_via_redis() {
+        // arrange — два независимых лимитера над одним Redis (как два инстанса приложения)
+        RedisRateLimiter instanceA = newLimiter(true);
+        RedisRateLimiter instanceB = newLimiter(true);
+        String key = "ip-" + UUID.randomUUID();
+        Duration window = Duration.ofSeconds(60);
+        int limit = 5;
+
+        // act — 3 запроса на инстансе A, 2 на инстансе B → суммарно 5
+        for (int i = 0; i < 3; i++) {
+            instanceA.increment(SCOPE, key, window);
+        }
+        for (int i = 0; i < 2; i++) {
+            instanceB.increment(SCOPE, key, window);
+        }
+
+        // assert — оба видят общий счётчик: лимит исчерпан с любого инстанса
+        assertThat(instanceA.isOverLimit(SCOPE, key, limit, window)).isTrue();
+        assertThat(instanceB.isOverLimit(SCOPE, key, limit, window)).isTrue();
+    }
+
+    @Test
+    void should_not_block_below_limit_with_shared_counter() {
+        // arrange
+        RedisRateLimiter instanceA = newLimiter(true);
+        RedisRateLimiter instanceB = newLimiter(true);
+        String key = "ip-" + UUID.randomUUID();
+        Duration window = Duration.ofSeconds(60);
+        int limit = 5;
+
+        // act — суммарно 4 запроса (под лимитом 5)
+        instanceA.increment(SCOPE, key, window);
+        instanceA.increment(SCOPE, key, window);
+        instanceB.increment(SCOPE, key, window);
+        instanceB.increment(SCOPE, key, window);
+
+        // assert
+        assertThat(instanceA.isOverLimit(SCOPE, key, limit, window)).isFalse();
+        assertThat(instanceB.isOverLimit(SCOPE, key, limit, window)).isFalse();
+    }
+
+    @Test
+    void should_set_ttl_on_window_key() {
+        // arrange
+        RedisRateLimiter limiter = newLimiter(true);
+        String key = "ip-" + UUID.randomUUID();
+        Duration window = Duration.ofSeconds(30);
+
+        // act
+        limiter.increment(SCOPE, key, window);
+
+        // assert — у ключа выставлен TTL в пределах окна (атомарный INCR+EXPIRE)
+        Long ttl = stringRedisTemplate.getExpire(
+                redisProperties.keyPrefix() + "rl:" + SCOPE + ":" + key);
+        assertThat(ttl).isNotNull().isPositive().isLessThanOrEqualTo(30L);
+    }
+
+    // ═══════════════ AC: fail-open при недоступном Redis ═══════════════
+
+    @Test
+    void should_fail_open_when_redis_is_down() {
+        // arrange — Redis-шаблон, который бросает на любой команде (Redis недоступен)
+        StringRedisTemplate broken = mock(StringRedisTemplate.class);
+        when(broken.opsForValue()).thenThrow(new RuntimeException("Redis down"));
+        when(broken.execute(org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyList(),
+                org.mockito.ArgumentMatchers.<Object>any()))
+                .thenThrow(new RuntimeException("Redis down"));
+
+        RedisRateLimiter limiter = new RedisRateLimiter(
+                broken, redisProperties,
+                new RateLimitProperties(true, 100_000L),
+                new SimpleMeterRegistry());
+
+        String key = "ip-down-" + UUID.randomUUID();
+        Duration window = Duration.ofSeconds(60);
+        int limit = 3;
+
+        // act + assert — никаких исключений наружу (fail-open), трафик не блокируется
+        assertThatNoException().isThrownBy(() -> {
+            for (int i = 0; i < 10; i++) {
+                limiter.increment(SCOPE, key, window);
+            }
+        });
+        // деградация на L1: после превышения лимита локальный счётчик всё-таки блокирует,
+        // но главное — Redis-сбой не уронил поток и не бросил исключение наружу
+        assertThatNoException().isThrownBy(() -> limiter.isOverLimit(SCOPE, key, limit, window));
+    }
+
+    @Test
+    void should_degrade_to_l1_counting_when_redis_is_down() {
+        // arrange — Redis недоступен → лимитер обязан считать локально (L1)
+        StringRedisTemplate broken = mock(StringRedisTemplate.class);
+        when(broken.opsForValue()).thenThrow(new RuntimeException("Redis down"));
+        when(broken.execute(org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyList(),
+                org.mockito.ArgumentMatchers.<Object>any()))
+                .thenThrow(new RuntimeException("Redis down"));
+
+        RedisRateLimiter limiter = new RedisRateLimiter(
+                broken, redisProperties,
+                new RateLimitProperties(true, 100_000L),
+                new SimpleMeterRegistry());
+
+        String key = "ip-l1-" + UUID.randomUUID();
+        Duration window = Duration.ofSeconds(60);
+        int limit = 3;
+
+        // act — превышаем лимит локально
+        for (int i = 0; i < 4; i++) {
+            limiter.increment(SCOPE, key, window);
+        }
+
+        // assert — L1 ловит превышение (per-instance деградация), сбоя нет
+        assertThat(limiter.isOverLimit(SCOPE, key, limit, window)).isTrue();
+    }
+}


### PR DESCRIPTION
## Что и зачем

**Эпик #277, фаза 2.** При нескольких инстансах приложения Caffeine-rate-limit (#92) считался **per-instance** → реальный лимит ×N. Переводим per-IP / per-user счётчики на **общий Redis-store**.

## Подход (решение владельца): Lua на Lettuce, БЕЗ новых зависимостей

Атомарный **Lua-скрипт** (`INCR` + `EXPIRE` одной командой, без гонки между инкрементом и установкой TTL) поверх уже подключённого **Lettuce** (`spring-boot-starter-data-redis`, фаза 0 #278). `bucket4j`/`redisson` отвергнуты — **в `pom.xml` новых зависимостей нет**.

Fixed-window счётчик `core.ratelimit.RedisRateLimiter` на `StringRedisTemplate`. Размещён в **`core`**, чтобы и `api`, и `admin` использовали один store, не нарушая границы модульного монолита (`api ∌ admin/bot` — ArchUnit `LayeredArchitectureTest` зелёный).

- Ключи с префиксом из `RedisProperties.keyPrefix()` (namespacing: `pc:rl:<scope>:<key>`).
- Лимиты (окно/количество) конфигурируемы — живут у точек вызова (`plantcare.auth.magic-link.rate-limit`, `plantcare.auth.guest.rate-limit`, `admin.rate-limit`). Инфраструктурные тумблеры — `RateLimitProperties` (`@ConfigurationProperties app.rate-limit`: `redis-enabled`, `l1-max-keys`).

## fail-open + L1-fallback

Redis недоступен / таймаут / ошибка → **трафик пропускается** (работоспособность > защита; DDoS — не основная угроза plant-care). Счёт деградирует на **Caffeine L1** (per-instance), переход в degraded логируется (раз в ~30 c) + метрики:
- `ratelimit.redis.degraded{reason}` — переход в degraded,
- `ratelimit.blocked{scope,source}` — срабатывание лимита.

## Что мигрировано с Caffeine (публичный API сохранён, callers не тронуты)

- `MagicLinkRateLimiter` (#88) — `POST /api/v1/auth/email/request`,
- `GuestRateLimiter` (#227) — `POST /api/v1/auth/guest`,
- admin `LoginRateLimiter` — брутфорс админ-логина.

## Тесты

`RedisRateLimiterIT` (Testcontainers Redis, наследует `IntegrationTestBase`):
- **AC: общий счётчик на два инстанса** — два независимых `RedisRateLimiter` над одним Redis видят один счётчик;
- TTL выставлен на ключе (атомарный `INCR+EXPIRE`);
- **AC: fail-open при Redis down** — трафик не блокируется, исключения наружу не пробрасываются;
- деградация счёта на L1.

## `mvn verify`

`Tests run: 1779`, **1777 зелёных**. 2 падения — `PlantScheduleServiceTest#should_compute_next_due_at_correctly_for_non_utc_timezone` и `PlantServiceTest#markCareDone_writesHistoryAndReschedules` — **пре-существующие**, host-timezone-зависимые (среда UTC+3): сравнивают `LocalDateTime.now()` с UTC-эталоном. Падают идентично на чистом `origin/develop` (проверено на отдельном worktree), к #280 отношения не имеют.

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)