### PR TITLE
fix(stats): per-plant streak считает уникальные ДНИ, а не записи (#313)

### DIFF
--- a/src/main/java/com/plantcare/api/v1/StatsController.java
+++ b/src/main/java/com/plantcare/api/v1/StatsController.java
@@ -34,7 +34,7 @@ public class StatsController implements StatsApi {
                 .orElseThrow(() -> new EntityNotFoundException(
                         "Plant not found: id=" + plantId + " for userId=" + user.getId()));
 
-        int streak = careHistoryService.computePlantStreak(plantId);
+        int streak = careHistoryService.computePlantStreak(plantId, user.getTimezone());
 
         return new StreakResponse(plantId, streak);
     }

--- a/src/main/java/com/plantcare/bot/service/PlantCardService.java
+++ b/src/main/java/com/plantcare/bot/service/PlantCardService.java
@@ -1042,7 +1042,7 @@ public class PlantCardService {
         }
 
         List<CareHistory> entries = careHistoryService.getHistoryPage(plantId, safePage);
-        CareHistoryService.PlantStats stats = careHistoryService.getPlantStats(plantId);
+        CareHistoryService.PlantStats stats = careHistoryService.getPlantStats(plantId, user.getTimezone());
         ZoneId tz = parseUserZone(user);
 
         String text = buildHistoryText(plant, entries, stats, safePage, totalPages, total, tz);

--- a/src/main/java/com/plantcare/core/service/CareHistoryService.java
+++ b/src/main/java/com/plantcare/core/service/CareHistoryService.java
@@ -30,12 +30,16 @@ import java.util.stream.Collectors;
  *
  * Логика стриков:
  *
- *  <b>Per-plant streak</b> — «выполнений подряд без пропусков».
+ *  <b>Per-plant streak</b> — «дней подряд с on-time-уходом, без пропуска расписания».
  *  Алгоритм:
  *   1) Если у любого активного расписания этого растения {@code nextDueAt + 1 day < now}
  *      и нет более свежего "сделано" — стрик 0 (просроченная задача висит).
- *   2) Иначе идём по истории DESC: пока {@code onTime=true} → +1, на первой
- *      late-записи стоп.
+ *   2) Иначе идём по истории DESC: пока {@code onTime=true} собираем уникальные ДНИ
+ *      (в TZ юзера), на первой late-записи стоп. Результат — число уникальных дней
+ *      в непрерывном on-time-прогоне: несколько уходов в один день дают +1, а не +N.
+ *  «Подряд» здесь = непрерывный прогон on-time-уходов без пропуска расписания
+ *  (стоп на late), а НЕ календарно-смежные дни — растение с интервалом 7 дней
+ *  тоже умеет набирать стрик &gt; 1.
  *  Compensating (cancelled) записи пропускаются.
  *
  *  <b>Per-user streak</b> — «дни подряд, в которые юзер сделал хотя бы одно действие».
@@ -191,7 +195,7 @@ public class CareHistoryService {
      * {@link #MIN_ACTIONS_FOR_STATS} — UI должен скрыть блок и показать заглушку.
      */
     @Transactional(readOnly = true)
-    public PlantStats getPlantStats(Long plantId) {
+    public PlantStats getPlantStats(Long plantId, String timezone) {
         long total = countHistory(plantId);
 
         if (total == 0) {
@@ -206,17 +210,24 @@ public class CareHistoryService {
                 ? 0
                 : (int) Math.round(100.0 * onTimeInWindow / actionsInWindow);
 
-        int streak = computePlantStreak(plantId);
+        int streak = computePlantStreak(plantId, timezone);
 
         return new PlantStats(streak, onTimePct, total);
     }
 
     /**
-     * Стрик по конкретному растению. Алгоритм описан в javadoc класса.
+     * Стрик по конкретному растению — число уникальных дней с on-time-уходом
+     * в непрерывном прогоне (стоп на первой late-записи). Повторы в один день
+     * (в TZ юзера) не накручивают стрик: 5 поливов за сутки = +1 день, а не +5.
+     * Алгоритм целиком описан в javadoc класса.
      * Публичный для удобства тестирования и переиспользования.
+     *
+     * @param plantId  id растения
+     * @param timezone IANA-таймзона юзера для определения границ суток; пустая/
+     *                 невалидная → UTC (см. {@link #safeZone(String)})
      */
     @Transactional(readOnly = true)
-    public int computePlantStreak(Long plantId) {
+    public int computePlantStreak(Long plantId, String timezone) {
         // 1) Просроченные расписания (без своего done) сразу обнуляют стрик.
         LocalDateTime now = LocalDateTime.now(clock);
         List<CareSchedule> schedules = careScheduleRepository.findAllByPlantId(plantId);
@@ -228,20 +239,27 @@ public class CareHistoryService {
             }
         }
 
-        // 2) Иначе идём по истории с конца, пока все on-time.
+        // 2) Иначе идём по истории с конца, пока все on-time, и считаем
+        //    уникальные ДНИ (в TZ юзера), а не количество записей.
+        ZoneId tz = safeZone(timezone);
         List<CareHistory> recent = careHistoryRepository.findAllByPlantIdOrderByDoneAtDesc(
                 plantId, Limit.of(STREAK_LOOKBACK));
 
-        int count = 0;
+        Set<LocalDate> uniqueDays = new HashSet<>();
         for (CareHistory h : recent) {
             if (h.isCancelled()) continue; // компенсирующие игнорируем
             if (h.isOnTime()) {
-                count++;
+                // doneAt хранится как LocalDateTime в UTC → переводим в TZ юзера.
+                LocalDate day = h.getDoneAt()
+                        .atOffset(ZoneOffset.UTC)
+                        .atZoneSameInstant(tz)
+                        .toLocalDate();
+                uniqueDays.add(day);
             } else {
-                break;
+                break; // первая late-запись обрывает прогон
             }
         }
-        return count;
+        return uniqueDays.size();
     }
 
     /**

--- a/src/test/java/com/plantcare/api/v1/StatsControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/StatsControllerTest.java
@@ -60,7 +60,7 @@ class StatsControllerTest {
         when(plant.getId()).thenReturn(10L);
         when(plantRepository.findByUserIdAndIdAndArchivedAtIsNull(1L, 10L))
                 .thenReturn(Optional.of(plant));
-        when(careHistoryService.computePlantStreak(10L)).thenReturn(5);
+        when(careHistoryService.computePlantStreak(10L, "UTC")).thenReturn(5);
 
         // act + assert
         mockMvc.perform(get("/api/v1/stats/streak")
@@ -81,7 +81,7 @@ class StatsControllerTest {
         when(plant.getId()).thenReturn(20L);
         when(plantRepository.findByUserIdAndIdAndArchivedAtIsNull(2L, 20L))
                 .thenReturn(Optional.of(plant));
-        when(careHistoryService.computePlantStreak(20L)).thenReturn(0);
+        when(careHistoryService.computePlantStreak(20L, "UTC")).thenReturn(0);
 
         // act + assert
         mockMvc.perform(get("/api/v1/stats/streak")

--- a/src/test/java/com/plantcare/core/service/CareHistoryServiceTest.java
+++ b/src/test/java/com/plantcare/core/service/CareHistoryServiceTest.java
@@ -57,6 +57,8 @@ class CareHistoryServiceTest {
     @DisplayName("computePlantStreak")
     class PlantStreakTests {
 
+        private final ZoneId UTC = ZoneOffset.UTC;
+
         @Test
         @DisplayName("Пустая история → 0")
         void emptyHistory_returnsZero() {
@@ -64,7 +66,7 @@ class CareHistoryServiceTest {
             when(historyRepository.findAllByPlantIdOrderByDoneAtDesc(eq(1L), any(Limit.class)))
                     .thenReturn(List.of());
 
-            assertThat(service.computePlantStreak(1L)).isZero();
+            assertThat(service.computePlantStreak(1L, "UTC")).isZero();
         }
 
         @Test
@@ -74,39 +76,41 @@ class CareHistoryServiceTest {
             when(historyRepository.findAllByPlantIdOrderByDoneAtDesc(eq(1L), any(Limit.class)))
                     .thenReturn(List.of(historyEntry(true, false)));
 
-            assertThat(service.computePlantStreak(1L)).isEqualTo(1);
+            assertThat(service.computePlantStreak(1L, "UTC")).isEqualTo(1);
         }
 
         @Test
-        @DisplayName("Идеальная серия из 5 on-time → 5")
+        @DisplayName("Серия из 5 on-time в РАЗНЫЕ дни → 5")
         void perfectStreakOfFive() {
+            LocalDate today = LocalDate.now(UTC);
             when(scheduleRepository.findAllByPlantId(1L)).thenReturn(List.of());
             when(historyRepository.findAllByPlantIdOrderByDoneAtDesc(eq(1L), any(Limit.class)))
                     .thenReturn(List.of(
-                            historyEntry(true, false),
-                            historyEntry(true, false),
-                            historyEntry(true, false),
-                            historyEntry(true, false),
-                            historyEntry(true, false)
+                            historyEntry(true, false, atUtc(today, 12)),
+                            historyEntry(true, false, atUtc(today.minusDays(1), 12)),
+                            historyEntry(true, false, atUtc(today.minusDays(2), 12)),
+                            historyEntry(true, false, atUtc(today.minusDays(3), 12)),
+                            historyEntry(true, false, atUtc(today.minusDays(4), 12))
                     ));
 
-            assertThat(service.computePlantStreak(1L)).isEqualTo(5);
+            assertThat(service.computePlantStreak(1L, "UTC")).isEqualTo(5);
         }
 
         @Test
-        @DisplayName("Серия 3 on-time + потом late → 3 (стрик ломается на late)")
+        @DisplayName("Серия 3 on-time-дня + потом late → 3 (стрик ломается на late)")
         void streakBreaksAtFirstLateEntry() {
+            LocalDate today = LocalDate.now(UTC);
             when(scheduleRepository.findAllByPlantId(1L)).thenReturn(List.of());
             when(historyRepository.findAllByPlantIdOrderByDoneAtDesc(eq(1L), any(Limit.class)))
                     .thenReturn(List.of(
-                            historyEntry(true, false),
-                            historyEntry(true, false),
-                            historyEntry(true, false),
-                            historyEntry(false, false), // late — стоп
-                            historyEntry(true, false)   // дальше неважно
+                            historyEntry(true, false, atUtc(today, 12)),
+                            historyEntry(true, false, atUtc(today.minusDays(1), 12)),
+                            historyEntry(true, false, atUtc(today.minusDays(2), 12)),
+                            historyEntry(false, false, atUtc(today.minusDays(3), 12)), // late — стоп
+                            historyEntry(true, false, atUtc(today.minusDays(4), 12))   // дальше неважно
                     ));
 
-            assertThat(service.computePlantStreak(1L)).isEqualTo(3);
+            assertThat(service.computePlantStreak(1L, "UTC")).isEqualTo(3);
         }
 
         @Test
@@ -116,7 +120,7 @@ class CareHistoryServiceTest {
             when(historyRepository.findAllByPlantIdOrderByDoneAtDesc(eq(1L), any(Limit.class)))
                     .thenReturn(List.of(historyEntry(false, false)));
 
-            assertThat(service.computePlantStreak(1L)).isZero();
+            assertThat(service.computePlantStreak(1L, "UTC")).isZero();
         }
 
         @Test
@@ -136,7 +140,7 @@ class CareHistoryServiceTest {
                             historyEntry(true, false)
                     ));
 
-            assertThat(service.computePlantStreak(1L)).isZero();
+            assertThat(service.computePlantStreak(1L, "UTC")).isZero();
         }
 
         @Test
@@ -151,12 +155,13 @@ class CareHistoryServiceTest {
             when(historyRepository.findAllByPlantIdOrderByDoneAtDesc(eq(1L), any(Limit.class)))
                     .thenReturn(List.of(historyEntry(true, false)));
 
-            assertThat(service.computePlantStreak(1L)).isEqualTo(1);
+            assertThat(service.computePlantStreak(1L, "UTC")).isEqualTo(1);
         }
 
         @Test
         @DisplayName("Неактивное расписание (active=false) не влияет, даже если просрочено")
         void inactiveScheduleIgnored() {
+            LocalDate today = LocalDate.now(UTC);
             CareSchedule offSchedule = CareSchedule.builder()
                     .taskType(TaskType.FERTILIZING)
                     .active(false)
@@ -165,26 +170,95 @@ class CareHistoryServiceTest {
             when(scheduleRepository.findAllByPlantId(1L)).thenReturn(List.of(offSchedule));
             when(historyRepository.findAllByPlantIdOrderByDoneAtDesc(eq(1L), any(Limit.class)))
                     .thenReturn(List.of(
-                            historyEntry(true, false),
-                            historyEntry(true, false)
+                            historyEntry(true, false, atUtc(today, 12)),
+                            historyEntry(true, false, atUtc(today.minusDays(1), 12))
                     ));
 
-            assertThat(service.computePlantStreak(1L)).isEqualTo(2);
+            assertThat(service.computePlantStreak(1L, "UTC")).isEqualTo(2);
         }
 
         @Test
         @DisplayName("Compensating (cancelled) записи пропускаются при подсчёте")
         void cancelledEntriesAreSkipped() {
+            LocalDate today = LocalDate.now(UTC);
             when(scheduleRepository.findAllByPlantId(1L)).thenReturn(List.of());
-            // Две on-time, между ними одна cancelled — должно дать 2 (пропустили cancelled).
+            // Две on-time в разные дни, между ними одна cancelled — должно дать 2.
             when(historyRepository.findAllByPlantIdOrderByDoneAtDesc(eq(1L), any(Limit.class)))
                     .thenReturn(List.of(
-                            historyEntry(true, false),
-                            historyEntry(false, true),  // cancelled — пропускаем, не ломает стрик
-                            historyEntry(true, false)
+                            historyEntry(true, false, atUtc(today, 12)),
+                            historyEntry(false, true, atUtc(today, 13)),  // cancelled — пропускаем
+                            historyEntry(true, false, atUtc(today.minusDays(1), 12))
                     ));
 
-            assertThat(service.computePlantStreak(1L)).isEqualTo(2);
+            assertThat(service.computePlantStreak(1L, "UTC")).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("should_count_same_day_repeats_as_one_when_multiple_on_time_cares")
+        void should_count_same_day_repeats_as_one_when_multiple_on_time_cares() {
+            LocalDate today = LocalDate.now(UTC);
+            when(scheduleRepository.findAllByPlantId(1L)).thenReturn(List.of());
+            // 5 on-time уходов в ОДИН день (в TZ юзера) → стрик 1, а не 5.
+            when(historyRepository.findAllByPlantIdOrderByDoneAtDesc(eq(1L), any(Limit.class)))
+                    .thenReturn(List.of(
+                            historyEntry(true, false, atUtc(today, 8)),
+                            historyEntry(true, false, atUtc(today, 10)),
+                            historyEntry(true, false, atUtc(today, 12)),
+                            historyEntry(true, false, atUtc(today, 14)),
+                            historyEntry(true, false, atUtc(today, 16))
+                    ));
+
+            assertThat(service.computePlantStreak(1L, "UTC")).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("should_count_distinct_days_when_on_time_cares_on_separate_days")
+        void should_count_distinct_days_when_on_time_cares_on_separate_days() {
+            LocalDate today = LocalDate.now(UTC);
+            when(scheduleRepository.findAllByPlantId(1L)).thenReturn(List.of());
+            // On-time уходы в 3 разных дня подряд по расписанию → стрик 3.
+            when(historyRepository.findAllByPlantIdOrderByDoneAtDesc(eq(1L), any(Limit.class)))
+                    .thenReturn(List.of(
+                            historyEntry(true, false, atUtc(today, 9)),
+                            historyEntry(true, false, atUtc(today.minusDays(1), 9)),
+                            historyEntry(true, false, atUtc(today.minusDays(2), 9))
+                    ));
+
+            assertThat(service.computePlantStreak(1L, "UTC")).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("should_dedup_by_user_timezone_when_cares_straddle_utc_midnight")
+        void should_dedup_by_user_timezone_when_cares_straddle_utc_midnight() {
+            // Europe/Moscow = UTC+3. Два ухода по разные стороны UTC-полуночи,
+            // но в один локальный день юзера → стрик 1 (дедуп по TZ юзера, не по UTC).
+            // 2026-06-07 22:00 UTC → 2026-06-08 01:00 MSK
+            // 2026-06-08 02:00 UTC → 2026-06-08 05:00 MSK  (тот же локальный день)
+            LocalDateTime beforeUtcMidnight = LocalDateTime.of(2026, 6, 7, 22, 0);
+            LocalDateTime afterUtcMidnight = LocalDateTime.of(2026, 6, 8, 2, 0);
+            when(scheduleRepository.findAllByPlantId(1L)).thenReturn(List.of());
+            when(historyRepository.findAllByPlantIdOrderByDoneAtDesc(eq(1L), any(Limit.class)))
+                    .thenReturn(List.of(
+                            historyEntry(true, false, afterUtcMidnight),
+                            historyEntry(true, false, beforeUtcMidnight)
+                    ));
+
+            assertThat(service.computePlantStreak(1L, "Europe/Moscow")).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("Те же два ухода по UTC дают 2 дня — контроль, что дедуп идёт по TZ")
+        void sameTwoCares_underUtc_countAsTwoDistinctDays() {
+            LocalDateTime beforeUtcMidnight = LocalDateTime.of(2026, 6, 7, 22, 0);
+            LocalDateTime afterUtcMidnight = LocalDateTime.of(2026, 6, 8, 2, 0);
+            when(scheduleRepository.findAllByPlantId(1L)).thenReturn(List.of());
+            when(historyRepository.findAllByPlantIdOrderByDoneAtDesc(eq(1L), any(Limit.class)))
+                    .thenReturn(List.of(
+                            historyEntry(true, false, afterUtcMidnight),
+                            historyEntry(true, false, beforeUtcMidnight)
+                    ));
+
+            assertThat(service.computePlantStreak(1L, "UTC")).isEqualTo(2);
         }
     }
 
@@ -301,7 +375,7 @@ class CareHistoryServiceTest {
         void noHistory() {
             when(historyRepository.countActiveByPlantId(1L)).thenReturn(0L);
 
-            CareHistoryService.PlantStats stats = service.getPlantStats(1L);
+            CareHistoryService.PlantStats stats = service.getPlantStats(1L, "UTC");
 
             assertThat(stats.total()).isZero();
             assertThat(stats.streak()).isZero();
@@ -319,7 +393,7 @@ class CareHistoryServiceTest {
             when(historyRepository.findAllByPlantIdOrderByDoneAtDesc(eq(1L), any(Limit.class)))
                     .thenReturn(List.of(historyEntry(true, false)));
 
-            CareHistoryService.PlantStats stats = service.getPlantStats(1L);
+            CareHistoryService.PlantStats stats = service.getPlantStats(1L, "UTC");
 
             assertThat(stats.total()).isEqualTo(4L);
             assertThat(stats.onTimePct()).isEqualTo(75);
@@ -337,7 +411,7 @@ class CareHistoryServiceTest {
             when(historyRepository.findAllByPlantIdOrderByDoneAtDesc(eq(1L), any(Limit.class)))
                     .thenReturn(List.of());
 
-            CareHistoryService.PlantStats stats = service.getPlantStats(1L);
+            CareHistoryService.PlantStats stats = service.getPlantStats(1L, "UTC");
 
             assertThat(stats.onTimePct()).isZero();
             assertThat(stats.total()).isEqualTo(5L);
@@ -354,7 +428,7 @@ class CareHistoryServiceTest {
             when(historyRepository.findAllByPlantIdOrderByDoneAtDesc(eq(1L), any(Limit.class)))
                     .thenReturn(List.of(historyEntry(true, false), historyEntry(true, false)));
 
-            CareHistoryService.PlantStats stats = service.getPlantStats(1L);
+            CareHistoryService.PlantStats stats = service.getPlantStats(1L, "UTC");
             assertThat(stats.hasEnoughData()).isFalse();
         }
     }
@@ -382,11 +456,19 @@ class CareHistoryServiceTest {
 
     // ===== helpers =====
 
-    /** Создаёт мок-CareHistory с указанными флагами on_time / cancelled. */
+    /** Создаёт мок-CareHistory с флагами on_time / cancelled и doneAt = now. */
     private CareHistory historyEntry(boolean onTime, boolean cancelled) {
+        return historyEntry(onTime, cancelled, LocalDateTime.now());
+    }
+
+    /**
+     * Создаёт мок-CareHistory с явным {@code doneAt} (хранится как LocalDateTime
+     * в UTC) — нужно для проверки дедупа стрика по уникальным дням в TZ юзера.
+     */
+    private CareHistory historyEntry(boolean onTime, boolean cancelled, LocalDateTime doneAt) {
         CareHistory h = new CareHistory();
         h.setTaskType(TaskType.WATERING);
-        h.setDoneAt(LocalDateTime.now());
+        h.setDoneAt(doneAt);
         h.setOnTime(onTime);
         if (cancelled) {
             // Лёгкий хак: для проверки isCancelled() достаточно non-null cancelledBy.


### PR DESCRIPTION
## Корень бага
`CareHistoryService.computePlantStreak` прибавлял **+1 за каждую** on-time-запись истории, без дедупликации по дню. Поэтому 5 поливов в один день давали стрик 5, а карточка растения подписывала это «5 дней подряд» — неверно. Подпись «дней подряд» в мобайле корректна; чинится подсчёт на бэкенде.

## Фикс
Стрик теперь = число **уникальных дней** (в TZ юзера) в непрерывном on-time-прогоне:
- идём по истории DESC, cancelled пропускаем, стоп на первой `isOnTime()==false`;
- `doneAt` (LocalDateTime в UTC) конвертируем в TZ юзера → `LocalDate`, собираем в `Set`; результат = размер набора.
- Несколько on-time-уходов в один день → +1, а не +N.
- «Подряд» = непрерывный on-time-прогон без пропуска расписания (стоп на late), **не** календарно-смежные дни — растения с большим интервалом (напр. 7 дней) по-прежнему набирают стрик > 1.
- Шаг 1 (просроченное активное расписание `nextDueAt + 1 day < now` → 0) сохранён без изменений.

Таймзона прокинута: `computePlantStreak(plantId, timezone)` и `getPlantStats(plantId, timezone)` (тот же `safeZone(...)`, что у `computeUserStreak`). Вызовы из `StatsController.getPlantStreak` и из карточки истории (`PlantCardService`) передают `user.getTimezone()`.

## Тесты (Mockito, как и весь существующий `CareHistoryServiceTest`)
- `should_count_same_day_repeats_as_one_when_multiple_on_time_cares` — 5 уходов в один день → 1.
- `should_count_distinct_days_when_on_time_cares_on_separate_days` — 3 разных дня → 3.
- `should_dedup_by_user_timezone_when_cares_straddle_utc_midnight` — Europe/Moscow, два ухода по разные стороны UTC-полуночи в один локальный день → 1 (+контрольный кейс: те же данные под UTC → 2).
- Существующие тесты `computePlantStreak`/`getPlantStats`/`StatsControllerTest` приведены к новой сигнатуре и семантике (distinct-дни), ни один не отключён.

> Примечание по тестам: метод `computePlantStreak` — чистая in-memory логика над выдачей репозитория; весь файл `CareHistoryServiceTest` исторически на Mockito. Семантика дедупа дней по TZ юзера полностью покрывается на моках (явно задаём `doneAt` и timezone), поэтому сохранён сложившийся паттерн файла, без перевода на Testcontainers.

## Проверка
`mvn verify` (эквивалент `./mvnw verify`; wrapper `/mvnw` локальный и в .gitignore) под Java 21 и `TZ=UTC` — **BUILD SUCCESS, 1815 тестов, 0 падений**.

Backend-only. OpenAPI-спека и мобайл не тронуты.

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)