### PR TITLE
fix(config): подключить Redis в dev-профиле (REDIS_URL) — чинит старт dev

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,6 +4,13 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  # Issue #278, эпик #277: на Railway-dev Redis-подключение через REDIS_URL
+  # (reference на Redis-сервис, redis://...railway.internal:6379). Базовый профиль
+  # читает host/port (localhost) — для деплоя dev нужен url, как в application-prod.yml.
+  # REQUIRED на dev: без REDIS_URL приложение упадёт fail-fast (Redis включён всегда).
+  data:
+    redis:
+      url: ${REDIS_URL}
 
 # Issue #88: dummy-секрет для локального запуска. НЕ использовать на prod —
 # там AUTH_JWT_SECRET задаётся через env. Длина >= 32 байт для HS256.


### PR DESCRIPTION
## Проблема
dev-деплой не стартует: `Unable to connect to Redis ... localhost/127.0.0.1:6379`. Приложение лезет на **localhost**, игнорируя `REDIS_URL`.

## Корень
На Railway-dev активен профиль **`dev`** (`application-dev.yml`), а он **не настраивал Redis** → конфиг падал в дефолт базового профиля `host=${REDIS_HOST:localhost}`. `REDIS_URL` читал только prod-профиль. Листенер инвалидации кэша (#281) при недоступном Redis валит контекст → старт падает.

## Фикс
Добавлен `spring.data.redis.url: ${REDIS_URL}` в `application-dev.yml` (как в `application-prod.yml`). dev-специфика (Sentry off, SQL debug) сохранена.

## Требования к dev-окружению
- `SPRING_PROFILES_ACTIVE=dev` (проверить по лог-строке старта «The following 1 profile is active: "dev"»);
- `REDIS_URL` = reference на Redis-сервис (уже задан).

## Отдельно (follow-up)
Листенер #281 жёстко падает при недоступном Redis на старте — нарушает fail-open. Отдельный PR сделает его устойчивым (retry, не ронять контекст).

auto-merge НЕ включён.

🤖 Generated with [Claude Code](https://claude.com/claude-code)