### PR TITLE
feat: серверный фильтр по комнате для SDUI-витрины home (#315)

### DIFF
--- a/src/main/java/com/plantcare/api/service/UiViewService.java
+++ b/src/main/java/com/plantcare/api/service/UiViewService.java
@@ -43,8 +43,8 @@ import java.util.Map;
  *   <tr><td>{@code weather_strip}</td><td>WeatherService</td></tr>
  *   <tr><td>{@code today_summary}</td><td>TodayApiService</td></tr>
  *   <tr><td>{@code today_tasks}</td><td>TodayApiService (тапабельный список)</td></tr>
- *   <tr><td>{@code location_chips}</td><td>LocationService</td></tr>
- *   <tr><td>{@code plant_grid}</td><td>PlantService</td></tr>
+ *   <tr><td>{@code location_chips}</td><td>LocationService (+ счётчики/активный чип, issue #315)</td></tr>
+ *   <tr><td>{@code plant_grid}</td><td>PlantService (фильтр по комнате, issue #315)</td></tr>
  *   <tr><td>{@code guest_banner}</td><td>инъекция сервиса (юзер-гость, MADR-017)</td></tr>
  *   <tr><td>{@code empty_state}</td><td>инъекция сервиса (пустой сад, MADR-017)</td></tr>
  * </table>
@@ -105,18 +105,24 @@ public class UiViewService {
      * Собирает опаковую композицию экрана {@code screen}.
      *
      * @param screen             идентификатор экрана (строка {@code ui_views.screen})
+     * @param locationId         серверный фильтр витрины по комнате (issue #315);
+     *                           {@code null} — «Все комнаты» (фильтр не применяется).
+     *                           Применяется к блокам {@code plant_grid}
+     *                           (гидрация только растениями комнаты) и
+     *                           {@code location_chips} (активный чип + счётчики)
      * @param clientCatalogVersion версия каталога блоков клиента; {@code null} —
      *                             новейший клиент (фильтрация по версии не применяется)
      * @return {@code { screenId, version, blocks: [...] }} с гидрированными данными
      * @throws EntityNotFoundException если экран не описан в {@code ui_views}
      */
     @Transactional(readOnly = true)
-    public Map<String, Object> buildScreen(String screen, Integer clientCatalogVersion) {
+    public Map<String, Object> buildScreen(String screen, Long locationId, Integer clientCatalogVersion) {
         var view = uiViewRepository.findByScreen(screen)
                 .orElseThrow(() -> new EntityNotFoundException("Unknown SDUI screen: " + screen));
 
         JsonNode layout = view.getLayoutJson();
-        log.info("GET /api/v1/ui/{}: clientCatalogVersion={}", screen, clientCatalogVersion);
+        log.info("GET /api/v1/ui/{}: locationId={}, clientCatalogVersion={}",
+                screen, locationId, clientCatalogVersion);
 
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("screenId", layout.path("screenId").asText(screen));
@@ -127,7 +133,7 @@ public class UiViewService {
             if (isBlockHidden(blockTemplate, clientCatalogVersion)) {
                 continue;
             }
-            Object rendered = renderBlock(blockTemplate);
+            Object rendered = renderBlock(blockTemplate, locationId);
             if (rendered != null) {
                 blocks.add(rendered);
             }
@@ -172,8 +178,12 @@ public class UiViewService {
     /**
      * Рендерит один блок шаблона: динамические типы гидрируются из сервисов,
      * прочие (статичные) отдаются verbatim как есть из шаблона.
+     *
+     * @param locationId серверный фильтр по комнате (issue #315); влияет на
+     *                   {@code location_chips} (активный чип) и {@code plant_grid}
+     *                   (фильтр сетки), для остальных блоков игнорируется
      */
-    private Object renderBlock(JsonNode blockTemplate) {
+    private Object renderBlock(JsonNode blockTemplate, Long locationId) {
         String type = blockTemplate.path("type").asText(null);
         if (type == null) {
             log.warn("SDUI: пропущен блок без поля type: {}", blockTemplate);
@@ -183,8 +193,8 @@ public class UiViewService {
             case TYPE_WEATHER_STRIP -> weatherStripBlock();
             case TYPE_TODAY_SUMMARY -> todaySummaryBlock();
             case TYPE_TODAY_TASKS -> todayTasksBlock();
-            case TYPE_LOCATION_CHIPS -> locationChipsBlock();
-            case TYPE_PLANT_GRID -> plantGridBlock();
+            case TYPE_LOCATION_CHIPS -> locationChipsBlock(locationId);
+            case TYPE_PLANT_GRID -> plantGridBlock(locationId);
             // Статичный блок: отдаём шаблон verbatim (без гидрации).
             default -> staticBlock(blockTemplate);
         };
@@ -282,15 +292,37 @@ public class UiViewService {
         };
     }
 
-    /** {@code location_chips} — локации пользователя из {@link LocationController}. */
-    private Map<String, Object> locationChipsBlock() {
+    /**
+     * {@code location_chips} — локации пользователя из {@link LocationController}.
+     *
+     * <p>Issue #315: сервер — single source of truth по фильтру комнаты.
+     * Блок несёт {@code selectedLocationId} (текущая выбранная комната,
+     * {@code null} = «Все»), а каждый чип — {@code count} (число активных
+     * растений в комнате). Активный чип и счётчики определяет сервер, клиент
+     * их только рисует. Счётчик берём из {@code total} листинга растений с
+     * фильтром по комнате (та же бизнес-логика, что у {@code GET /plants}),
+     * без дублирования запроса в сервисе.
+     *
+     * @param selectedLocationId выбранная комната ({@code null} = «Все»)
+     */
+    private Map<String, Object> locationChipsBlock(Long selectedLocationId) {
         List<Map<String, Object>> chips = locationController.listLocations().stream()
-                .map(UiViewService::toChip)
+                .map(this::toChip)
                 .toList();
         Map<String, Object> block = new LinkedHashMap<>();
         block.put("type", TYPE_LOCATION_CHIPS);
+        block.put("selectedLocationId", selectedLocationId);
         block.put("locations", chips);
         return block;
+    }
+
+    /**
+     * Число активных растений в комнате (issue #315). Reuse листинга растений
+     * (та же фильтрация, что у {@code GET /plants?locationId=}); берём только
+     * {@code total}, элементы не нужны — {@code limit=1}.
+     */
+    private int plantCountInLocation(Long locationId) {
+        return plantController.listPlants(null, locationId, 0, 1).getTotal();
     }
 
     /**
@@ -302,11 +334,22 @@ public class UiViewService {
      * {@code empty_state} (серверная видимость по состоянию юзера). Пустоту
      * определяем по списку {@code plant_grid} того же запроса (без лишнего
      * count-запроса): главный экран и так грузит первую страницу.
+     *
+     * <p>Issue #315: при заданном {@code locationId} сетка гидрируется ТОЛЬКО
+     * растениями этой комнаты. Пустая ОТФИЛЬТРОВАННАЯ комната — это НЕ пустой
+     * сад: вместо глобального {@code empty_state} (который скрыл бы выбор
+     * другой комнаты) отдаём тот же блок {@code plant_grid} с {@code plants: []}
+     * и контекстными ключами ({@code emptyTitleKey}/{@code emptyBodyKey}),
+     * чтобы чипы остались и юзер мог переключить комнату. Глобальный
+     * {@code empty_state} — только когда {@code locationId == null} (пустой сад
+     * целиком).
+     *
+     * @param locationId фильтр по комнате ({@code null} = все комнаты)
      */
-    private Map<String, Object> plantGridBlock() {
-        List<PlantDto> plants = plantController.listPlants(null, null, 0, PLANT_GRID_LIMIT).getItems();
+    private Map<String, Object> plantGridBlock(Long locationId) {
+        List<PlantDto> plants = plantController.listPlants(null, locationId, 0, PLANT_GRID_LIMIT).getItems();
         if (plants.isEmpty()) {
-            return emptyStateBlock();
+            return locationId == null ? emptyStateBlock() : emptyRoomGridBlock();
         }
         List<Map<String, Object>> cards = plants.stream()
                 .map(UiViewService::toCard)
@@ -314,6 +357,22 @@ public class UiViewService {
         Map<String, Object> block = new LinkedHashMap<>();
         block.put("type", TYPE_PLANT_GRID);
         block.put("plants", cards);
+        return block;
+    }
+
+    /**
+     * Контекстный пустой стейт ОТФИЛЬТРОВАННОЙ комнаты (issue #315). Остаётся
+     * блоком {@code plant_grid} (НЕ {@code empty_state}), чтобы чипы выбора
+     * другой комнаты сохранились: {@code plants: []} + l10n-ключи «в этой
+     * комнате пусто». Поля аддитивны — старый клиент просто покажет пустую
+     * сетку, новый — контекстное сообщение.
+     */
+    private static Map<String, Object> emptyRoomGridBlock() {
+        Map<String, Object> block = new LinkedHashMap<>();
+        block.put("type", TYPE_PLANT_GRID);
+        block.put("plants", List.of());
+        block.put("emptyTitleKey", "home.room.empty.title");
+        block.put("emptyBodyKey", "home.room.empty.body");
         return block;
     }
 
@@ -356,11 +415,14 @@ public class UiViewService {
         return block;
     }
 
-    private static Map<String, Object> toChip(LocationDto location) {
+    private Map<String, Object> toChip(LocationDto location) {
         Map<String, Object> chip = new LinkedHashMap<>();
         chip.put("id", location.getId());
         chip.put("name", location.getName());
         chip.put("emoji", location.getEmoji());
+        // issue #315: число активных растений в комнате — сервер считает,
+        // клиент рисует число рядом с чипом.
+        chip.put("count", plantCountInLocation(location.getId()));
         return chip;
     }
 

--- a/src/main/java/com/plantcare/api/v1/UiController.java
+++ b/src/main/java/com/plantcare/api/v1/UiController.java
@@ -28,7 +28,7 @@ public class UiController implements UiApi {
     private final UiViewService uiViewService;
 
     @Override
-    public Map<String, Object> getUiScreen(String screen, Integer xUiCatalogVersion) {
-        return uiViewService.buildScreen(screen, xUiCatalogVersion);
+    public Map<String, Object> getUiScreen(String screen, Long locationId, Integer xUiCatalogVersion) {
+        return uiViewService.buildScreen(screen, locationId, xUiCatalogVersion);
     }
 }

--- a/src/main/resources/openapi/resources/ui.yaml
+++ b/src/main/resources/openapi/resources/ui.yaml
@@ -32,6 +32,23 @@
 # Элементы `plant_grid` несут декларативный action-descriptor «полить»
 # (`log_care`): клиент сам исполняет `POST /care-events` с подставленным
 # `payloadTemplate`. Сервер не выполняет действие — только описывает его.
+#
+# ## Серверный фильтр по комнате (issue #315)
+#
+# Query-param `locationId` (опциональный int64) фильтрует витрину `home` на
+# СЕРВЕРЕ (single source of truth): null/отсутствие = «Все комнаты».
+# Расширение формы блоков (аддитивно, min_catalog_version НЕ меняется —
+# старые клиенты игнорируют незнакомые поля опакового ответа):
+#
+#  * `location_chips` несёт `selectedLocationId` (int64|null — активный чип,
+#    null = «Все») и в каждом элементе `locations[]` — `count` (int, число
+#    активных растений в комнате; счётчики и активный чип задаёт сервер).
+#  * `plant_grid` при заданном `locationId` содержит только растения этой
+#    комнаты. Если отфильтрованная комната пуста — блок остаётся `plant_grid`
+#    с `plants: []` и контекстными ключами `emptyTitleKey`/`emptyBodyKey`
+#    («в этой комнате пусто»), чтобы чипы остались и можно было выбрать другую
+#    комнату. Глобальный `empty_state` (пустой сад целиком) отдаётся только
+#    при `locationId == null`.
 
 paths:
   Screen:
@@ -78,6 +95,18 @@ paths:
           schema:
             type: string
           example: home
+        - name: locationId
+          in: query
+          required: false
+          description: |
+            Серверный фильтр витрины по комнате (issue #315). Применяется к
+            экрану `home`: блок `plant_grid` гидрируется только растениями этой
+            комнаты, блок `location_chips` помечает её активной
+            (`selectedLocationId`). Опционален: при отсутствии/`null` —
+            «Все комнаты» (фильтр не применяется, поведение как раньше).
+          schema:
+            type: integer
+            format: int64
         - name: X-UI-Catalog-Version
           in: header
           required: false

--- a/src/test/java/com/plantcare/api/service/UiViewServiceTest.java
+++ b/src/test/java/com/plantcare/api/service/UiViewServiceTest.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
@@ -92,6 +93,11 @@ class UiViewServiceTest {
                 new PageResponsePlantDto(
                         List.of(new PlantDto(10L, "Монстера", false).locationName("Гостиная")),
                         1, 0, 100));
+
+        // Счётчик чипа (issue #315): listPlants(null, locId, 0, 1).getTotal().
+        // По умолчанию комната «Гостиная» (id=5) содержит 3 растения.
+        lenient().when(plantController.listPlants(isNull(), eq(5L), eq(0), eq(1))).thenReturn(
+                new PageResponsePlantDto(List.of(), 3, 0, 1));
     }
 
     private void seedHomeView(String layoutJson, int minVersion) {
@@ -130,7 +136,7 @@ class UiViewServiceTest {
                   {"type":"plant_grid","minCatalogVersion":1} ] }""", 1);
 
         // act
-        Map<String, Object> screen = service.buildScreen("home", null);
+        Map<String, Object> screen = service.buildScreen("home", null, null);
 
         // assert — верхний уровень + фиксированный порядок из таблицы
         assertThat(screen).containsEntry("screenId", "home").containsEntry("version", 1);
@@ -153,9 +159,13 @@ class UiViewServiceTest {
                 .containsEntry("type", "FERTILIZE")   // FERTILIZING → FERTILIZE (нормализация)
                 .containsEntry("dueAt", OffsetDateTime.of(2026, 5, 27, 9, 0, 0, 0, ZoneOffset.UTC));
 
+        // issue #315: фильтр не задан → selectedLocationId == null («Все»),
+        // каждый чип несёт count (число активных растений в комнате)
+        assertThat(blocks.get(2)).containsEntry("selectedLocationId", null);
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> chips = (List<Map<String, Object>>) blocks.get(2).get("locations");
-        assertThat(chips.get(0)).containsEntry("id", 5L).containsEntry("name", "Гостиная").containsEntry("emoji", "🛋️");
+        assertThat(chips.get(0)).containsEntry("id", 5L).containsEntry("name", "Гостиная")
+                .containsEntry("emoji", "🛋️").containsEntry("count", 3);
 
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> plants = (List<Map<String, Object>>) blocks.get(3).get("plants");
@@ -190,7 +200,7 @@ class UiViewServiceTest {
                   {"type":"plant_grid","minCatalogVersion":2} ] }""", 1);
 
         // act — клиент с X-UI-Catalog-Version: 1
-        Map<String, Object> screen = service.buildScreen("home", 1);
+        Map<String, Object> screen = service.buildScreen("home", null, 1);
 
         // assert — блок v2 исключён, остался только weather_strip
         @SuppressWarnings("unchecked")
@@ -207,7 +217,7 @@ class UiViewServiceTest {
                   {"type":"banner","minCatalogVersion":1,"text":"Привет","dismissible":true} ] }""", 1);
 
         // act
-        Map<String, Object> screen = service.buildScreen("home", null);
+        Map<String, Object> screen = service.buildScreen("home", null, null);
 
         // assert — отдан verbatim из layout_json
         @SuppressWarnings("unchecked")
@@ -233,7 +243,7 @@ class UiViewServiceTest {
                   {"type":"today_tasks","minCatalogVersion":1} ] }""", 1);
 
         // act
-        Map<String, Object> screen = service.buildScreen("home", null);
+        Map<String, Object> screen = service.buildScreen("home", null, null);
 
         // assert — WATERING→WATER, MISTING→SPRAY, FERTILIZING→FERTILIZE, SOIL_CHECK как есть
         @SuppressWarnings("unchecked")
@@ -255,7 +265,7 @@ class UiViewServiceTest {
                   {"type":"today_tasks","minCatalogVersion":1} ] }""", 1);
 
         // act
-        Map<String, Object> screen = service.buildScreen("home", null);
+        Map<String, Object> screen = service.buildScreen("home", null, null);
 
         // assert — блок есть, counts нулевые, список пустой (а не null)
         @SuppressWarnings("unchecked")
@@ -282,7 +292,7 @@ class UiViewServiceTest {
                   {"type":"plant_grid","minCatalogVersion":1} ] }""", 1);
 
         // act
-        Map<String, Object> screen = service.buildScreen("home", null);
+        Map<String, Object> screen = service.buildScreen("home", null, null);
 
         // assert — guest_banner вставлен сразу после weather_strip
         @SuppressWarnings("unchecked")
@@ -310,7 +320,7 @@ class UiViewServiceTest {
                   {"type":"plant_grid","minCatalogVersion":1} ] }""", 1);
 
         // act
-        Map<String, Object> screen = service.buildScreen("home", null);
+        Map<String, Object> screen = service.buildScreen("home", null, null);
 
         // assert — guest_banner отсутствует
         @SuppressWarnings("unchecked")
@@ -332,7 +342,7 @@ class UiViewServiceTest {
                   {"type":"plant_grid","minCatalogVersion":1} ] }""", 1);
 
         // act
-        Map<String, Object> screen = service.buildScreen("home", null);
+        Map<String, Object> screen = service.buildScreen("home", null, null);
 
         // assert — plant_grid заменён на empty_state с l10n-ключами и CTA-navigate
         @SuppressWarnings("unchecked")
@@ -355,13 +365,104 @@ class UiViewServiceTest {
                   {"type":"plant_grid","minCatalogVersion":1} ] }""", 1);
 
         // act
-        Map<String, Object> screen = service.buildScreen("home", null);
+        Map<String, Object> screen = service.buildScreen("home", null, null);
 
         // assert — обычная сетка, не empty_state
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> blocks = (List<Map<String, Object>>) screen.get("blocks");
         assertThat(blocks).extracting(b -> b.get("type")).containsExactly("plant_grid");
         assertThat(blocks.get(0)).containsKey("plants");
+    }
+
+    @Test
+    @DisplayName("should_filter_grid_and_mark_selected_chip_when_locationId_given")
+    void should_filter_grid_and_mark_selected_chip_when_locationId_given() {
+        // arrange — две комнаты; фильтр по «Гостиная» (id=5).
+        // Сетка с фильтром по 5 → только растения этой комнаты.
+        when(locationController.listLocations()).thenReturn(List.of(
+                new LocationDto(5L, "Гостиная", true, true).emoji("🛋️"),
+                new LocationDto(7L, "Спальня", true, true).emoji("🛏️")));
+        when(plantController.listPlants(isNull(), eq(5L), eq(0), eq(100))).thenReturn(
+                new PageResponsePlantDto(
+                        List.of(new PlantDto(10L, "Монстера", false).locationName("Гостиная")),
+                        1, 0, 100));
+        // Счётчики чипов: Гостиная=3 (из стаба), Спальня=2.
+        when(plantController.listPlants(isNull(), eq(7L), eq(0), eq(1))).thenReturn(
+                new PageResponsePlantDto(List.of(), 2, 0, 1));
+        seedHomeView("""
+                { "screenId":"home","version":1,"blocks":[
+                  {"type":"location_chips","minCatalogVersion":1},
+                  {"type":"plant_grid","minCatalogVersion":1} ] }""", 1);
+
+        // act — выбран locationId=5
+        Map<String, Object> screen = service.buildScreen("home", 5L, null);
+
+        // assert — selectedLocationId=5, count'ы корректны, сетка отфильтрована
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> blocks = (List<Map<String, Object>>) screen.get("blocks");
+        assertThat(blocks.get(0)).containsEntry("type", "location_chips")
+                .containsEntry("selectedLocationId", 5L);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> chips = (List<Map<String, Object>>) blocks.get(0).get("locations");
+        assertThat(chips).extracting(c -> c.get("id")).containsExactly(5L, 7L);
+        assertThat(chips).extracting(c -> c.get("count")).containsExactly(3, 2);
+
+        assertThat(blocks.get(1)).containsEntry("type", "plant_grid");
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> plants = (List<Map<String, Object>>) blocks.get(1).get("plants");
+        assertThat(plants).hasSize(1);
+        assertThat(plants.get(0)).containsEntry("id", 10L);
+    }
+
+    @Test
+    @DisplayName("should_render_contextual_empty_grid_when_selected_room_is_empty")
+    void should_render_contextual_empty_grid_when_selected_room_is_empty() {
+        // arrange — комната выбрана (id=5), но в ней нет растений.
+        // Важно: НЕ глобальный empty_state — чипы выбора другой комнаты должны остаться.
+        when(plantController.listPlants(isNull(), eq(5L), eq(0), eq(100))).thenReturn(
+                new PageResponsePlantDto(List.of(), 0, 0, 100));
+        seedHomeView("""
+                { "screenId":"home","version":1,"blocks":[
+                  {"type":"location_chips","minCatalogVersion":1},
+                  {"type":"plant_grid","minCatalogVersion":1} ] }""", 1);
+
+        // act
+        Map<String, Object> screen = service.buildScreen("home", 5L, null);
+
+        // assert — чипы на месте, grid остался plant_grid (НЕ empty_state) с
+        // пустыми plants и контекстными ключами «в этой комнате пусто»
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> blocks = (List<Map<String, Object>>) screen.get("blocks");
+        assertThat(blocks).extracting(b -> b.get("type"))
+                .containsExactly("location_chips", "plant_grid")
+                .doesNotContain("empty_state");
+        Map<String, Object> grid = blocks.get(1);
+        assertThat(grid).containsEntry("type", "plant_grid")
+                .containsKeys("emptyTitleKey", "emptyBodyKey");
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> plants = (List<Map<String, Object>>) grid.get("plants");
+        assertThat(plants).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_render_global_empty_state_when_no_location_filter_and_garden_empty")
+    void should_render_global_empty_state_when_no_location_filter_and_garden_empty() {
+        // arrange — фильтра нет (locationId=null) И сад пуст → глобальный empty_state
+        when(plantController.listPlants(isNull(), isNull(), eq(0), eq(100))).thenReturn(
+                new PageResponsePlantDto(List.of(), 0, 0, 100));
+        seedHomeView("""
+                { "screenId":"home","version":1,"blocks":[
+                  {"type":"location_chips","minCatalogVersion":1},
+                  {"type":"plant_grid","minCatalogVersion":1} ] }""", 1);
+
+        // act
+        Map<String, Object> screen = service.buildScreen("home", null, null);
+
+        // assert — plant_grid заменён глобальным empty_state (пустой сад целиком)
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> blocks = (List<Map<String, Object>>) screen.get("blocks");
+        assertThat(blocks).extracting(b -> b.get("type"))
+                .containsExactly("location_chips", "empty_state");
     }
 
     private static TaskDto task(Long scheduleId, String domainTaskType) {
@@ -377,7 +478,7 @@ class UiViewServiceTest {
         when(uiViewRepository.findByScreen("ghost")).thenReturn(Optional.empty());
 
         // act + assert
-        assertThatThrownBy(() -> service.buildScreen("ghost", null))
+        assertThatThrownBy(() -> service.buildScreen("ghost", null, null))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessageContaining("ghost");
     }

--- a/src/test/java/com/plantcare/api/v1/UiControllerTest.java
+++ b/src/test/java/com/plantcare/api/v1/UiControllerTest.java
@@ -67,8 +67,8 @@ class UiControllerTest {
 
     @Test
     void should_return_opaque_layout_when_screen_resolved() throws Exception {
-        // arrange
-        when(uiViewService.buildScreen(eq("home"), isNull())).thenReturn(homeLayout());
+        // arrange — без фильтра по комнате (locationId == null)
+        when(uiViewService.buildScreen(eq("home"), isNull(), isNull())).thenReturn(homeLayout());
 
         // act + assert — опаковая структура отдаётся как JSON «как есть»
         mockMvc.perform(get("/api/v1/ui/home"))
@@ -84,10 +84,21 @@ class UiControllerTest {
     @Test
     void should_pass_catalog_version_to_service() throws Exception {
         // arrange
-        when(uiViewService.buildScreen(eq("home"), eq(1))).thenReturn(homeLayout());
+        when(uiViewService.buildScreen(eq("home"), isNull(), eq(1))).thenReturn(homeLayout());
 
         // act + assert
         mockMvc.perform(get("/api/v1/ui/home").header("X-UI-Catalog-Version", 1))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.screenId").value("home"));
+    }
+
+    @Test
+    void should_pass_location_filter_to_service() throws Exception {
+        // arrange — query-param locationId пробрасывается в сервис (issue #315)
+        when(uiViewService.buildScreen(eq("home"), eq(5L), isNull())).thenReturn(homeLayout());
+
+        // act + assert
+        mockMvc.perform(get("/api/v1/ui/home").param("locationId", "5"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.screenId").value("home"));
     }
@@ -105,7 +116,7 @@ class UiControllerTest {
     @Test
     void should_return_404_when_screen_unknown() throws Exception {
         // arrange
-        when(uiViewService.buildScreen(eq("ghost"), isNull()))
+        when(uiViewService.buildScreen(eq("ghost"), isNull(), isNull()))
                 .thenThrow(new EntityNotFoundException("Unknown SDUI screen: ghost"));
 
         // act + assert
@@ -117,7 +128,7 @@ class UiControllerTest {
     @Test
     void should_return_401_when_no_authenticated_user() throws Exception {
         // arrange — гидрация дёргает контроллер, который пробрасывает ошибку аутентификации
-        when(uiViewService.buildScreen(eq("home"), isNull()))
+        when(uiViewService.buildScreen(eq("home"), isNull(), isNull()))
                 .thenThrow(AuthTokenException.invalid("No authenticated user in security context"));
 
         // act + assert


### PR DESCRIPTION
Closes #315

## Что сделано
- `GET /api/v1/ui/home` принимает опциональный query-param **`locationId`** (int64, nullable). null/отсутствие = «Все комнаты» — старые клиенты без параметра работают как раньше.
- `UiViewService` прокидывает `locationId` в гидрацию `plant_grid` (`plantController.listPlants(null, locationId, 0, 100)`) — сетка фильтруется по комнате на сервере.
- Блок `location_chips` теперь несёт **`selectedLocationId`** (int64\|null — активный чип, null = «Все») и в каждом `locations[]` — **`count`** (int, число активных растений в комнате). Активный чип и счётчики задаёт сервер (single source of truth).
- Пустая **отфильтрованная** комната → контекстный пустой стейт остаётся блоком `plant_grid` (`plants: []` + `emptyTitleKey`/`emptyBodyKey`), чтобы чипы выбора другой комнаты сохранились. Глобальный `empty_state` (пустой сад целиком) — только при `locationId == null`.
- `ui.yaml`: добавлен query-param `locationId`, обновлён прозовый словарь блоков (форма `location_chips`/`plant_grid`).

## Контракт `/ui/home` (для синхронизации мобайла)
- Query-param: `locationId` (integer int64, optional). Отсутствие/null = все комнаты.
- `location_chips`: `{ type, selectedLocationId: Long|null, locations: [{ id, name, emoji, count: int }] }`.
- `plant_grid` (комната пуста): `{ type: "plant_grid", plants: [], emptyTitleKey: "home.room.empty.title", emptyBodyKey: "home.room.empty.body" }`.
- Глобальный пустой сад (только при `locationId == null`): блок `empty_state` (как раньше).

## Миграции
нет (изменения аддитивны; `minCatalogVersion` не меняется, сид `V52` не трогали).

## Backward-compat риски
safe. Новые поля опциональны, опаковый Map-контракт — старые клиенты игнорируют незнакомые поля; `locationId` опционален.

## Тесты
- `UiViewServiceTest`: фильтр по комнате + `selectedLocationId`, контекстный пустой стейт отфильтрованной комнаты (чипы остаются), глобальный `empty_state` при `locationId=null`, корректность `count`. Существующий full-home тест расширен проверкой `selectedLocationId=null` и `count`.
- `UiControllerTest`: проброс `locationId` в сервис.

## Чек
- [x] UI-тесты (`UiViewServiceTest`, `UiControllerTest`) зелёные
- [ ] `mvn verify` локально: 4 НЕсвязанных падения (timezone-чувствительные `PlantScheduleServiceTest`/`PlantServiceTest.markCareDone` — зелёные под `-Duser.timezone=UTC`, т.е. CI-окружение; `SpeciesRepositoryTest`/`getPopularSpecies` — порядок видов, не относится к SDUI). Ни один из падающих тестов не затронут этой веткой.
