### PR TITLE
feat(api): REST API фото-прогресса растения (#253)

### DIFF
--- a/src/main/java/com/plantcare/api/v1/PhotoProgressController.java
+++ b/src/main/java/com/plantcare/api/v1/PhotoProgressController.java
@@ -1,0 +1,161 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.api.generated.PhotoProgressApi;
+import com.plantcare.api.generated.model.PhotoProgressCompareResponse;
+import com.plantcare.api.generated.model.PhotoProgressFrequencyRequest;
+import com.plantcare.api.generated.model.PhotoProgressFrequencyResponse;
+import com.plantcare.api.generated.model.PhotoProgressFrequencyValue;
+import com.plantcare.api.generated.model.PhotoProgressHistoryResponse;
+import com.plantcare.api.generated.model.PhotoProgressItemDto;
+import com.plantcare.core.domain.Photo;
+import com.plantcare.core.domain.Plant;
+import com.plantcare.core.domain.PlantProgressPhoto;
+import com.plantcare.core.domain.enums.PhotoProgressFrequency;
+import com.plantcare.core.service.InvalidPhotoException;
+import com.plantcare.core.service.PhotoProgressService;
+import com.plantcare.core.service.PhotoProgressService.PhotoPair;
+import com.plantcare.core.service.PhotoService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.time.ZoneOffset;
+import java.util.List;
+
+/**
+ * REST API фото-дневника растения (issue #253): добавление снимков прогресса,
+ * история, сравнение «до/после» и частота напоминаний о фото.
+ *
+ * <p>Контроллер тонкий: загрузку бинаря делегирует {@link PhotoService} (S3,
+ * issue #90), бизнес-логику таймлайна — {@link PhotoProgressService}. Текущего
+ * пользователя берёт из {@link CurrentUserProvider}. Документация и mapping —
+ * в сгенерированном {@link PhotoProgressApi} (см. openapi.yaml →
+ * resources/plant-photo-progress.yaml).
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class PhotoProgressController implements PhotoProgressApi {
+
+    private final PhotoProgressService photoProgressService;
+    private final PhotoService photoService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    @ResponseStatus(HttpStatus.CREATED)
+    public PhotoProgressItemDto addPhotoProgress(Long id, MultipartFile file, String caption) {
+        Long userId = currentUserProvider.currentUserId();
+
+        byte[] bytes = readBytes(file);
+        String contentType = file.getContentType();
+
+        // Бинарь — в S3 (валидация типа/размера внутри PhotoService), затем ссылка
+        // в таймлайн через PhotoProgressService (ownership/анти-спам внутри).
+        Photo photo = photoService.upload(userId, bytes, contentType);
+        PlantProgressPhoto saved =
+                photoProgressService.addPhotoFromStorage(userId, id, photo, caption);
+
+        log.info("POST /api/v1/plants/{}/photo-progress: userId={} progressPhotoId={} photoId={}",
+                id, userId, saved.getId(), photo.getId());
+
+        return toDto(userId, saved);
+    }
+
+    @Override
+    public PhotoProgressHistoryResponse getPhotoProgressHistory(Long id, Integer limit, Integer offset) {
+        Long userId = currentUserProvider.currentUserId();
+
+        // limit валидирован [1,100] на входе (@Min/@Max). Сервис страницей по
+        // HISTORY_PAGE_SIZE не умеет произвольный limit — берём окно вручную через
+        // offset/limit поверх полного таймлайна растения.
+        int safeOffset = Math.max(0, offset);
+
+        long total = photoProgressService.countHistory(userId, id);
+        List<PlantProgressPhoto> all = photoProgressService.getRecent(userId, id, safeOffset + limit);
+
+        List<PhotoProgressItemDto> items = all.stream()
+                .skip(safeOffset)
+                .limit(limit)
+                .map(p -> toDto(userId, p))
+                .toList();
+
+        log.info("GET /api/v1/plants/{}/photo-progress: userId={} limit={} offset={} total={}",
+                id, userId, limit, safeOffset, total);
+
+        return new PhotoProgressHistoryResponse(items, total, limit, safeOffset);
+    }
+
+    @Override
+    public PhotoProgressCompareResponse comparePhotoProgress(Long id, Long from, Long to) {
+        Long userId = currentUserProvider.currentUserId();
+
+        PhotoPair pair = photoProgressService.compareByIds(userId, id, from, to)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Photo pair not found for plant " + id + ": from=" + from + " to=" + to));
+
+        log.info("GET /api/v1/plants/{}/photo-progress/compare: userId={} from={} to={}",
+                id, userId, from, to);
+
+        return new PhotoProgressCompareResponse(
+                toDto(userId, pair.before()),
+                toDto(userId, pair.after()));
+    }
+
+    @Override
+    public PhotoProgressFrequencyResponse setPhotoProgressFrequency(
+            Long id, PhotoProgressFrequencyRequest request) {
+        Long userId = currentUserProvider.currentUserId();
+
+        // Значения enum в спеке и домене совпадают (OFF/P2W/P1M); маппим по value.
+        PhotoProgressFrequency frequency =
+                PhotoProgressFrequency.valueOf(request.getFrequency().getValue());
+
+        Plant plant = photoProgressService.setFrequency(userId, id, frequency);
+
+        log.info("PATCH /api/v1/plants/{}/photo-progress/frequency: userId={} frequency={}",
+                id, userId, frequency);
+
+        return new PhotoProgressFrequencyResponse(
+                PhotoProgressFrequencyValue.fromValue(plant.getPhotoProgressFrequency().name()));
+    }
+
+    /**
+     * Снимок таймлайна → DTO. Для S3-источника подтягивает свежий presigned URL
+     * через {@link PhotoService} (ownership уже проверена сервисом). Бот-фото
+     * (Telegram file_id) отдаём без url/photoId — мобайл его пока не скачивает.
+     */
+    private PhotoProgressItemDto toDto(Long userId, PlantProgressPhoto progressPhoto) {
+        PhotoProgressItemDto dto = new PhotoProgressItemDto(
+                progressPhoto.getId(),
+                progressPhoto.getTakenAt().atOffset(ZoneOffset.UTC))
+                .caption(progressPhoto.getCaption());
+
+        Photo photo = progressPhoto.getPhoto();
+        if (photo != null) {
+            dto.photoId(photo.getId());
+            URL presigned = photoService.presignedUrl(userId, photo.getId());
+            // format:uri → сгенерён URI; presigned — URL, конвертим через строку (#310).
+            dto.url(URI.create(presigned.toString()));
+        }
+        return dto;
+    }
+
+    private static byte[] readBytes(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new InvalidPhotoException("Empty file");
+        }
+        try {
+            return file.getBytes();
+        } catch (IOException e) {
+            throw new InvalidPhotoException("Cannot read uploaded file");
+        }
+    }
+}

--- a/src/main/java/com/plantcare/core/domain/PlantProgressPhoto.java
+++ b/src/main/java/com/plantcare/core/domain/PlantProgressPhoto.java
@@ -21,6 +21,13 @@ import java.time.LocalDateTime;
  *
  * <p>FK на {@link Plant} и {@link User} — ON DELETE CASCADE (см. миграцию V16),
  * поэтому при удалении растения или юзера записи уйдут автоматически.
+ *
+ * <p>Источник бинаря — один из двух (инвариант {@code chk_progress_photo_source},
+ * миграция V54):
+ * <ul>
+ *   <li>{@code telegramFileId} — фото загружено через бота (Telegram file_id);</li>
+ *   <li>{@code photo} — фото загружено через REST в S3-бакет (issue #90).</li>
+ * </ul>
  */
 @Entity
 @Table(name = "plant_progress_photos")
@@ -37,8 +44,20 @@ public class PlantProgressPhoto extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "telegram_file_id", nullable = false, length = 255)
+    /**
+     * Telegram file_id (бот-источник). {@code null}, когда фото загружено через
+     * REST в S3 — тогда заполнен {@link #photo}. Инвариант — в миграции V54.
+     */
+    @Column(name = "telegram_file_id", length = 255)
     private String telegramFileId;
+
+    /**
+     * S3-источник фото ({@link Photo} из issue #90). {@code null} для бот-фото
+     * (тогда заполнен {@link #telegramFileId}).
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "photo_id")
+    private Photo photo;
 
     @Column(name = "taken_at", nullable = false)
     private LocalDateTime takenAt;

--- a/src/main/java/com/plantcare/core/service/PhotoProgressService.java
+++ b/src/main/java/com/plantcare/core/service/PhotoProgressService.java
@@ -1,5 +1,6 @@
 package com.plantcare.core.service;
 
+import com.plantcare.core.domain.Photo;
 import com.plantcare.core.domain.Plant;
 import com.plantcare.core.domain.PlantProgressPhoto;
 import com.plantcare.core.domain.enums.PhotoProgressFrequency;
@@ -107,6 +108,54 @@ public class PhotoProgressService {
 
         log.info("Progress photo added: plant={} user={} photoId={} nextDueAt={}",
                 plantId, userId, saved.getId(), plant.getNextPhotoDueAt());
+        return saved;
+    }
+
+    /**
+     * Добавить в таймлайн фото, загруженное через REST в S3-хранилище
+     * (issue #253, #90). Аналог {@link #addPhoto} для бота, но источник —
+     * {@link Photo} вместо Telegram file_id ({@code telegramFileId = null}).
+     *
+     * <p>Переиспользует ту же логику: проверка владения растением, анти-спам по
+     * {@link #ANTI_SPAM_HOURS}, пересчёт {@code nextPhotoDueAt} и сброс
+     * {@code lastPhotoPromptSentAt}.
+     *
+     * @param photo   запись фото в S3 (уже создана {@code PhotoService.upload})
+     * @param caption опциональная подпись (до 500 символов), может быть {@code null}
+     * @throws IllegalArgumentException если растение не найдено у юзера или {@code photo == null}
+     * @throws IllegalStateException    если за последние {@link #ANTI_SPAM_HOURS}ч уже было фото
+     */
+    public PlantProgressPhoto addPhotoFromStorage(Long userId, Long plantId, Photo photo, String caption) {
+        if (photo == null) {
+            throw new IllegalArgumentException("photo is required");
+        }
+
+        Plant plant = requirePlant(userId, plantId);
+        LocalDateTime now = LocalDateTime.now();
+
+        if (photoRepository.existsByPlantIdAndTakenAtAfter(
+                plantId, now.minusHours(ANTI_SPAM_HOURS))) {
+            throw new IllegalStateException("Уже есть фото за последние 24 часа");
+        }
+
+        PlantProgressPhoto progressPhoto = new PlantProgressPhoto();
+        progressPhoto.setPlant(plant);
+        progressPhoto.setUser(plant.getUser());
+        progressPhoto.setPhoto(photo);
+        progressPhoto.setCaption(caption);
+        progressPhoto.setTakenAt(now);
+
+        PlantProgressPhoto saved = photoRepository.save(progressPhoto);
+
+        PhotoProgressFrequency frequency = plant.getPhotoProgressFrequency();
+        if (frequency != null && frequency.isEnabled()) {
+            plant.setNextPhotoDueAt(now.plus(frequency.getPeriod()));
+        }
+        plant.setLastPhotoPromptSentAt(null);
+        plantRepository.save(plant);
+
+        log.info("Progress photo added from S3: plant={} user={} progressPhotoId={} photoId={} nextDueAt={}",
+                plantId, userId, saved.getId(), photo.getId(), plant.getNextPhotoDueAt());
         return saved;
     }
 

--- a/src/main/resources/db/migration/V54__plant_progress_photos_s3_ref.sql
+++ b/src/main/resources/db/migration/V54__plant_progress_photos_s3_ref.sql
@@ -1,0 +1,51 @@
+-- V54__plant_progress_photos_s3_ref.sql
+-- Issue #253: REST API фото-прогресса растения.
+--
+-- Бот пишет в plant_progress_photos.telegram_file_id (Telegram file_id).
+-- REST-загрузка кладёт бинарь в S3-совместимый бакет (issue #90, таблица photos)
+-- и у неё нет telegram_file_id. Чтобы один таймлайн обслуживал оба источника:
+--
+--   1. Ослабляем NOT NULL на telegram_file_id (бот продолжит писать своё
+--      значение — для него ничего не меняется; REST оставляет колонку NULL).
+--   2. Добавляем nullable photo_id — FK на photos(id) из #90, переиспользует
+--      Photo-сущность и presigned-URL.
+--   3. CHECK-инвариант: ровно один источник — либо telegram_file_id, либо
+--      photo_id — должен быть заполнен (исключаем «оба пусты» и «оба заданы»).
+--
+-- Backward-compat:
+--   * DROP NOT NULL — ослабление, безопасно для rolling deploy (старый код,
+--     всегда передающий telegram_file_id, продолжает работать).
+--   * photo_id — nullable, для старого кода невидим.
+--   * CHECK добавляется поверх существующих строк: у них telegram_file_id
+--     заполнен, photo_id IS NULL — инвариант выполняется, валидация пройдёт.
+--   * ON DELETE SET NULL: удаление фото из photos (soft-delete не трогает строку,
+--     но физическая чистка в Slice B+ может) не должно ломать таймлайн —
+--     запись остаётся, ссылка обнуляется. Инвариант при этом мог бы нарушиться
+--     для чисто-S3 записи, но физический DELETE фото в #90 пока не делается;
+--     SET NULL выбран как наименее разрушительный для истории.
+
+ALTER TABLE plant_progress_photos
+    ALTER COLUMN telegram_file_id DROP NOT NULL;
+
+ALTER TABLE plant_progress_photos
+    ADD COLUMN photo_id BIGINT REFERENCES photos(id) ON DELETE SET NULL;
+
+ALTER TABLE plant_progress_photos
+    ADD CONSTRAINT chk_progress_photo_source
+        CHECK (
+            (telegram_file_id IS NOT NULL AND photo_id IS NULL)
+            OR (telegram_file_id IS NULL AND photo_id IS NOT NULL)
+        );
+
+-- Выборка фото таймлайна с присоединением S3-метаданных (REST history/compare).
+CREATE INDEX idx_progress_photo_photo_id
+    ON plant_progress_photos (photo_id)
+    WHERE photo_id IS NOT NULL;
+
+COMMENT ON COLUMN plant_progress_photos.telegram_file_id IS
+    'Telegram file_id (бот-источник). NULL, если фото загружено через REST в S3 '
+        '(тогда заполнен photo_id). Инвариант chk_progress_photo_source: ровно один источник.';
+
+COMMENT ON COLUMN plant_progress_photos.photo_id IS
+    'FK на photos(id) из issue #90 — S3-источник фото (REST-загрузка). NULL для '
+        'бот-фото (тогда заполнен telegram_file_id).';

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -154,6 +154,12 @@ tags:
       Хранилище фото в S3-совместимом бакете (issue #90, Slice A): загрузка
       (multipart), выдача через presigned URL (302 redirect) и soft-delete.
       Все эндпоинты требуют bearer-токен.
+  - name: PhotoProgress
+    description: |
+      Фото-дневник развития растения (issue #253): загрузка снимков прогресса
+      (multipart в S3), история с датами и presigned URL, сравнение двух
+      снимков «до/после» и частота напоминаний о фото. REST поверх
+      `PhotoProgressService`; растение должно принадлежать пользователю.
 
 paths:
   /api/v1/auth/apple:
@@ -206,6 +212,13 @@ paths:
     $ref: './resources/schedules.yaml#/paths/Item'
   /api/v1/plants/{id}/schedules/{type}/postpone:
     $ref: './resources/schedules.yaml#/paths/ItemPostpone'
+
+  /api/v1/plants/{id}/photo-progress:
+    $ref: './resources/plant-photo-progress.yaml#/paths/Collection'
+  /api/v1/plants/{id}/photo-progress/compare:
+    $ref: './resources/plant-photo-progress.yaml#/paths/Compare'
+  /api/v1/plants/{id}/photo-progress/frequency:
+    $ref: './resources/plant-photo-progress.yaml#/paths/Frequency'
 
   /api/v1/plant-templates:
     $ref: './resources/plant-templates.yaml#/paths/Collection'
@@ -572,6 +585,19 @@ components:
 
     PhotoUploadResponse:
       $ref: './resources/photos.yaml#/schemas/PhotoUploadResponse'
+
+    PhotoProgressFrequencyValue:
+      $ref: './resources/plant-photo-progress.yaml#/schemas/PhotoProgressFrequencyValue'
+    PhotoProgressItemDto:
+      $ref: './resources/plant-photo-progress.yaml#/schemas/PhotoProgressItemDto'
+    PhotoProgressHistoryResponse:
+      $ref: './resources/plant-photo-progress.yaml#/schemas/PhotoProgressHistoryResponse'
+    PhotoProgressCompareResponse:
+      $ref: './resources/plant-photo-progress.yaml#/schemas/PhotoProgressCompareResponse'
+    PhotoProgressFrequencyRequest:
+      $ref: './resources/plant-photo-progress.yaml#/schemas/PhotoProgressFrequencyRequest'
+    PhotoProgressFrequencyResponse:
+      $ref: './resources/plant-photo-progress.yaml#/schemas/PhotoProgressFrequencyResponse'
 
     ApiErrorResponse:
       $ref: './_common/errors.yaml#/schemas/ApiErrorResponse'

--- a/src/main/resources/openapi/resources/plant-photo-progress.yaml
+++ b/src/main/resources/openapi/resources/plant-photo-progress.yaml
@@ -1,0 +1,283 @@
+# Фото-прогресс растения (issue #253). REST поверх PhotoProgressService.
+# Загрузка фото идёт в S3-совместимый бакет (issue #90, PhotoStorageService).
+# Все эндпоинты требуют bearer-токен; растение должно принадлежать пользователю.
+
+paths:
+  Collection:
+    post:
+      tags: [PhotoProgress]
+      operationId: addPhotoProgress
+      summary: Добавить фото прогресса
+      description: |
+        Загружает фото развития растения текущего пользователя (из bearer-токена)
+        в S3-совместимый бакет и добавляет его в таймлайн фото-прогресса.
+
+        Принимается только `image/*`. Размер ограничен сервером (~5 МБ, лимит
+        `app.storage.s3.max-upload-bytes`); превышение → 413. Невалидный тип /
+        пустой файл → 400. Анти-спам: не больше одного фото за 24 часа на
+        растение → 409. Растение не найдено / чужое → 404.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '../_common/parameters.yaml#/PlantIdPath'
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: Файл изображения (image/*).
+                caption:
+                  type: string
+                  maxLength: 500
+                  description: Опциональная подпись к фото (до 500 символов).
+      responses:
+        '201':
+          description: Фото добавлено в таймлайн.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/PhotoProgressItemDto'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+        '409':
+          $ref: '../_common/responses.yaml#/Conflict'
+        '413':
+          description: Файл превышает допустимый размер.
+          content:
+            application/json:
+              schema:
+                $ref: '../_common/errors.yaml#/schemas/ApiErrorResponse'
+    get:
+      tags: [PhotoProgress]
+      operationId: getPhotoProgressHistory
+      summary: История фото прогресса
+      description: |
+        Возвращает страницу таймлайна фото-прогресса растения в обратном
+        хронологическом порядке (свежие сверху), с датами и presigned URL на
+        скачивание каждого снимка.
+
+        Пагинация — `limit/offset`. `limit` строго в диапазоне [1, 100]
+        (вне диапазона → 400). `offset` < 0 нормализуется в 0. Растение не
+        найдено / чужое → 404.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '../_common/parameters.yaml#/PlantIdPath'
+        - name: limit
+          in: query
+          required: false
+          description: Размер страницы. Допустимые значения — [1, 100].
+          schema:
+            type: integer
+            format: int32
+            default: 10
+            minimum: 1
+            maximum: 100
+        - name: offset
+          in: query
+          required: false
+          description: Сдвиг от начала истории. Значения < 0 нормализуются в 0.
+          schema:
+            type: integer
+            format: int32
+            default: 0
+            minimum: 0
+      responses:
+        '200':
+          description: Страница истории фото.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/PhotoProgressHistoryResponse'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+  Compare:
+    get:
+      tags: [PhotoProgress]
+      operationId: comparePhotoProgress
+      summary: Сравнить два снимка
+      description: |
+        Возвращает пару снимков «до/после» по двум идентификаторам записей
+        таймлайна (`from`, `to`). Сервер сам определяет, какой из двух — «до»
+        (более раннее `takenAt`), а какой — «после». Оба снимка должны
+        принадлежать этому растению пользователя.
+
+        Если снимки совпадают, не найдены или не относятся к растению — 404.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '../_common/parameters.yaml#/PlantIdPath'
+        - name: from
+          in: query
+          required: true
+          description: Идентификатор первого снимка таймлайна.
+          schema:
+            type: integer
+            format: int64
+            example: 10
+        - name: to
+          in: query
+          required: true
+          description: Идентификатор второго снимка таймлайна.
+          schema:
+            type: integer
+            format: int64
+            example: 25
+      responses:
+        '200':
+          description: Пара снимков для сравнения.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/PhotoProgressCompareResponse'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+
+  Frequency:
+    patch:
+      tags: [PhotoProgress]
+      operationId: setPhotoProgressFrequency
+      summary: Частота напоминаний о фото
+      description: |
+        Устанавливает частоту пушей «обнови фото» для растения: `OFF` —
+        выключено, `P2W` — раз в 2 недели, `P1M` — раз в месяц. Растение не
+        найдено / чужое → 404.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '../_common/parameters.yaml#/PlantIdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/schemas/PhotoProgressFrequencyRequest'
+      responses:
+        '200':
+          description: Частота обновлена.
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/PhotoProgressFrequencyResponse'
+        '400':
+          $ref: '../_common/responses.yaml#/BadRequest'
+        '401':
+          $ref: '../_common/responses.yaml#/Unauthorized'
+        '404':
+          $ref: '../_common/responses.yaml#/NotFound'
+        '422':
+          $ref: '../_common/responses.yaml#/UnprocessableEntity'
+
+schemas:
+  PhotoProgressFrequencyValue:
+    type: string
+    description: |
+      Частота напоминаний о фото: `OFF` — выключено, `P2W` — раз в 2 недели,
+      `P1M` — раз в месяц.
+    enum: [OFF, P2W, P1M]
+    example: P2W
+
+  PhotoProgressItemDto:
+    type: object
+    description: Снимок таймлайна фото-прогресса с presigned URL на скачивание.
+    required: [id, takenAt]
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Идентификатор записи таймлайна.
+        example: 25
+      photoId:
+        type: integer
+        format: int64
+        nullable: true
+        description: |
+          Идентификатор фото в S3-хранилище (issue #90). `null`, если снимок
+          загружен через бота (Telegram-источник) — тогда `url` отсутствует.
+        example: 42
+      url:
+        type: string
+        format: uri
+        nullable: true
+        description: |
+          Presigned URL для скачивания снимка. Присутствует только для
+          S3-источника; для бот-фото (Telegram file_id) `null`.
+        example: https://bucket.example.com/photos/3f2a...?X-Amz-Signature=...
+      takenAt:
+        type: string
+        format: date-time
+        description: Момент, когда снимок попал в систему (UTC).
+        example: '2026-06-01T09:30:00Z'
+      caption:
+        type: string
+        nullable: true
+        description: Опциональная подпись к снимку.
+        example: Выпустила новый лист
+
+  PhotoProgressHistoryResponse:
+    type: object
+    description: Страница таймлайна фото-прогресса с метаданными пагинации.
+    required: [items, total, limit, offset]
+    properties:
+      items:
+        type: array
+        items:
+          $ref: '#/schemas/PhotoProgressItemDto'
+      total:
+        type: integer
+        format: int64
+        description: Общее количество снимков в таймлайне растения.
+        example: 17
+      limit:
+        type: integer
+        format: int32
+        example: 10
+      offset:
+        type: integer
+        format: int32
+        example: 0
+
+  PhotoProgressCompareResponse:
+    type: object
+    description: Пара снимков «до/после» для сравнения.
+    required: [before, after]
+    properties:
+      before:
+        $ref: '#/schemas/PhotoProgressItemDto'
+      after:
+        $ref: '#/schemas/PhotoProgressItemDto'
+
+  PhotoProgressFrequencyRequest:
+    type: object
+    description: Запрос смены частоты напоминаний о фото.
+    required: [frequency]
+    properties:
+      frequency:
+        $ref: '#/schemas/PhotoProgressFrequencyValue'
+
+  PhotoProgressFrequencyResponse:
+    type: object
+    description: Текущая частота напоминаний о фото после обновления.
+    required: [frequency]
+    properties:
+      frequency:
+        $ref: '#/schemas/PhotoProgressFrequencyValue'

--- a/src/test/java/com/plantcare/api/v1/PhotoProgressControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/PhotoProgressControllerTest.java
@@ -1,0 +1,239 @@
+package com.plantcare.api.v1;
+
+import com.plantcare.api.ApiExceptionHandler;
+import com.plantcare.api.CurrentUserProvider;
+import com.plantcare.core.domain.Photo;
+import com.plantcare.core.domain.PlantProgressPhoto;
+import com.plantcare.core.service.PhotoProgressService;
+import com.plantcare.core.service.PhotoProgressService.PhotoPair;
+import com.plantcare.core.service.PhotoService;
+import com.plantcare.core.service.PhotoTooLargeException;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.net.URL;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * {@code @WebMvcTest} для {@link PhotoProgressController} (issue #253).
+ *
+ * <p>POST upload (+413 на превышении размера), GET history, GET compare,
+ * PATCH frequency.
+ */
+@WebMvcTest(PhotoProgressController.class)
+@Import(ApiExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PhotoProgressControllerTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long PLANT_ID = 42L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PhotoProgressService photoProgressService;
+
+    @MockitoBean
+    private PhotoService photoService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    @BeforeEach
+    void stubCurrentUser() {
+        when(currentUserProvider.currentUserId()).thenReturn(USER_ID);
+    }
+
+    private static MockMultipartFile imageFile() {
+        return new MockMultipartFile("file", "plant.jpg", "image/jpeg", new byte[]{1, 2, 3, 4});
+    }
+
+    private static Photo photo(long id) {
+        Photo photo = new Photo("photos/abc", "image/jpeg", 4L, USER_ID, java.time.Instant.now());
+        ReflectionTestUtils.setField(photo, "id", id);
+        return photo;
+    }
+
+    private static PlantProgressPhoto progressPhoto(long id, Photo photo, String caption) {
+        PlantProgressPhoto p = new PlantProgressPhoto();
+        ReflectionTestUtils.setField(p, "id", id);
+        p.setPhoto(photo);
+        p.setCaption(caption);
+        p.setTakenAt(LocalDateTime.of(2026, 6, 1, 9, 30));
+        return p;
+    }
+
+    // ------------------------------------------------------------------ POST
+
+    @Test
+    void should_return_201_with_item_when_upload_succeeds() throws Exception {
+        // arrange
+        Photo photo = photo(7L);
+        when(photoService.upload(eq(USER_ID), any(byte[].class), eq("image/jpeg"))).thenReturn(photo);
+        when(photoProgressService.addPhotoFromStorage(eq(USER_ID), eq(PLANT_ID), eq(photo), eq("Новый лист")))
+                .thenReturn(progressPhoto(25L, photo, "Новый лист"));
+        when(photoService.presignedUrl(USER_ID, 7L))
+                .thenReturn(new URL("https://s3.example.com/photos/abc?sig=1"));
+
+        // act + assert
+        mockMvc.perform(multipart("/api/v1/plants/42/photo-progress")
+                        .file(imageFile())
+                        .param("caption", "Новый лист"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(25))
+                .andExpect(jsonPath("$.photoId").value(7))
+                .andExpect(jsonPath("$.url").value("https://s3.example.com/photos/abc?sig=1"))
+                .andExpect(jsonPath("$.caption").value("Новый лист"));
+
+        verify(photoService).upload(eq(USER_ID), any(byte[].class), eq("image/jpeg"));
+        verify(photoProgressService).addPhotoFromStorage(eq(USER_ID), eq(PLANT_ID), eq(photo), eq("Новый лист"));
+    }
+
+    @Test
+    void should_return_413_when_file_too_large() throws Exception {
+        // arrange
+        when(photoService.upload(eq(USER_ID), any(byte[].class), eq("image/jpeg")))
+                .thenThrow(new PhotoTooLargeException(9_000_000L, 5_242_880L));
+
+        // act + assert
+        mockMvc.perform(multipart("/api/v1/plants/42/photo-progress").file(imageFile()))
+                .andExpect(status().isPayloadTooLarge())
+                .andExpect(jsonPath("$.error.code").value("PAYLOAD_TOO_LARGE"));
+    }
+
+    @Test
+    void should_return_409_when_anti_spam_window_hit() throws Exception {
+        // arrange
+        Photo photo = photo(7L);
+        when(photoService.upload(eq(USER_ID), any(byte[].class), eq("image/jpeg"))).thenReturn(photo);
+        when(photoProgressService.addPhotoFromStorage(eq(USER_ID), eq(PLANT_ID), eq(photo), any()))
+                .thenThrow(new IllegalStateException("Уже есть фото за последние 24 часа"));
+
+        // act + assert
+        mockMvc.perform(multipart("/api/v1/plants/42/photo-progress").file(imageFile()))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("CONFLICT"));
+    }
+
+    // ------------------------------------------------------------------ GET history
+
+    @Test
+    void should_return_history_page_with_urls_and_dates() throws Exception {
+        // arrange
+        Photo p1 = photo(7L);
+        Photo p2 = photo(8L);
+        when(photoProgressService.countHistory(USER_ID, PLANT_ID)).thenReturn(2L);
+        when(photoProgressService.getRecent(eq(USER_ID), eq(PLANT_ID), anyInt()))
+                .thenReturn(List.of(progressPhoto(25L, p2, "свежее"), progressPhoto(24L, p1, "старое")));
+        when(photoService.presignedUrl(USER_ID, 7L)).thenReturn(new URL("https://s3.example.com/photos/abc?sig=1"));
+        when(photoService.presignedUrl(USER_ID, 8L)).thenReturn(new URL("https://s3.example.com/photos/def?sig=2"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants/42/photo-progress").param("limit", "10").param("offset", "0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(2))
+                .andExpect(jsonPath("$.limit").value(10))
+                .andExpect(jsonPath("$.offset").value(0))
+                .andExpect(jsonPath("$.items.length()").value(2))
+                .andExpect(jsonPath("$.items[0].id").value(25))
+                .andExpect(jsonPath("$.items[0].url").value("https://s3.example.com/photos/def?sig=2"));
+    }
+
+    @Test
+    void should_return_400_when_limit_out_of_range() throws Exception {
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants/42/photo-progress").param("limit", "0"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ------------------------------------------------------------------ GET compare
+
+    @Test
+    void should_return_before_after_pair_for_compare() throws Exception {
+        // arrange
+        Photo before = photo(7L);
+        Photo after = photo(8L);
+        when(photoProgressService.compareByIds(USER_ID, PLANT_ID, 24L, 25L))
+                .thenReturn(Optional.of(new PhotoPair(
+                        progressPhoto(24L, before, "до"), progressPhoto(25L, after, "после"))));
+        when(photoService.presignedUrl(USER_ID, 7L)).thenReturn(new URL("https://s3.example.com/photos/abc?sig=1"));
+        when(photoService.presignedUrl(USER_ID, 8L)).thenReturn(new URL("https://s3.example.com/photos/def?sig=2"));
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants/42/photo-progress/compare").param("from", "24").param("to", "25"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.before.id").value(24))
+                .andExpect(jsonPath("$.after.id").value(25))
+                .andExpect(jsonPath("$.before.url").value("https://s3.example.com/photos/abc?sig=1"))
+                .andExpect(jsonPath("$.after.url").value("https://s3.example.com/photos/def?sig=2"));
+    }
+
+    @Test
+    void should_return_404_when_compare_pair_not_found() throws Exception {
+        // arrange
+        when(photoProgressService.compareByIds(USER_ID, PLANT_ID, 1L, 2L)).thenReturn(Optional.empty());
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/plants/42/photo-progress/compare").param("from", "1").param("to", "2"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("NOT_FOUND"));
+    }
+
+    // ------------------------------------------------------------------ PATCH frequency
+
+    @Test
+    void should_set_frequency_and_echo_it() throws Exception {
+        // arrange
+        com.plantcare.core.domain.Plant plant = com.plantcare.core.domain.Plant.builder()
+                .photoProgressFrequency(com.plantcare.core.domain.enums.PhotoProgressFrequency.P2W)
+                .build();
+        when(photoProgressService.setFrequency(
+                eq(USER_ID), eq(PLANT_ID),
+                eq(com.plantcare.core.domain.enums.PhotoProgressFrequency.P2W)))
+                .thenReturn(plant);
+
+        // act + assert
+        mockMvc.perform(patch("/api/v1/plants/42/photo-progress/frequency")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"frequency\":\"P2W\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.frequency").value("P2W"));
+
+        verify(photoProgressService).setFrequency(
+                eq(USER_ID), eq(PLANT_ID),
+                eq(com.plantcare.core.domain.enums.PhotoProgressFrequency.P2W));
+    }
+
+    @Test
+    void should_return_422_when_frequency_unknown() throws Exception {
+        // act + assert
+        mockMvc.perform(patch("/api/v1/plants/42/photo-progress/frequency")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"frequency\":\"WEEKLY\"}"))
+                .andExpect(status().isUnprocessableEntity());
+    }
+}

--- a/src/test/java/com/plantcare/core/service/PhotoProgressServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/PhotoProgressServiceTest.java
@@ -1,5 +1,6 @@
 package com.plantcare.core.service;
 
+import com.plantcare.core.domain.Photo;
 import com.plantcare.core.domain.Plant;
 import com.plantcare.core.domain.PlantProgressPhoto;
 import com.plantcare.core.domain.User;
@@ -159,6 +160,80 @@ class PhotoProgressServiceTest {
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> service.addPhoto(USER_ID, PLANT_ID, null))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ---------------------------------------------------- addPhotoFromStorage (issue #253)
+
+    @Test
+    void should_save_s3_photo_and_reschedule_when_frequency_enabled() {
+        plant.setPhotoProgressFrequency(PhotoProgressFrequency.P1M);
+        when(photoRepository.existsByPlantIdAndTakenAtAfter(eq(PLANT_ID), any(LocalDateTime.class)))
+                .thenReturn(false);
+        when(photoRepository.save(any(PlantProgressPhoto.class)))
+                .thenAnswer(i -> {
+                    PlantProgressPhoto p = i.getArgument(0);
+                    ReflectionTestUtils.setField(p, "id", 200L);
+                    return p;
+                });
+        Photo s3photo = s3Photo(77L);
+
+        LocalDateTime before = LocalDateTime.now();
+        PlantProgressPhoto saved = service.addPhotoFromStorage(USER_ID, PLANT_ID, s3photo, "новый лист");
+
+        assertThat(saved.getPhoto()).isEqualTo(s3photo);
+        assertThat(saved.getTelegramFileId()).isNull();
+        assertThat(saved.getCaption()).isEqualTo("новый лист");
+        assertThat(saved.getPlant()).isEqualTo(plant);
+        assertThat(saved.getUser()).isEqualTo(user);
+        assertThat(saved.getTakenAt()).isAfterOrEqualTo(before);
+        assertThat(plant.getNextPhotoDueAt())
+                .isAfterOrEqualTo(before.plusMonths(1).minusSeconds(5));
+        assertThat(plant.getLastPhotoPromptSentAt()).isNull();
+    }
+
+    @Test
+    void should_save_s3_photo_without_reschedule_when_frequency_off() {
+        plant.setPhotoProgressFrequency(PhotoProgressFrequency.OFF);
+        when(photoRepository.existsByPlantIdAndTakenAtAfter(eq(PLANT_ID), any(LocalDateTime.class)))
+                .thenReturn(false);
+        when(photoRepository.save(any(PlantProgressPhoto.class))).thenAnswer(i -> i.getArgument(0));
+
+        service.addPhotoFromStorage(USER_ID, PLANT_ID, s3Photo(77L), null);
+
+        assertThat(plant.getNextPhotoDueAt()).isNull();
+    }
+
+    @Test
+    void should_throw_when_s3_photo_null() {
+        assertThatThrownBy(() -> service.addPhotoFromStorage(USER_ID, PLANT_ID, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("photo is required");
+
+        verify(photoRepository, never()).save(any());
+    }
+
+    @Test
+    void should_throw_when_s3_photo_added_to_foreign_plant() {
+        when(plantRepository.findByUserIdAndIdAndArchivedAtIsNull(USER_ID, 999L))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.addPhotoFromStorage(USER_ID, 999L, s3Photo(77L), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Plant not found");
+
+        verify(photoRepository, never()).save(any());
+    }
+
+    @Test
+    void should_throw_when_s3_photo_anti_spam_24h_violated() {
+        when(photoRepository.existsByPlantIdAndTakenAtAfter(eq(PLANT_ID), any(LocalDateTime.class)))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> service.addPhotoFromStorage(USER_ID, PLANT_ID, s3Photo(77L), null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("24 часа");
+
+        verify(photoRepository, never()).save(any());
     }
 
     @Test
@@ -350,5 +425,11 @@ class PhotoProgressServiceTest {
         p.setUser(user);
         p.setTelegramFileId("file-" + id);
         return p;
+    }
+
+    private static Photo s3Photo(long id) {
+        Photo photo = new Photo("photos/" + id, "image/jpeg", 1024L, USER_ID, java.time.Instant.now());
+        ReflectionTestUtils.setField(photo, "id", id);
+        return photo;
     }
 }


### PR DESCRIPTION
## Что сделано

Мобайл получает фото-дневник развития растения через REST — закрывает паритет бот↔REST (аудит, issue #253). 4 эндпоинта `/api/v1/plants/{id}/photo-progress` (scope user, bearer):

| Метод | Путь | Назначение |
|---|---|---|
| `POST` | `/photo-progress` | multipart upload в S3 → таймлайн (201) |
| `GET` | `/photo-progress` | история с датами и presigned URL (пагинация limit/offset) |
| `GET` | `/photo-progress/compare?from=&to=` | пара «до/после» по id снимков |
| `PATCH` | `/photo-progress/frequency` | частота напоминаний (`OFF`/`P2W`/`P1M`) |

## Переиспользование (без дублирования логики)

- **`PhotoProgressService`** — вся бизнес-логика таймлайна. Добавлен **новый** метод `addPhotoFromStorage(userId, plantId, Photo, caption)` (S3-источник, `telegramFileId = null`), переиспользующий ownership-проверку, анти-спам 24ч и пересчёт `nextPhotoDueAt`. Старая сигнатура `addPhoto(...telegramFileId)` **не тронута** — бот на ней. История/сравнение/частота — существующие `getRecent`/`countHistory`/`compareByIds`/`setFrequency`.
- **`PhotoService` + S3-хранилище (#90)** — загрузка бинаря, валидация типа/размера (лимит `app.storage.s3.max-upload-bytes`), presigned URL. Контроллер тонкий: `PhotoService.upload` → `PhotoProgressService.addPhotoFromStorage`.

## Дизайн `telegram_file_id` → `photo_id` (миграция V54)

`plant_progress_photos.telegram_file_id` был `NOT NULL` (бот пишет Telegram file_id), а у REST-загрузки его нет. **V54**:
- `DROP NOT NULL` на `telegram_file_id` (ослабление — безопасно для rolling deploy, бот продолжает писать своё значение);
- nullable `photo_id BIGINT` FK на `photos(id)` из #90 (`ON DELETE SET NULL`) — переиспользует `Photo` и presigned-URL;
- CHECK `chk_progress_photo_source`: ровно один источник (`telegram_file_id` XOR `photo_id`);
- partial index `idx_progress_photo_photo_id`.

Сущность `PlantProgressPhoto` получила nullable `@ManyToOne Photo photo`.

## Контракт-first

Новый `resources/plant-photo-progress.yaml` + регистрация путей/тега/схем в `openapi.yaml`; контроллер `implements` сгенерированный `PhotoProgressApi`. Presigned url — `format:uri` → `URI.create(url.toString())` (грабли #310). Без `@Bean ObjectMapper` (#281/#307). ArchUnit зелёный (сервис/домен/миграция в core, контроллер в api).

> Направление контракта: эндпоинты на бэкенде → дальше правка OpenAPI-спеки в `plants-care-mobile` и регенерация клиента (вне этого PR).

## Тесты

- `PhotoProgressControllerTest` (WebMvcTest, 9): upload 201 + 413 (размер) + 409 (анти-спам); history + 400 (limit вне диапазона); compare + 404; frequency + 422.
- `PhotoProgressServiceTest` (+5): `addPhotoFromStorage` happy (reschedule/off), null photo, чужое растение, анти-спам.

**`mvn verify`: 1811 тестов, 1809 зелёных, 2 падения** — пред-существующие host-TZ flaky (`PlantScheduleServiceTest#…non_utc…`, `PlantServiceTest#markCareDone…`, машина UTC+3), не связаны с задачей. Все новые тесты + photo-progress/ArchUnit/миграции зелёные.

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)