### PR TITLE
fix(cache): сделать старт Redis-листенера инвалидации fail-open (#281…

### DIFF
--- a/src/main/java/com/plantcare/core/cache/CacheInvalidationListenerStarter.java
+++ b/src/main/java/com/plantcare/core/cache/CacheInvalidationListenerStarter.java
@@ -1,0 +1,82 @@
+package com.plantcare.core.cache;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Резильентный стартер listener-контейнера инвалидации кеша (issue #281, эпик #277 фаза 3).
+ *
+ * <p><b>Проблема (инцидент на dev).</b> {@link RedisMessageListenerContainer} с
+ * {@code autoStartup=true} стартует синхронно во время refresh контекста. Когда Redis
+ * недоступен, {@code lazyListen} бросает {@code RedisConnectionFailureException} из
+ * {@code SmartLifecycle.start()}, и весь {@code ApplicationContext} не поднимается —
+ * приложение не стартует. Это нарушает заявленный для #281 принцип <b>fail-open</b>:
+ * Redis-блип не должен класть прод, кэш должен деградировать на L1 + БД.
+ *
+ * <p><b>Решение.</b> Контейнер сконфигурирован с {@code autoStartup=false}
+ * ({@link com.plantcare.core.config.CacheConfig}), Spring его не стартует. Этот стартер:
+ * <ul>
+ *   <li>на {@link ApplicationReadyEvent} пытается {@code start()} в try/catch — при ошибке
+ *       пишет WARN и НЕ роняет контекст;</li>
+ *   <li>{@link Scheduled} периодически проверяет {@code !isRunning()} и пробует стартовать
+ *       снова — так листенер поднимется, как только Redis вернётся.</li>
+ * </ul>
+ * Бин активен в two-level-режиме ({@code app.cache.two-level.enabled=true}, дефолт), то есть
+ * ровно тогда же, когда создаётся сам контейнер. В фоллбэк-режиме контейнера нет — стартер
+ * тоже не создаётся.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "app.cache.two-level", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class CacheInvalidationListenerStarter {
+
+    private final RedisMessageListenerContainer cacheInvalidationListenerContainer;
+
+    /**
+     * Первая попытка запуска после готовности приложения. Ошибка (Redis недоступен) не
+     * пробрасывается — контекст уже поднят, ретраи продолжит {@link #retryStartIfDown()}.
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void startOnReady() {
+        tryStart();
+    }
+
+    /**
+     * Периодический ретрай: если контейнер ещё не запущен (Redis был недоступен на старте или
+     * упал), пробуем поднять его снова. Когда Redis вернётся — листенер подпишется и
+     * кросс-инстансная инвалидация заработает. Интервал — из {@code app.cache.two-level
+     * .listener-retry-interval} (дефолт 30s).
+     */
+    @Scheduled(
+            fixedDelayString = "${app.cache.two-level.listener-retry-interval:PT30S}",
+            initialDelayString = "${app.cache.two-level.listener-retry-interval:PT30S}")
+    public void retryStartIfDown() {
+        if (!cacheInvalidationListenerContainer.isRunning()) {
+            tryStart();
+        }
+    }
+
+    /**
+     * Идемпотентный запуск: не дублирует старт, если контейнер уже running; ошибку запуска
+     * (Redis недоступен) глотает с WARN, чтобы не ронять контекст и не валить шедулер.
+     */
+    private void tryStart() {
+        if (cacheInvalidationListenerContainer.isRunning()) {
+            return;
+        }
+        try {
+            cacheInvalidationListenerContainer.start();
+            log.info("Cache invalidation listener started (Redis Pub/Sub subscription active)");
+        } catch (RuntimeException e) {
+            log.warn("Redis недоступен, листенер инвалидации кеша не запущен, ретрай позже: {}",
+                    e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/plantcare/core/config/CacheConfig.java
+++ b/src/main/java/com/plantcare/core/config/CacheConfig.java
@@ -67,6 +67,15 @@ public class CacheConfig {
      * Контейнер-слушатель Redis Pub/Sub-канала инвалидации. Поднимается только в two-level-режиме.
      * Регистрирует {@link CacheInvalidationListener}, который чистит локальный L1 по сообщениям
      * от других инстансов.
+     *
+     * <p><b>Fail-open старт (issue #281).</b> {@code autoStartup=false} — Spring НЕ стартует
+     * контейнер во время refresh контекста. Иначе при недоступном Redis
+     * {@code lazyListen} бросает {@code RedisConnectionFailureException} из
+     * {@code SmartLifecycle.start()} и роняет весь {@code ApplicationContext} — приложение не
+     * поднимается. Реальный запуск (с try/catch и ретраями, когда Redis вернётся) делает
+     * {@link com.plantcare.core.cache.CacheInvalidationListenerStarter}.
+     * {@code recoveryInterval} управляет переподпиской контейнера при разрыве уже
+     * установленного соединения.
      */
     @Bean
     @ConditionalOnProperty(prefix = "app.cache.two-level", name = "enabled", havingValue = "true", matchIfMissing = true)
@@ -79,11 +88,22 @@ public class CacheConfig {
                 (TwoLevelCacheManager) twoLevelCacheManager,
                 TwoLevelCacheManager.messageSerializer());
 
-        var container = new RedisMessageListenerContainer();
+        // autoStartup=false через override isAutoStartup(): RedisMessageListenerContainer не
+        // имеет setAutoStartup(), а Spring стартует SmartLifecycle во время refresh по этому флагу.
+        // НЕ стартуем в refresh: при недоступном Redis lazyListen уронил бы контекст.
+        // Старт берёт на себя CacheInvalidationListenerStarter (ApplicationReadyEvent + ретраи).
+        var container = new RedisMessageListenerContainer() {
+            @Override
+            public boolean isAutoStartup() {
+                return false;
+            }
+        };
         container.setConnectionFactory(connectionFactory);
         container.addMessageListener(listener, new ChannelTopic(properties.invalidationChannel()));
+        container.setRecoveryInterval(properties.recoveryInterval().toMillis());
 
-        log.info("Cache invalidation listener subscribed to channel {}", properties.invalidationChannel());
+        log.info("Cache invalidation listener configured for channel {} (autoStartup=false, fail-open start)",
+                properties.invalidationChannel());
         return container;
     }
 

--- a/src/main/java/com/plantcare/core/config/TwoLevelCacheProperties.java
+++ b/src/main/java/com/plantcare/core/config/TwoLevelCacheProperties.java
@@ -48,7 +48,24 @@ public record TwoLevelCacheProperties(
          * Имя Redis Pub/Sub-канала для рассылки сообщений инвалидации между инстансами.
          * Дефолт: {@code pc:cache:invalidate}.
          */
-        String invalidationChannel
+        String invalidationChannel,
+
+        /**
+         * Интервал восстановления подписки listener-контейнера ({@code recoveryInterval}
+         * у {@link org.springframework.data.redis.listener.RedisMessageListenerContainer}).
+         * Если соединение с Redis рвётся, контейнер пытается переподписаться через этот интервал.
+         * Дефолт: 5 секунд.
+         */
+        Duration recoveryInterval,
+
+        /**
+         * Интервал повторных попыток запуска listener-контейнера, когда Redis недоступен на
+         * старте приложения (fail-open, issue #281). Резильентный стартер периодически проверяет
+         * {@code !container.isRunning()} и пробует {@code start()} — так листенер поднимется,
+         * как только Redis вернётся, не роняя ApplicationContext.
+         * Дефолт: 30 секунд.
+         */
+        Duration listenerRetryInterval
 
 ) {
 
@@ -60,5 +77,7 @@ public record TwoLevelCacheProperties(
         if (invalidationChannel == null || invalidationChannel.isBlank()) {
             invalidationChannel = "pc:cache:invalidate";
         }
+        if (recoveryInterval == null) recoveryInterval = Duration.ofSeconds(5);
+        if (listenerRetryInterval == null) listenerRetryInterval = Duration.ofSeconds(30);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,6 +89,11 @@ app:
       l1-max-size: ${CACHE_L1_MAX_SIZE:10000}
       l2-ttl: ${CACHE_L2_TTL:PT1H}
       invalidation-channel: ${CACHE_INVALIDATION_CHANNEL:pc:cache:invalidate}
+      # Переподписка listener-контейнера при разрыве уже установленного соединения с Redis.
+      recovery-interval: ${CACHE_LISTENER_RECOVERY_INTERVAL:PT5S}
+      # Ретрай запуска listener-контейнера, когда Redis был недоступен на старте (fail-open):
+      # листенер поднимется сам, как только Redis вернётся, не роняя ApplicationContext.
+      listener-retry-interval: ${CACHE_LISTENER_RETRY_INTERVAL:PT30S}
 
   # Issue #79: публичная подписка на .ics календарь.
   calendar:

--- a/src/test/java/com/plantcare/core/cache/CacheListenerFailOpenStartupIT.java
+++ b/src/test/java/com/plantcare/core/cache/CacheListenerFailOpenStartupIT.java
@@ -1,0 +1,77 @@
+package com.plantcare.core.cache;
+
+import com.plantcare.bot.support.IntegrationTestBase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Регресс-тест на dev-инцидент (issue #281, эпик #277 фаза 3): при two-level-режиме
+ * с НЕДОСТУПНЫМ Redis {@code ApplicationContext} обязан подняться.
+ *
+ * <p>Раньше listener-контейнер ({@link org.springframework.data.redis.listener.RedisMessageListenerContainer})
+ * стартовал синхронно во время refresh; при недоступном Redis {@code lazyListen} бросал
+ * {@code RedisConnectionFailureException} из {@code SmartLifecycle.start()} и валил весь
+ * контекст — приложение не стартовало. Это нарушало принцип fail-open.
+ *
+ * <p>Фикс: контейнер с {@code autoStartup=false}, реальный запуск — резильентный
+ * {@link CacheInvalidationListenerStarter} (try/catch + ретраи на {@code @Scheduled}).
+ * Поэтому недоступность Redis на старте больше не блокирует контекст: кэш деградирует на
+ * L1 + БД, а листенер поднимется сам, когда Redis вернётся.
+ *
+ * <p>Здесь Redis намеренно «мёртвый» — порт {@code 6390}, на котором никто не слушает
+ * (перекрывает live-Redis из {@link IntegrationTestBase} через {@code @TestPropertySource},
+ * у которого приоритет выше {@code @DynamicPropertySource}). two-level включён.
+ */
+@TestPropertySource(properties = {
+        "app.cache.two-level.enabled=true",
+        // Заведомо мёртвый Redis: порт, на котором никто не слушает.
+        "spring.data.redis.host=127.0.0.1",
+        "spring.data.redis.port=6390",
+        // Короткие таймауты, чтобы старт listener-контейнера падал быстро, а не висел.
+        "spring.data.redis.connect-timeout=200ms",
+        "spring.data.redis.timeout=200ms"
+})
+class CacheListenerFailOpenStartupIT extends IntegrationTestBase {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Test
+    void should_start_context_and_keep_cache_usable_when_redis_unavailable() {
+        // assert — контекст поднялся (этот тест вообще запустился = refresh прошёл),
+        // приложение живо несмотря на недоступный Redis.
+        assertThat(applicationContext).isNotNull();
+
+        // two-level-менеджер создан (фоллбэк-Caffeine НЕ активен при enabled=true),
+        // листенер сконфигурирован, но Redis недоступен — кэш деградирует на L1 + БД (fail-open).
+        assertThat(applicationContext.containsBean("twoLevelCacheManager")).isTrue();
+        assertThat(applicationContext.containsBean("cacheInvalidationListenerContainer")).isTrue();
+
+        // act + assert — кэш пригоден к использованию: загрузчик отрабатывает, значение
+        // кладётся в L1, повторное чтение берёт из кэша без повторного вызова загрузчика.
+        var cache = cacheManager.getCache("species-detail");
+        assertThat(cache).isNotNull();
+
+        int[] loaderCalls = {0};
+        String first = cache.get(99L, () -> {
+            loaderCalls[0]++;
+            return "loaded-99";
+        });
+        String second = cache.get(99L, () -> {
+            loaderCalls[0]++;
+            return "loaded-99";
+        });
+
+        assertThat(first).isEqualTo("loaded-99");
+        assertThat(second).isEqualTo("loaded-99");
+        assertThat(loaderCalls[0]).isEqualTo(1); // второе чтение — L1 hit, без загрузчика
+    }
+}

--- a/src/test/java/com/plantcare/core/cache/TwoLevelCacheIT.java
+++ b/src/test/java/com/plantcare/core/cache/TwoLevelCacheIT.java
@@ -4,6 +4,7 @@ import com.plantcare.bot.support.IntegrationTestBase;
 import com.plantcare.core.config.RedisProperties;
 import com.plantcare.core.config.TwoLevelCacheProperties;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.Cache;
@@ -57,7 +58,21 @@ class TwoLevelCacheIT extends IntegrationTestBase {
     @Autowired
     private RedisConnectionFactory connectionFactory;
 
+    @Autowired
+    private RedisMessageListenerContainer cacheInvalidationListenerContainer; // инстанс A: listener
+
     private RedisMessageListenerContainer instanceBContainer;
+
+    @BeforeEach
+    void ensureListenerStarted() {
+        // Issue #281 (fail-open): контейнер инвалидации теперь autoStartup=false и стартует на
+        // ApplicationReadyEvent через CacheInvalidationListenerStarter. К моменту теста событие
+        // уже прошло, но на всякий случай гарантируем, что подписка инстанса A активна, иначе
+        // кросс-инстансная инвалидация не дойдёт.
+        if (!cacheInvalidationListenerContainer.isRunning()) {
+            cacheInvalidationListenerContainer.start();
+        }
+    }
 
     @AfterEach
     void cleanup() throws Exception {
@@ -156,7 +171,7 @@ class TwoLevelCacheIT extends IntegrationTestBase {
 
     private static TwoLevelCacheProperties props() {
         return new TwoLevelCacheProperties(true, Duration.ofMinutes(5), 1000L,
-                Duration.ofHours(1), CHANNEL);
+                Duration.ofHours(1), CHANNEL, Duration.ofSeconds(5), Duration.ofSeconds(30));
     }
 
     /** Собирает второй «инстанс» (менеджер + его listener) поверх того же Redis. */


### PR DESCRIPTION
…, #277)

Дев-инцидент: бин cacheInvalidationListenerContainer (RedisMessageListenerContainer) стартовал синхронно во время refresh контекста. При недоступном Redis lazyListen бросал RedisConnectionFailureException из SmartLifecycle.start() → весь ApplicationContext не поднимался, приложение не стартовало. Это нарушало заявленный для #281 принцип fail-open (Redis-блип не должен класть прод).

Фикс:
- CacheConfig: контейнер с autoStartup=false (через override isAutoStartup(), т.к. setAutoStartup() у контейнера нет) — Spring не стартует его в refresh; recoveryInterval из проперти управляет переподпиской при разрыве уже установленного соединения.
- CacheInvalidationListenerStarter: резильентный стартер (two-level enabled, matchIfMissing=true). На ApplicationReadyEvent пробует start() в try/catch (WARN, контекст не падает); @Scheduled периодически проверяет !isRunning() и ретраит — листенер поднимется, когда Redis вернётся. Старт идемпотентен (не дублирует running).
- TwoLevelCacheProperties: новые поля recoveryInterval (5s) и listenerRetryInterval (30s) с дефолтами в компакт-конструкторе; проброшены в application.yml.

Доступность Redis больше не блокирует старт приложения: кэш деградирует на L1 + БД, листенер самовосстанавливается.

Тесты: новый CacheListenerFailOpenStartupIT — контекст поднимается при two-level.enabled=true и заведомо мёртвом Redis (порт 6390), кэш пригоден к использованию (L1 + загрузчик). TwoLevelCacheIT (Redis доступен) остаётся зелёным; добавлен @BeforeEach, гарантирующий запуск listener-контейнера инстанса A (autoStartup=false теперь).

mvn verify: 1779 тестов, 2 падения — оба пред-существующие host-TZ (PlantServiceTest#markCareDone, PlantScheduleServiceTest#non_utc, UTC+3; зелёные на CI UTC), 0 errors. Все cache/redis/ArchUnit + новый тест green.