### PR TITLE
feat(photos): S3-хранилище фото — Slice A of #90 (REST + сервис + конфиг)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,9 @@
         <sentry.version>7.22.5</sentry.version>
         <!-- Эпик #277 (фаза 1, #279): ShedLock 5.x совместим со Spring 6 / Boot 3.5.x. -->
         <shedlock.version>5.16.0</shedlock.version>
+        <!-- Issue #90 (Slice A): AWS SDK v2 для S3-совместимого object storage (Railway).
+             Лёгкий sync-клиент url-connection-client вместо netty-async (см. зависимости ниже). -->
+        <awssdk.version>2.30.18</awssdk.version>
 
         <!-- Sonar -->
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
@@ -211,6 +214,26 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+
+        <!-- Issue #90 (Slice A): S3-совместимое object storage (Railway) через AWS SDK v2.
+             netty-nio-client исключён в пользу url-connection-client (лёгкий sync-HTTP),
+             чтобы не тащить netty-async — нам достаточно простого синхронного клиента. -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>${awssdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            <version>${awssdk.version}</version>
         </dependency>
 
         <!-- Lombok -->

--- a/src/main/java/com/plantcare/PlantsCareApplication.java
+++ b/src/main/java/com/plantcare/PlantsCareApplication.java
@@ -3,6 +3,7 @@ package com.plantcare;
 import com.plantcare.api.ratelimit.ApiRateLimitProperties;
 import com.plantcare.core.config.CalendarProperties;
 import com.plantcare.core.config.HealthScoreProperties;
+import com.plantcare.core.config.S3StorageProperties;
 import com.plantcare.core.config.SpeciesProperties;
 import com.plantcare.bot.config.TelegramRateLimitProperties;
 import com.plantcare.core.config.TransplantSuggestionProperties;
@@ -17,7 +18,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication
 @EnableScheduling
 @EnableSchedulerLock(defaultLockAtMostFor = "PT1M")
-@EnableConfigurationProperties({SpeciesProperties.class, CalendarProperties.class, HealthScoreProperties.class, TelegramRateLimitProperties.class, TransplantSuggestionProperties.class, ApiRateLimitProperties.class})
+@EnableConfigurationProperties({SpeciesProperties.class, CalendarProperties.class, HealthScoreProperties.class, TelegramRateLimitProperties.class, TransplantSuggestionProperties.class, ApiRateLimitProperties.class, S3StorageProperties.class})
 public class PlantsCareApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/plantcare/api/ApiExceptionHandler.java
+++ b/src/main/java/com/plantcare/api/ApiExceptionHandler.java
@@ -5,6 +5,8 @@ import com.plantcare.api.auth.exception.GuestConvertException;
 import com.plantcare.api.auth.exception.RateLimitExceededException;
 import com.plantcare.api.dto.ApiErrorResponse;
 import com.plantcare.api.dto.FieldError;
+import com.plantcare.core.service.InvalidPhotoException;
+import com.plantcare.core.service.PhotoTooLargeException;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.ConstraintViolationException;
 import java.util.List;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.server.ResponseStatusException;
 
 /**
@@ -143,6 +146,26 @@ public class ApiExceptionHandler {
         String code = e.getStatusCode().value() == 410 ? "GONE" : e.getStatusCode().toString();
         return ResponseEntity.status(e.getStatusCode())
                 .body(ApiErrorResponse.of(code, e.getReason() != null ? e.getReason() : e.getMessage()));
+    }
+
+    /**
+     * Issue #90: загруженный файл не является валидным фото ({@code image/*}) или пустой → 400.
+     */
+    @ExceptionHandler(InvalidPhotoException.class)
+    public ResponseEntity<ApiErrorResponse> handleInvalidPhoto(InvalidPhotoException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiErrorResponse.of("INVALID_PHOTO", e.getMessage()));
+    }
+
+    /**
+     * Issue #90: размер фото превышает лимит → 413 Payload Too Large.
+     * {@link MaxUploadSizeExceededException} — когда лимит срабатывает на уровне
+     * multipart-резолвера ещё до контроллера.
+     */
+    @ExceptionHandler({PhotoTooLargeException.class, MaxUploadSizeExceededException.class})
+    public ResponseEntity<ApiErrorResponse> handlePhotoTooLarge(Exception e) {
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE)
+                .body(ApiErrorResponse.of("PAYLOAD_TOO_LARGE", "Uploaded file is too large"));
     }
 
     @ExceptionHandler(RuntimeException.class)

--- a/src/main/java/com/plantcare/api/v1/PhotoController.java
+++ b/src/main/java/com/plantcare/api/v1/PhotoController.java
@@ -1,0 +1,93 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.generated.PhotosApi;
+import com.plantcare.api.generated.model.PhotoUploadResponse;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.core.domain.Photo;
+import com.plantcare.core.service.InvalidPhotoException;
+import com.plantcare.core.service.PhotoService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * REST API хранилища фото в S3-совместимом бакете (issue #90, Slice A).
+ *
+ * <p>Документация и mapping живут в сгенерированном {@link PhotosApi}
+ * (см. openapi.yaml → resources/photos.yaml). Хендлер тонкий: текущего
+ * пользователя берёт из {@link CurrentUserProvider}, всю логику делегирует
+ * {@link PhotoService}.
+ *
+ * <ul>
+ *   <li>{@code POST /photos} — multipart upload, 201 с {@code { id, url }}.</li>
+ *   <li>{@code GET /photos/{id}} — 302 на presigned URL объекта.</li>
+ *   <li>{@code DELETE /photos/{id}} — soft-delete, 204.</li>
+ * </ul>
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class PhotoController implements PhotosApi {
+
+    private final PhotoService photoService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    public PhotoUploadResponse uploadPhoto(MultipartFile file) {
+        Long userId = currentUserProvider.currentUserId();
+
+        byte[] bytes = readBytes(file);
+        String contentType = file.getContentType();
+
+        Photo photo = photoService.upload(userId, bytes, contentType);
+        URL url = photoService.presignedUrl(userId, photo.getId());
+
+        return new PhotoUploadResponse(photo.getId(), url.toString());
+    }
+
+    @Override
+    public void getPhoto(Long id) {
+        Long userId = currentUserProvider.currentUserId();
+        URL url = photoService.presignedUrl(userId, id);
+
+        // Метод сгенерирован как void с @ResponseStatus(FOUND); ставим Location
+        // на текущем ответе. Сам редирект (302) проставляет @ResponseStatus.
+        HttpServletResponse response = currentResponse();
+        response.setHeader("Location", url.toString());
+    }
+
+    @Override
+    public void deletePhoto(Long id) {
+        Long userId = currentUserProvider.currentUserId();
+        photoService.softDelete(userId, id);
+    }
+
+    private static byte[] readBytes(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new InvalidPhotoException("Empty file");
+        }
+        try {
+            return file.getBytes();
+        } catch (IOException e) {
+            throw new InvalidPhotoException("Cannot read uploaded file");
+        }
+    }
+
+    private static HttpServletResponse currentResponse() {
+        ServletRequestAttributes attributes =
+                (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+        HttpServletResponse response = attributes.getResponse();
+        if (response == null) {
+            throw new IllegalStateException("No current HttpServletResponse");
+        }
+        return response;
+    }
+}

--- a/src/main/java/com/plantcare/api/v1/PhotoController.java
+++ b/src/main/java/com/plantcare/api/v1/PhotoController.java
@@ -16,6 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 
 /**
@@ -50,7 +51,7 @@ public class PhotoController implements PhotosApi {
         Photo photo = photoService.upload(userId, bytes, contentType);
         URL url = photoService.presignedUrl(userId, photo.getId());
 
-        return new PhotoUploadResponse(photo.getId(), url.toString());
+        return new PhotoUploadResponse(photo.getId(), URI.create(url.toString()));
     }
 
     @Override

--- a/src/main/java/com/plantcare/core/config/S3StorageConfig.java
+++ b/src/main/java/com/plantcare/core/config/S3StorageConfig.java
@@ -1,0 +1,71 @@
+package com.plantcare.core.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import java.net.URI;
+
+/**
+ * Бины S3-клиента и пресайнера для object storage фото (issue #90, Slice A).
+ *
+ * <p>Хранилище — S3-совместимое (Railway), НЕ настоящий AWS, поэтому:
+ * <ul>
+ *   <li>{@code forcePathStyle(true)} — path-style адресация (виртуальные хосты
+ *       бакета у не-AWS провайдеров обычно не настроены);</li>
+ *   <li>{@code endpointOverride} — если задан {@code AWS_ENDPOINT_URL};</li>
+ *   <li>{@link DefaultCredentialsProvider} — креды читаются из окружения
+ *       ({@code AWS_ACCESS_KEY_ID} / {@code AWS_SECRET_ACCESS_KEY}), не хардкодим;</li>
+ *   <li>{@link UrlConnectionHttpClient} — лёгкий синхронный HTTP-клиент вместо
+ *       netty-async (netty-nio-client исключён из зависимости s3 в pom).</li>
+ * </ul>
+ *
+ * <p>{@link S3Presigner} HTTP-вызовов не делает (только подписывает URL локально),
+ * поэтому httpClient ему не передаём.
+ */
+@Configuration
+public class S3StorageConfig {
+
+    @Bean
+    public SdkHttpClient s3HttpClient() {
+        return UrlConnectionHttpClient.builder().build();
+    }
+
+    @Bean
+    public S3Client s3Client(S3StorageProperties properties, SdkHttpClient s3HttpClient) {
+        S3ClientBuilder builder = S3Client.builder()
+                .region(Region.of(properties.getRegion()))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .httpClient(s3HttpClient)
+                .forcePathStyle(true);
+
+        if (properties.hasEndpointOverride()) {
+            builder = builder.endpointOverride(URI.create(properties.getEndpoint()));
+        }
+        return builder.build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner(S3StorageProperties properties) {
+        S3Presigner.Builder builder = S3Presigner.builder()
+                .region(Region.of(properties.getRegion()))
+                .credentialsProvider(DefaultCredentialsProvider.create());
+
+        if (properties.hasEndpointOverride()) {
+            builder = builder.endpointOverride(URI.create(properties.getEndpoint()));
+        }
+        // forcePathStyle через serviceConfiguration: на S3Presigner.Builder нет
+        // прямого forcePathStyle(...), путь задаётся через S3Configuration.
+        return builder
+                .serviceConfiguration(software.amazon.awssdk.services.s3.S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/com/plantcare/core/config/S3StorageProperties.java
+++ b/src/main/java/com/plantcare/core/config/S3StorageProperties.java
@@ -1,0 +1,55 @@
+package com.plantcare.core.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+/**
+ * Конфигурация S3-совместимого object storage для фото (issue #90, Slice A).
+ *
+ * <p>Хранилище — Railway (S3-совместимое), НЕ настоящий AWS. Поэтому критичны
+ * {@code endpoint} (endpointOverride) и path-style адресация на стороне клиента.
+ * Креды ({@code AWS_ACCESS_KEY_ID} / {@code AWS_SECRET_ACCESS_KEY}) сюда НЕ
+ * попадают — их читает напрямую {@code DefaultCredentialsProvider} из окружения.
+ *
+ * <ul>
+ *   <li>{@code bucket} — имя бакета ({@code AWS_S3_BUCKET_NAME}).</li>
+ *   <li>{@code endpoint} — URL S3-эндпоинта ({@code AWS_ENDPOINT_URL}); пустой =
+ *       не переопределять (дефолтный AWS-резолвинг).</li>
+ *   <li>{@code region} — регион ({@code AWS_DEFAULT_REGION}); SDK читает его и сам,
+ *       но клиенты собираем явно, поэтому дублируем здесь.</li>
+ *   <li>{@code maxUploadBytes} — верхний предел размера загружаемого фото (~5 МБ).</li>
+ *   <li>{@code presignTtl} — TTL пресайн-ссылки на GET.</li>
+ *   <li>{@code keyPrefix} — namespace-префикс ключей в бакете.</li>
+ * </ul>
+ */
+@Getter
+@AllArgsConstructor
+@ConfigurationProperties(prefix = "app.storage.s3")
+public class S3StorageProperties {
+
+    /** Имя бакета. */
+    private final String bucket;
+
+    /** Endpoint S3-совместимого хранилища. Пустая строка = не переопределять. */
+    private final String endpoint;
+
+    /** Регион. */
+    private final String region;
+
+    /** Максимальный размер загружаемого файла в байтах (дефолт ~5 МБ). */
+    private final long maxUploadBytes;
+
+    /** TTL пресайн-ссылки на скачивание. */
+    private final Duration presignTtl;
+
+    /** Namespace-префикс ключей в бакете (например, {@code photos/}). */
+    private final String keyPrefix;
+
+    /** {@code true}, если endpoint задан и его надо переопределить на клиенте. */
+    public boolean hasEndpointOverride() {
+        return endpoint != null && !endpoint.isBlank();
+    }
+}

--- a/src/main/java/com/plantcare/core/domain/Photo.java
+++ b/src/main/java/com/plantcare/core/domain/Photo.java
@@ -1,0 +1,93 @@
+package com.plantcare.core.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+/**
+ * Фото, хранящееся в S3-совместимом object storage (issue #90, Slice A).
+ *
+ * <p>Запись хранит метаданные объекта в бакете: namespaced {@code storageKey}
+ * (например, {@code photos/<uuid>}), MIME-тип, размер и владельца. Сам бинарь
+ * лежит в S3, не в БД.
+ *
+ * <p>Удаление — soft-delete: проставляем {@code deletedAt}, физический объект в
+ * бакете в этом срезе не трогаем (чистку делает отдельная batch-задача, Slice B+).
+ *
+ * <p>Не наследуем {@code BaseEntity}: там {@code created_at} — {@code LocalDateTime}
+ * через {@code @CreationTimestamp}. Здесь нужен {@code Instant} (UTC) для
+ * {@code created_at} и {@code deleted_at}, поэтому управляем id и временем вручную
+ * (как {@link UserDevice}).
+ */
+@Entity
+@Table(name = "photos")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Photo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Namespaced-ключ объекта в бакете, например {@code photos/<uuid>}. */
+    @Column(name = "storage_key", nullable = false, length = 512, unique = true)
+    private String storageKey;
+
+    /** MIME-тип загруженного файла ({@code image/...}). */
+    @Column(name = "content_type", nullable = false, length = 128)
+    private String contentType;
+
+    /** Размер объекта в байтах. */
+    @Column(name = "size_bytes", nullable = false)
+    private long sizeBytes;
+
+    /** Владелец фото ({@code users.id}). FK + ON DELETE CASCADE в миграции. */
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    /** Момент soft-delete; {@code null} — запись активна. */
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
+    public Photo(String storageKey, String contentType, long sizeBytes, Long userId, Instant now) {
+        this.storageKey = storageKey;
+        this.contentType = contentType;
+        this.sizeBytes = sizeBytes;
+        this.userId = userId;
+        this.createdAt = now;
+    }
+
+    /** Помечает запись удалённой (soft-delete). Идемпотентно — первый момент удаления сохраняется. */
+    public void markDeleted(Instant now) {
+        if (this.deletedAt == null) {
+            this.deletedAt = now;
+        }
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Photo that)) return false;
+        return id != null && id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+}

--- a/src/main/java/com/plantcare/core/repository/PhotoRepository.java
+++ b/src/main/java/com/plantcare/core/repository/PhotoRepository.java
@@ -1,0 +1,17 @@
+package com.plantcare.core.repository;
+
+import com.plantcare.core.domain.Photo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PhotoRepository extends JpaRepository<Photo, Long> {
+
+    /**
+     * Активное (не soft-deleted) фото по id для авторизованного владельца.
+     * Используется на GET/DELETE: чужое или удалённое не отдаём.
+     */
+    Optional<Photo> findByIdAndUserIdAndDeletedAtIsNull(Long id, Long userId);
+}

--- a/src/main/java/com/plantcare/core/service/InvalidPhotoException.java
+++ b/src/main/java/com/plantcare/core/service/InvalidPhotoException.java
@@ -1,0 +1,12 @@
+package com.plantcare.core.service;
+
+/**
+ * Загружаемый файл не является валидным фото (не {@code image/*} или пустой) —
+ * issue #90, Slice A. Маппится в HTTP 400 Bad Request.
+ */
+public class InvalidPhotoException extends RuntimeException {
+
+    public InvalidPhotoException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/plantcare/core/service/PhotoService.java
+++ b/src/main/java/com/plantcare/core/service/PhotoService.java
@@ -1,0 +1,88 @@
+package com.plantcare.core.service;
+
+import com.plantcare.core.config.S3StorageProperties;
+import com.plantcare.core.domain.Photo;
+import com.plantcare.core.repository.PhotoRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.URL;
+import java.time.Clock;
+import java.time.Instant;
+
+/**
+ * Бизнес-логика хранения фото (issue #90, Slice A).
+ *
+ * <p>Делегирует бинарь {@link PhotoStorageService} (S3), а метаданные пишет в
+ * {@code photos}. Валидирует тип ({@code image/*}) и размер (≤ {@code maxUploadBytes}).
+ * Удаление — soft-delete (проставляем {@code deleted_at}), физический объект в
+ * бакете не трогаем (чистка — отдельная задача, Slice B+).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PhotoService {
+
+    private final PhotoStorageService photoStorageService;
+    private final PhotoRepository photoRepository;
+    private final S3StorageProperties properties;
+    private final Clock clock;
+
+    /**
+     * Валидирует и сохраняет загруженное фото: кладёт байты в S3, создаёт запись.
+     *
+     * @throws InvalidPhotoException  если контент не {@code image/*} или пустой (HTTP 400)
+     * @throws PhotoTooLargeException если размер превышает лимит (HTTP 413)
+     */
+    @Transactional
+    public Photo upload(Long userId, byte[] bytes, String contentType) {
+        if (bytes == null || bytes.length == 0) {
+            throw new InvalidPhotoException("Empty file");
+        }
+        if (contentType == null || !contentType.toLowerCase().startsWith("image/")) {
+            throw new InvalidPhotoException("Unsupported content type: " + contentType);
+        }
+        if (bytes.length > properties.getMaxUploadBytes()) {
+            throw new PhotoTooLargeException(bytes.length, properties.getMaxUploadBytes());
+        }
+
+        StoredPhoto stored = photoStorageService.put(bytes, contentType);
+
+        Photo photo = photoRepository.save(
+                new Photo(stored.storageKey(), contentType, stored.sizeBytes(), userId, Instant.now(clock)));
+        log.info("Created photo {} for user {} key={}", photo.getId(), userId, stored.storageKey());
+        return photo;
+    }
+
+    /**
+     * Пресайн-URL на скачивание активного фото пользователя.
+     *
+     * @throws EntityNotFoundException если фото нет, оно чужое или soft-deleted (HTTP 404)
+     */
+    @Transactional(readOnly = true)
+    public URL presignedUrl(Long userId, Long photoId) {
+        Photo photo = requireActive(userId, photoId);
+        return photoStorageService.presignedGetUrl(photo.getStorageKey());
+    }
+
+    /**
+     * Soft-delete фото пользователя. Идемпотентно для уже удалённого: повторный
+     * вызов вернёт 404 (запись уже не активна).
+     *
+     * @throws EntityNotFoundException если фото нет, оно чужое или уже удалено (HTTP 404)
+     */
+    @Transactional
+    public void softDelete(Long userId, Long photoId) {
+        Photo photo = requireActive(userId, photoId);
+        photo.markDeleted(Instant.now(clock));
+        log.info("Soft-deleted photo {} for user {}", photoId, userId);
+    }
+
+    private Photo requireActive(Long userId, Long photoId) {
+        return photoRepository.findByIdAndUserIdAndDeletedAtIsNull(photoId, userId)
+                .orElseThrow(() -> new EntityNotFoundException("Photo not found: " + photoId));
+    }
+}

--- a/src/main/java/com/plantcare/core/service/PhotoStorageService.java
+++ b/src/main/java/com/plantcare/core/service/PhotoStorageService.java
@@ -1,0 +1,31 @@
+package com.plantcare.core.service;
+
+import java.net.URL;
+
+/**
+ * Хранилище бинарного контента фото в S3-совместимом бакете (issue #90, Slice A).
+ *
+ * <p>Работает на уровне «байты ↔ ключ объекта», метаданные ({@code Photo}-entity)
+ * и бизнес-правила (валидация типа/размера, владелец) — уровнем выше, в
+ * {@code PhotoService}. Реализация — {@link S3PhotoStorage}.
+ */
+public interface PhotoStorageService {
+
+    /**
+     * Загружает байты в бакет под сгенерированным namespaced-ключом.
+     *
+     * @param bytes       содержимое объекта
+     * @param contentType MIME-тип ({@code image/...})
+     * @return ключ созданного объекта и его размер
+     */
+    StoredPhoto put(byte[] bytes, String contentType);
+
+    /**
+     * Пресайн-URL на GET объекта по ключу (TTL из конфигурации).
+     * URL временный и не требует авторизации у клиента.
+     */
+    URL presignedGetUrl(String storageKey);
+
+    /** Удаляет объект из бакета по ключу. В Slice A на основном флоу не вызывается (soft-delete). */
+    void delete(String storageKey);
+}

--- a/src/main/java/com/plantcare/core/service/PhotoTooLargeException.java
+++ b/src/main/java/com/plantcare/core/service/PhotoTooLargeException.java
@@ -1,0 +1,12 @@
+package com.plantcare.core.service;
+
+/**
+ * Загружаемое фото превышает лимит размера (issue #90, Slice A).
+ * Маппится в HTTP 413 Payload Too Large.
+ */
+public class PhotoTooLargeException extends RuntimeException {
+
+    public PhotoTooLargeException(long sizeBytes, long maxBytes) {
+        super("Photo too large: " + sizeBytes + " bytes (max " + maxBytes + ")");
+    }
+}

--- a/src/main/java/com/plantcare/core/service/S3PhotoStorage.java
+++ b/src/main/java/com/plantcare/core/service/S3PhotoStorage.java
@@ -1,0 +1,86 @@
+package com.plantcare.core.service;
+
+import com.plantcare.core.config.S3StorageProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+import java.net.URL;
+import java.util.UUID;
+
+/**
+ * Реализация {@link PhotoStorageService} поверх AWS SDK v2 для S3-совместимого
+ * хранилища (issue #90, Slice A).
+ *
+ * <p>Ключи namespaced: {@code <keyPrefix><uuid>} (например, {@code photos/<uuid>}).
+ * GET отдаётся как пресайн-ссылка с TTL из {@link S3StorageProperties}.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3PhotoStorage implements PhotoStorageService {
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+    private final S3StorageProperties properties;
+
+    @Override
+    public StoredPhoto put(byte[] bytes, String contentType) {
+        String key = buildKey();
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(properties.getBucket())
+                .key(key)
+                .contentType(contentType)
+                .contentLength((long) bytes.length)
+                .build();
+
+        s3Client.putObject(request, RequestBody.fromBytes(bytes));
+        log.info("Stored photo object key={} bytes={} contentType={}", key, bytes.length, contentType);
+
+        return new StoredPhoto(key, bytes.length);
+    }
+
+    @Override
+    public URL presignedGetUrl(String storageKey) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(properties.getBucket())
+                .key(storageKey)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(properties.getPresignTtl())
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        return s3Presigner.presignGetObject(presignRequest).url();
+    }
+
+    @Override
+    public void delete(String storageKey) {
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(properties.getBucket())
+                .key(storageKey)
+                .build();
+
+        s3Client.deleteObject(request);
+        log.info("Deleted photo object key={}", storageKey);
+    }
+
+    private String buildKey() {
+        String prefix = properties.getKeyPrefix();
+        if (prefix == null || prefix.isBlank()) {
+            prefix = "photos/";
+        } else if (!prefix.endsWith("/")) {
+            prefix = prefix + "/";
+        }
+        return prefix + UUID.randomUUID();
+    }
+}

--- a/src/main/java/com/plantcare/core/service/StoredPhoto.java
+++ b/src/main/java/com/plantcare/core/service/StoredPhoto.java
@@ -1,0 +1,10 @@
+package com.plantcare.core.service;
+
+/**
+ * Результат загрузки объекта в бакет (issue #90, Slice A): namespaced-ключ и размер.
+ *
+ * @param storageKey ключ объекта в бакете (например, {@code photos/<uuid>})
+ * @param sizeBytes  размер записанного объекта в байтах
+ */
+public record StoredPhoto(String storageKey, long sizeBytes) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,15 @@ spring:
           time_zone: UTC
         format_sql: false
 
+  # Issue #90 (Slice A): загрузка фото (multipart). Дефолт Spring — 1 МБ, мал для фото.
+  # Ставим чуть выше прикладного лимита (~5 МБ из app.storage.s3.max-upload-bytes),
+  # чтобы файлы около лимита доходили до контроллера и отдавали чистый 413
+  # (PhotoTooLargeException), а не обрезались резолвером multipart.
+  servlet:
+    multipart:
+      max-file-size: ${PHOTO_MULTIPART_MAX_FILE_SIZE:6MB}
+      max-request-size: ${PHOTO_MULTIPART_MAX_REQUEST_SIZE:8MB}
+
   # Issue #88: SMTP для magic-link писем. Реальные креды только из env.
   mail:
     host: ${MAIL_HOST:localhost}
@@ -62,6 +71,19 @@ spring:
 app:
   species:
     search-limit: 5
+
+  # Issue #90 (Slice A): S3-совместимое object storage фото (Railway).
+  # Креды (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY) читает DefaultCredentialsProvider
+  # из окружения — здесь их НЕТ. endpoint пустой = не переопределять (дефолтный AWS-резолвинг).
+  # На S3-совместимых провайдерах endpoint обязателен (AWS_ENDPOINT_URL) + path-style на клиенте.
+  storage:
+    s3:
+      bucket: ${AWS_S3_BUCKET_NAME:}
+      endpoint: ${AWS_ENDPOINT_URL:}
+      region: ${AWS_DEFAULT_REGION:us-east-1}
+      max-upload-bytes: ${PHOTO_MAX_UPLOAD_BYTES:5242880}   # ~5 МБ
+      presign-ttl: ${PHOTO_PRESIGN_TTL:PT15M}
+      key-prefix: ${PHOTO_KEY_PREFIX:photos/}
 
   # Issue #278, эпик #277 фаза 0: параметры Lettuce-клиента и namespacing ключей.
   redis:

--- a/src/main/resources/db/migration/V53__create_photos.sql
+++ b/src/main/resources/db/migration/V53__create_photos.sql
@@ -1,0 +1,38 @@
+-- V53__create_photos.sql
+-- Issue #90 (Slice A): REST-хранилище фото в S3-совместимом бакете (Railway).
+--
+-- Таблица метаданных фото. Сам бинарь лежит в object storage (S3-совместимый
+-- бакет), здесь храним только namespaced ключ объекта (storage_key вида
+-- photos/<uuid>), MIME-тип, размер и владельца.
+--
+-- Удаление — soft-delete: проставляем deleted_at, физический объект в бакете в
+-- этом срезе не трогаем (чистку делает отдельная batch-задача, вне Slice A).
+--
+-- Backward-compat note:
+--   * Новая таблица — для старого кода невидима (аддитивно, один релиз).
+--   * id маппится JPA как GenerationType.IDENTITY → BIGSERIAL.
+--   * created_at / deleted_at — TIMESTAMPTZ (UTC), как везде; маппятся в Instant.
+--   * ON DELETE CASCADE на user_id: удаление пользователя убирает его фото-записи.
+--   * Существующие plants.photo_file_id / plant_progress_photos.telegram_file_id
+--     НЕ трогаем — миграция Telegram-фото это отдельный срез (Slice B).
+--   * Только DDL, без сидинга. Безопасно для rolling deploy.
+
+CREATE TABLE photos (
+    id           BIGSERIAL    PRIMARY KEY,
+    storage_key  VARCHAR(512) NOT NULL UNIQUE,
+    content_type VARCHAR(128) NOT NULL,
+    size_bytes   BIGINT       NOT NULL,
+    user_id      BIGINT       NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    deleted_at   TIMESTAMPTZ
+);
+
+COMMENT ON TABLE  photos              IS 'Метаданные фото в S3-совместимом бакете (issue #90). Бинарь — в object storage, не в БД.';
+COMMENT ON COLUMN photos.storage_key  IS 'Namespaced-ключ объекта в бакете, например photos/<uuid>.';
+COMMENT ON COLUMN photos.content_type IS 'MIME-тип загруженного фото (image/...).';
+COMMENT ON COLUMN photos.size_bytes   IS 'Размер объекта в байтах.';
+COMMENT ON COLUMN photos.user_id      IS 'Владелец фото (users.id).';
+COMMENT ON COLUMN photos.deleted_at   IS 'Момент soft-delete; NULL — запись активна.';
+
+-- Выборка активных фото пользователя (GET/DELETE: findByIdAndUserIdAndDeletedAtIsNull).
+CREATE INDEX idx_photos_user_active ON photos (user_id) WHERE deleted_at IS NULL;

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -149,6 +149,11 @@ tags:
       Пользовательские шаблоны растений (issue #254): сохранение набора интервалов
       ухода из существующего растения, быстрое создание нового растения по шаблону.
       Максимум 30 шаблонов на пользователя.
+  - name: Photos
+    description: |
+      Хранилище фото в S3-совместимом бакете (issue #90, Slice A): загрузка
+      (multipart), выдача через presigned URL (302 redirect) и soft-delete.
+      Все эндпоинты требуют bearer-токен.
 
 paths:
   /api/v1/auth/apple:
@@ -310,6 +315,11 @@ paths:
 
   /api/v1/ui/{screen}:
     $ref: './resources/ui.yaml#/paths/Screen'
+
+  /api/v1/photos:
+    $ref: './resources/photos.yaml#/paths/Collection'
+  /api/v1/photos/{id}:
+    $ref: './resources/photos.yaml#/paths/Item'
 
 components:
   securitySchemes:
@@ -559,6 +569,9 @@ components:
 
     ScreenLayout:
       $ref: './resources/ui.yaml#/schemas/ScreenLayout'
+
+    PhotoUploadResponse:
+      $ref: './resources/photos.yaml#/schemas/PhotoUploadResponse'
 
     ApiErrorResponse:
       $ref: './_common/errors.yaml#/schemas/ApiErrorResponse'

--- a/src/main/resources/openapi/resources/photos.yaml
+++ b/src/main/resources/openapi/resources/photos.yaml
@@ -1,0 +1,120 @@
+# Хранилище фото в S3-совместимом бакете (issue #90, Slice A). Требует bearer-токен.
+
+paths:
+  Collection:
+    post:
+      tags: [Photos]
+      operationId: uploadPhoto
+      summary: Загрузить фото
+      description: |
+        Загружает фото текущего пользователя (из bearer-токена) в S3-совместимый
+        бакет и возвращает его `id` и presigned `url` на скачивание.
+
+        Принимается только `image/*`. Размер ограничен сервером (~5 МБ);
+        превышение → 413. Невалидный тип / пустой файл → 400.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: Файл изображения (image/*).
+      responses:
+        '201':
+          description: Фото загружено.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/PhotoUploadResponse'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+        '413':
+          description: Файл превышает допустимый размер.
+          content:
+            application/json:
+              schema:
+                $ref: '../_common/errors.yaml#/schemas/ApiErrorResponse'
+
+  Item:
+    get:
+      tags: [Photos]
+      operationId: getPhoto
+      summary: Получить фото (redirect на presigned URL)
+      description: |
+        Возвращает `302 Found` с заголовком `Location`, указывающим на свежий
+        presigned URL объекта в бакете. 404, если фото нет, оно чужое или удалено.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Идентификатор фото.
+          schema:
+            type: integer
+            format: int64
+            example: 42
+      responses:
+        '302':
+          description: Redirect на presigned URL объекта.
+          headers:
+            Location:
+              description: Presigned URL для скачивания фото.
+              schema:
+                type: string
+                format: uri
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+    delete:
+      tags: [Photos]
+      operationId: deletePhoto
+      summary: Удалить фото (soft-delete)
+      description: |
+        Помечает фото удалённым (soft-delete). Объект в бакете в этом срезе не
+        чистится. Чужое, несуществующее или уже удалённое фото → 404.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Идентификатор фото.
+          schema:
+            type: integer
+            format: int64
+            example: 42
+      responses:
+        '204':
+          description: Фото помечено удалённым.
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+schemas:
+  PhotoUploadResponse:
+    type: object
+    description: Результат загрузки фото.
+    required: [id, url]
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Идентификатор созданной записи фото.
+        example: 42
+      url:
+        type: string
+        format: uri
+        description: Presigned URL для скачивания загруженного фото.
+        example: https://bucket.example.com/photos/3f2a...?X-Amz-Signature=...

--- a/src/test/java/com/plantcare/api/v1/PhotoControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/PhotoControllerTest.java
@@ -1,0 +1,148 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.core.domain.Photo;
+import com.plantcare.core.service.PhotoService;
+import com.plantcare.core.service.PhotoTooLargeException;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.net.URL;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * {@code @WebMvcTest} для {@link PhotoController} (issue #90, Slice A).
+ *
+ * <p>POST /api/v1/photos: 201 + {@code { id, url }}; превышение размера → 413.
+ * GET /api/v1/photos/{id}: 302 c presigned URL в Location; 404 на чужое/удалённое.
+ * DELETE /api/v1/photos/{id}: 204; 404 на чужое/удалённое.
+ */
+@WebMvcTest(PhotoController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PhotoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PhotoService photoService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    @BeforeEach
+    void stubCurrentUser() {
+        when(currentUserProvider.currentUserId()).thenReturn(1L);
+    }
+
+    private static MockMultipartFile imageFile() {
+        return new MockMultipartFile("file", "plant.jpg", "image/jpeg", new byte[]{1, 2, 3, 4});
+    }
+
+    // ------------------------------------------------------------------ POST /api/v1/photos
+
+    @Test
+    void should_return_201_with_id_and_url_when_upload_succeeds() throws Exception {
+        // arrange
+        Photo photo = mock(Photo.class);
+        when(photo.getId()).thenReturn(42L);
+        when(photoService.upload(eq(1L), any(byte[].class), eq("image/jpeg"))).thenReturn(photo);
+        when(photoService.presignedUrl(1L, 42L))
+                .thenReturn(new URL("https://s3.example.com/test-bucket/photos/abc?sig=1"));
+
+        // act + assert
+        mockMvc.perform(multipart("/api/v1/photos").file(imageFile()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(42))
+                .andExpect(jsonPath("$.url").value("https://s3.example.com/test-bucket/photos/abc?sig=1"));
+
+        verify(photoService).upload(eq(1L), any(byte[].class), eq("image/jpeg"));
+    }
+
+    @Test
+    void should_return_413_when_file_too_large() throws Exception {
+        // arrange
+        when(photoService.upload(eq(1L), any(byte[].class), eq("image/jpeg")))
+                .thenThrow(new PhotoTooLargeException(9_000_000L, 5_242_880L));
+
+        // act + assert
+        mockMvc.perform(multipart("/api/v1/photos").file(imageFile()))
+                .andExpect(status().isPayloadTooLarge())
+                .andExpect(jsonPath("$.error.code").value("PAYLOAD_TOO_LARGE"));
+    }
+
+    // ------------------------------------------------------------------ GET /api/v1/photos/{id}
+
+    @Test
+    void should_return_302_redirect_to_presigned_url() throws Exception {
+        // arrange
+        when(photoService.presignedUrl(1L, 42L))
+                .thenReturn(new URL("https://s3.example.com/test-bucket/photos/abc?sig=1"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/photos/42"))
+                .andExpect(status().isFound())
+                .andExpect(header().string("Location", "https://s3.example.com/test-bucket/photos/abc?sig=1"));
+    }
+
+    @Test
+    void should_return_404_when_getting_missing_or_foreign_photo() throws Exception {
+        // arrange
+        when(photoService.presignedUrl(1L, 99L))
+                .thenThrow(new EntityNotFoundException("Photo not found: 99"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/photos/99"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // ------------------------------------------------------------------ DELETE /api/v1/photos/{id}
+
+    @Test
+    void should_return_204_when_soft_deleting_own_photo() throws Exception {
+        // arrange
+        doNothing().when(photoService).softDelete(1L, 42L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/photos/42"))
+                .andExpect(status().isNoContent());
+
+        verify(photoService).softDelete(1L, 42L);
+    }
+
+    @Test
+    void should_return_404_when_deleting_missing_or_already_deleted_photo() throws Exception {
+        // arrange
+        doThrow(new EntityNotFoundException("Photo not found: 99"))
+                .when(photoService).softDelete(1L, 99L);
+
+        // act + assert
+        mockMvc.perform(delete("/api/v1/photos/99"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+}

--- a/src/test/java/com/plantcare/core/service/PhotoServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/PhotoServiceTest.java
@@ -1,0 +1,156 @@
+package com.plantcare.core.service;
+
+import com.plantcare.core.config.S3StorageProperties;
+import com.plantcare.core.domain.Photo;
+import com.plantcare.core.repository.PhotoRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.URL;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Юнит-тест {@link PhotoService} (issue #90): валидация типа/размера, soft-delete,
+ * 404 на чужое/удалённое. Хранилище и репозиторий — моки.
+ */
+@ExtendWith(MockitoExtension.class)
+class PhotoServiceTest {
+
+    private static final Instant NOW = Instant.parse("2026-06-08T12:00:00Z");
+
+    @Mock
+    private PhotoStorageService photoStorageService;
+
+    @Mock
+    private PhotoRepository photoRepository;
+
+    private PhotoService photoService;
+
+    @BeforeEach
+    void setUp() {
+        S3StorageProperties properties = new S3StorageProperties(
+                "test-bucket", "https://s3.example.com", "us-east-1",
+                10L, Duration.ofMinutes(15), "photos/");
+        Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+        photoService = new PhotoService(photoStorageService, photoRepository, properties, clock);
+    }
+
+    @Test
+    void should_store_and_persist_when_valid_image() {
+        // arrange
+        byte[] bytes = new byte[]{1, 2, 3};
+        when(photoStorageService.put(bytes, "image/jpeg"))
+                .thenReturn(new StoredPhoto("photos/abc", 3L));
+        when(photoRepository.save(any(Photo.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        // act
+        Photo photo = photoService.upload(1L, bytes, "image/jpeg");
+
+        // assert
+        assertThat(photo.getStorageKey()).isEqualTo("photos/abc");
+        assertThat(photo.getContentType()).isEqualTo("image/jpeg");
+        assertThat(photo.getSizeBytes()).isEqualTo(3L);
+        assertThat(photo.getUserId()).isEqualTo(1L);
+        assertThat(photo.getCreatedAt()).isEqualTo(NOW);
+        verify(photoStorageService).put(bytes, "image/jpeg");
+        verify(photoRepository).save(any(Photo.class));
+    }
+
+    @Test
+    void should_reject_non_image_content_type_with_invalid_photo() {
+        // arrange
+        byte[] bytes = new byte[]{1, 2, 3};
+
+        // act + assert
+        assertThatThrownBy(() -> photoService.upload(1L, bytes, "application/pdf"))
+                .isInstanceOf(InvalidPhotoException.class);
+
+        verify(photoStorageService, never()).put(any(), any());
+        verify(photoRepository, never()).save(any());
+    }
+
+    @Test
+    void should_reject_empty_file_with_invalid_photo() {
+        // act + assert
+        assertThatThrownBy(() -> photoService.upload(1L, new byte[0], "image/png"))
+                .isInstanceOf(InvalidPhotoException.class);
+    }
+
+    @Test
+    void should_reject_oversized_file_with_too_large() {
+        // arrange — лимит 10 байт, шлём 11
+        byte[] bytes = new byte[11];
+
+        // act + assert
+        assertThatThrownBy(() -> photoService.upload(1L, bytes, "image/png"))
+                .isInstanceOf(PhotoTooLargeException.class);
+
+        verify(photoStorageService, never()).put(any(), any());
+    }
+
+    @Test
+    void should_return_presigned_url_for_active_photo() throws Exception {
+        // arrange
+        Photo photo = new Photo("photos/abc", "image/png", 3L, 1L, NOW);
+        URL url = new URL("https://s3.example.com/test-bucket/photos/abc?sig=1");
+        when(photoRepository.findByIdAndUserIdAndDeletedAtIsNull(42L, 1L)).thenReturn(Optional.of(photo));
+        when(photoStorageService.presignedGetUrl("photos/abc")).thenReturn(url);
+
+        // act
+        URL result = photoService.presignedUrl(1L, 42L);
+
+        // assert
+        assertThat(result).isEqualTo(url);
+    }
+
+    @Test
+    void should_throw_not_found_when_presigning_missing_or_foreign_photo() {
+        // arrange
+        when(photoRepository.findByIdAndUserIdAndDeletedAtIsNull(eq(99L), eq(1L)))
+                .thenReturn(Optional.empty());
+
+        // act + assert
+        assertThatThrownBy(() -> photoService.presignedUrl(1L, 99L))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void should_soft_delete_active_photo() {
+        // arrange
+        Photo photo = new Photo("photos/abc", "image/png", 3L, 1L, NOW);
+        when(photoRepository.findByIdAndUserIdAndDeletedAtIsNull(42L, 1L)).thenReturn(Optional.of(photo));
+
+        // act
+        photoService.softDelete(1L, 42L);
+
+        // assert
+        assertThat(photo.isDeleted()).isTrue();
+        assertThat(photo.getDeletedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    void should_throw_not_found_when_deleting_missing_or_already_deleted_photo() {
+        // arrange — уже удалённое не находится фильтром deleted_at IS NULL
+        when(photoRepository.findByIdAndUserIdAndDeletedAtIsNull(99L, 1L)).thenReturn(Optional.empty());
+
+        // act + assert
+        assertThatThrownBy(() -> photoService.softDelete(1L, 99L))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+}

--- a/src/test/java/com/plantcare/core/service/S3PhotoStorageTest.java
+++ b/src/test/java/com/plantcare/core/service/S3PhotoStorageTest.java
@@ -1,0 +1,100 @@
+package com.plantcare.core.service;
+
+import com.plantcare.core.config.S3StorageProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.net.URL;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Юнит-тест {@link S3PhotoStorage} с моками S3-клиента и пресайнера (issue #90).
+ * LocalStack намеренно не поднимаем — проверяем построение запросов к SDK.
+ */
+@ExtendWith(MockitoExtension.class)
+class S3PhotoStorageTest {
+
+    @Mock
+    private S3Client s3Client;
+
+    @Mock
+    private S3Presigner s3Presigner;
+
+    private S3PhotoStorage storage;
+
+    @BeforeEach
+    void setUp() {
+        S3StorageProperties properties = new S3StorageProperties(
+                "test-bucket", "https://s3.example.com", "us-east-1",
+                5_242_880L, Duration.ofMinutes(15), "photos/");
+        storage = new S3PhotoStorage(s3Client, s3Presigner, properties);
+    }
+
+    @Test
+    void should_put_object_with_namespaced_key_and_metadata() {
+        // arrange
+        byte[] bytes = new byte[]{1, 2, 3, 4};
+
+        // act
+        StoredPhoto stored = storage.put(bytes, "image/png");
+
+        // assert
+        ArgumentCaptor<PutObjectRequest> requestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(s3Client).putObject(requestCaptor.capture(), any(RequestBody.class));
+
+        PutObjectRequest request = requestCaptor.getValue();
+        assertThat(request.bucket()).isEqualTo("test-bucket");
+        assertThat(request.key()).startsWith("photos/");
+        assertThat(request.contentType()).isEqualTo("image/png");
+        assertThat(request.contentLength()).isEqualTo(4L);
+
+        assertThat(stored.storageKey()).startsWith("photos/");
+        assertThat(stored.sizeBytes()).isEqualTo(4L);
+    }
+
+    @Test
+    void should_return_presigned_url_for_key() throws Exception {
+        // arrange
+        URL expectedUrl = new URL("https://s3.example.com/test-bucket/photos/abc?X-Amz-Signature=xyz");
+        PresignedGetObjectRequest presigned = org.mockito.Mockito.mock(PresignedGetObjectRequest.class);
+        when(presigned.url()).thenReturn(expectedUrl);
+        when(s3Presigner.presignGetObject(any(GetObjectPresignRequest.class))).thenReturn(presigned);
+
+        // act
+        URL url = storage.presignedGetUrl("photos/abc");
+
+        // assert
+        assertThat(url).isEqualTo(expectedUrl);
+        verify(s3Presigner).presignGetObject(any(GetObjectPresignRequest.class));
+    }
+
+    @Test
+    void should_delete_object_by_key() {
+        // act
+        storage.delete("photos/abc");
+
+        // assert
+        ArgumentCaptor<DeleteObjectRequest> requestCaptor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+        verify(s3Client).deleteObject(requestCaptor.capture());
+
+        DeleteObjectRequest request = requestCaptor.getValue();
+        assertThat(request.bucket()).isEqualTo("test-bucket");
+        assertThat(request.key()).isEqualTo("photos/abc");
+    }
+}


### PR DESCRIPTION
## Slice A issue #90 — хранилище фото в S3-совместимом Railway-бакете

Новые фото мобайла/API хранятся в S3. **Отложено в отдельные срезы:** миграция существующих Telegram-фото (Slice B), переключение бота (Slice C). `plants.photo_file_id` / `plant_progress_photos.telegram_file_id` не трогаются.

### Что внутри
- **pom:** `awssdk:s3` 2.30.18 (netty-nio-client исключён) + `url-connection-client` (лёгкий sync-HTTP).
- **core/config:** `S3StorageProperties` (`app.storage.s3`) + `S3StorageConfig` — `S3Client`/`S3Presigner` с `DefaultCredentialsProvider`, `forcePathStyle(true)`, `endpointOverride`, `UrlConnectionHttpClient`.
- **core/service:** `PhotoStorageService` + `S3PhotoStorage` (put / presigned-get / delete), `PhotoService`, домен `Photo` + репозиторий.
- **Flyway** `V53__create_photos.sql` (storage_key, content_type, size, owner, soft-delete).
- **api:** `PhotoController` — `POST /api/v1/photos` (multipart, ≤5MB), `GET /{id}` (302 presigned), `DELETE /{id}` (soft). OpenAPI `photos.yaml`.
- **Тесты:** PhotoControllerTest (WebMvcTest), PhotoServiceTest + S3PhotoStorageTest (мок S3, без LocalStack).

### Env-контракт (владелец задал на dev)
`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (→ DefaultCredentialsProvider), `AWS_DEFAULT_REGION`, `AWS_ENDPOINT_URL` (→ endpointOverride), `AWS_S3_BUCKET_NAME`.

### ⚠️ Верификация
Локально не собрать (AWS SDK не резолвится в окружении — нет Maven Central, `url-connection-client` отсутствует в `~/.m2`). **Верифицирует CI** (`build` на PR→develop, после #299). Вычитано глазами; ключевые грабли проверены: нет `@Bean ObjectMapper`, ArchUnit core∌api/bot/admin, V53 без коллизии, forcePathStyle включён.

Разблокирует mobile #253 (фото-прогресс). auto-merge НЕ включён — мержит человек по зелёному build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)