### PR TITLE
fix(sdui): тап по карточке растения на home не переходит (navigate target без /home)

### DIFF
--- a/src/main/java/com/plantcare/api/service/UiViewService.java
+++ b/src/main/java/com/plantcare/api/service/UiViewService.java
@@ -342,7 +342,7 @@ public class UiViewService {
         block.put("type", TYPE_GUEST_BANNER);
         block.put("titleKey", "home.guest.title");
         block.put("bodyKey", "home.guest.body");
-        block.put("ctaAction", navigateAction("/home/register"));
+        block.put("ctaAction", navigateAction("/profile/convert-guest"));
         return block;
     }
 
@@ -401,11 +401,13 @@ public class UiViewService {
 
     /**
      * Действие «навигация к карточке растения» (MADR-017). Путь строится из
-     * допустимого словаря витринных путей ({@code /plants/{id}}), не из
-     * произвольного URL.
+     * допустимого словаря витринных путей ({@code /home/plants/{id}}), не из
+     * произвольного URL. Префикс {@code /home} обязателен: маршрут карточки у
+     * клиента вложен в home-shell ({@code /home/plants/:id}); без него
+     * go_router не находит маршрут и тап молча игнорируется.
      */
     private static Map<String, Object> plantCardNavigateAction(Long plantId) {
-        return navigateAction("/plants/" + plantId);
+        return navigateAction("/home/plants/" + plantId);
     }
 
     /**

--- a/src/test/java/com/plantcare/api/service/UiViewServiceTest.java
+++ b/src/test/java/com/plantcare/api/service/UiViewServiceTest.java
@@ -165,7 +165,9 @@ class UiViewServiceTest {
         // MADR-017: тап по телу карточки → navigate к витрине растения
         @SuppressWarnings("unchecked")
         Map<String, Object> navAction = (Map<String, Object>) plants.get(0).get("action");
-        assertThat(navAction).containsEntry("kind", "navigate").containsEntry("target", "/plants/10");
+        // target обязан содержать /home-префикс: маршрут карточки у клиента вложен
+        // в home-shell (/home/plants/:id); без него go_router не находит маршрут.
+        assertThat(navAction).containsEntry("kind", "navigate").containsEntry("target", "/home/plants/10");
 
         // MADR-017: явная кнопка «полить» → log_care + invalidates
         @SuppressWarnings("unchecked")
@@ -292,7 +294,10 @@ class UiViewServiceTest {
                 .containsKeys("titleKey", "bodyKey", "ctaAction");
         @SuppressWarnings("unchecked")
         Map<String, Object> cta = (Map<String, Object>) banner.get("ctaAction");
-        assertThat(cta).containsEntry("kind", "navigate");
+        // target должен совпадать с клиентским маршрутом конвертации гостя
+        // (/profile/convert-guest), иначе тап молча игнорируется go_router.
+        assertThat(cta).containsEntry("kind", "navigate")
+                .containsEntry("target", "/profile/convert-guest");
     }
 
     @Test


### PR DESCRIPTION
## Баг (регрессия SDUI-home #284)
На главной (SDUI) тап по карточке растения **не открывает карточку**.

## Корень
`UiViewService.plantCardNavigateAction` слал `target: "/plants/{id}"`, а маршрут карточки у клиента вложен в home-shell — **`/home/plants/:id`**. Клиент делает `appRouter.push("/plants/123")`, go_router не находит такой маршрут → `ActionRunner._runNavigate` **молча no-op** (graceful, без краша → баг не виден в логах). Соседние CTA-блоки уже корректно используют `/home/add`.

## Фикс (два несогласованных таргета)
| Действие | Было | Стало |
|---|---|---|
| тап по карточке | `/plants/{id}` | `/home/plants/{id}` |
| guest-banner CTA | `/home/register` | `/profile/convert-guest` |

(`/home/register` у клиента тоже нет — маршрут `ConvertGuestScreen` вложен в `/profile`; тот же молчаливый no-op, второй баг того же класса.)

## Проверка
Тесты `UiViewServiceTest` усилены — ассертят точные `target` обоих действий (ловят регрессию). Локально **15/15 зелёные** (UiViewServiceTest + UiControllerTest, кэш прогрет).

## Природа
Композиция блоков — в коде (`UiViewService`), не в `ui_views.layout_json`, поэтому фикс кодовый, не UPDATE строки. Клиент менять не нужно — он навигацию обрабатывает верно, проблема в присылаемом target.

auto-merge НЕ включён.

🤖 Generated with [Claude Code](https://claude.com/claude-code)