### PR TITLE
fix(redis): redisObjectMapper ломал весь write-API (подменял MVC ObjectMapper)

### DIFF
--- a/src/main/java/com/plantcare/bot/config/RedisConfig.java
+++ b/src/main/java/com/plantcare/bot/config/RedisConfig.java
@@ -67,8 +67,12 @@ public class RedisConfig {
      * <p>Type info необходима для корректной десериализации полиморфных типов при
      * восстановлении данных из Redis (иначе Jackson не знает в какой класс маппить).
      */
-    @Bean("redisObjectMapper")
-    public ObjectMapper redisObjectMapper() {
+    // НЕ @Bean: бин типа ObjectMapper подавляет авто-конфигурируемый Spring Boot
+    // ObjectMapper (@ConditionalOnMissingBean(ObjectMapper.class)) и становится основным
+    // для Spring MVC. Тогда default-typing (@class) протекает в HTTP: тела POST/PUT/PATCH
+    // не парсятся («Malformed request body»), ответы засоряются @class. Этот mapper —
+    // ТОЛЬКО для Redis-сериализации, создаётся локально для redisTemplate().
+    private ObjectMapper redisObjectMapper() {
         var mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
@@ -98,14 +102,13 @@ public class RedisConfig {
      */
     @Bean
     public RedisTemplate<String, Object> redisTemplate(
-            RedisConnectionFactory connectionFactory,
-            ObjectMapper redisObjectMapper) {
+            RedisConnectionFactory connectionFactory) {
 
         var template = new RedisTemplate<String, Object>();
         template.setConnectionFactory(connectionFactory);
 
         var stringSerializer = new StringRedisSerializer();
-        var jsonSerializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper);
+        var jsonSerializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper());
 
         template.setKeySerializer(stringSerializer);
         template.setHashKeySerializer(stringSerializer);

--- a/src/test/java/com/plantcare/bot/config/PrimaryObjectMapperTest.java
+++ b/src/test/java/com/plantcare/bot/config/PrimaryObjectMapperTest.java
@@ -1,0 +1,36 @@
+package com.plantcare.bot.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.plantcare.bot.support.IntegrationTestBase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Регресс на #281 (эпик #277 фаза 3): {@code redisObjectMapper} НЕ должен подменять
+ * основной Spring MVC {@link ObjectMapper}.
+ *
+ * <p>До фикса {@code redisObjectMapper} был объявлен как {@code @Bean ObjectMapper} и
+ * подавлял авто-конфигурируемый Spring Boot mapper ({@code @ConditionalOnMissingBean}),
+ * становясь основным. Его {@code activateDefaultTyping(NON_FINAL)} протекал в HTTP:
+ * тела POST/PUT/PATCH не парсились («Malformed request body»), а ответы засорялись
+ * {@code @class} / типизированными коллекциями ({@code ["java.util...ListN",[...]]}).
+ */
+class PrimaryObjectMapperTest extends IntegrationTestBase {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void should_serialize_collections_without_type_info_in_primary_mapper() throws Exception {
+        // arrange / act
+        String json = objectMapper.writeValueAsString(List.of("a", "b"));
+
+        // assert — чистый JSON-массив, НЕ ["java.util.ImmutableCollections$ListN",[...]]
+        assertThat(json).isEqualTo("[\"a\",\"b\"]");
+        assertThat(json).doesNotContain("@class");
+    }
+}


### PR DESCRIPTION
## 🔴 Критично — сломан весь write-API на dev/prod
Обнаружено при ручной проверке dev: `POST /api/v1/auth/guest` с валидным телом → **400 «Malformed request body»**, а `GET /api/v1/diseases` отдаёт ответ с `@class` и `["java.util.ImmutableCollections$ListN",[...]]`.

## Корень
`RedisConfig` объявлял `@Bean("redisObjectMapper") ObjectMapper` с `activateDefaultTyping(NON_FINAL)` (#281). Бин типа `ObjectMapper` подавляет авто-конфигурируемый Spring Boot mapper (`@ConditionalOnMissingBean(ObjectMapper.class)`) → **redisObjectMapper становится основным для Spring MVC**:
- тела POST/PUT/PATCH не парсятся (MVC ждёт `@class`) → 400 на guest/magic-link/plants/care-events/…;
- все ответы засоряются `@class` → ломают мобильный клиент.

## Почему CI не поймал
`@WebMvcTest`-слайсы не грузят `RedisConfig` → не видят глобальный side-effect. Full-context тесты не постили JSON-тела и не проверяли форму ответа.

## Фикс
`redisObjectMapper` больше **не `@Bean`** — приватный метод, вызывается локально только в `redisTemplate()` для `GenericJackson2JsonRedisSerializer`. Spring Boot снова создаёт чистый MVC ObjectMapper; Redis-сериализация (type info) сохранена.

## Тест
`PrimaryObjectMapperTest` (full context): основной ObjectMapper сериализует коллекцию без type info. Падает на develop, проходит с фиксом. Локально: PrimaryObjectMapperTest ✅, RedisConnectionIT ✅. (Cross-instance TwoLevelCacheIT — пред-существующий машинный флак Pub/Sub, на CI зелёный.)

auto-merge НЕ включён.

🤖 Generated with [Claude Code](https://claude.com/claude-code)