### PR TITLE
feat: мультиканальный фан-аут напоминаний (Telegram + Push) (#177)

### DIFF
--- a/src/main/java/com/plantcare/bot/service/NotificationDeliveryCallbacks.java
+++ b/src/main/java/com/plantcare/bot/service/NotificationDeliveryCallbacks.java
@@ -8,6 +8,7 @@ import com.plantcare.core.domain.enums.TaskType;
 import com.plantcare.core.metrics.MetricsService;
 import com.plantcare.core.repository.NotificationLogRepository;
 import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.UserDeviceRepository;
 import com.plantcare.core.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +37,7 @@ public class NotificationDeliveryCallbacks {
     private final NotificationLogRepository notificationLogRepository;
     private final PlantRepository plantRepository;
     private final UserRepository userRepository;
+    private final UserDeviceRepository userDeviceRepository;
     private final MetricsService metricsService;
 
     /**
@@ -103,6 +105,55 @@ public class NotificationDeliveryCallbacks {
             };
             metricsService.recordNotificationFailed(MetricsService.CHANNEL_TELEGRAM, reason);
         }
+    }
+
+    /**
+     * Зафиксировать успешную push-доставку (issue #177): метрика sent в канале
+     * {@link MetricsService#CHANNEL_PUSH}. Дедуп-лог по задаче в push-канал
+     * отдельно НЕ пишется — дедуп ведётся канал-независимо по {@code notifications_log}
+     * в {@code shouldSend}, и его уже пишет основной (telegram) путь либо
+     * push-путь шедулера для mobile-only юзера. Здесь фиксируем только метрику
+     * доставки.
+     *
+     * @param taskType тип задачи (для среза «сколько поливных пушей в день»)
+     */
+    @Transactional
+    public void onPushSent(TaskType taskType) {
+        metricsService.recordNotificationSent(MetricsService.CHANNEL_PUSH, taskType);
+    }
+
+    /**
+     * Обработать протухший push-токен (issue #177): FCM вернул
+     * {@code UNREGISTERED} / {@code NOT_FOUND} — приложение удалено или токен
+     * ротировал. Удаляем запись устройства из {@code user_devices}, чтобы не
+     * слать в пустоту на каждом тике, и пишем метрику неудачи в push-канал.
+     *
+     * <p>Идемпотентно: если устройство уже удалено (например, конкурентным
+     * тиком), повторный вызов просто ничего не делает.
+     *
+     * @param deviceId id записи устройства в {@code user_devices}
+     */
+    @Transactional
+    public void onPushStaleToken(long deviceId) {
+        userDeviceRepository.findById(deviceId).ifPresentOrElse(
+                device -> {
+                    userDeviceRepository.delete(device);
+                    log.info("Removed stale device id={} (FCM UNREGISTERED/NOT_FOUND)", deviceId);
+                },
+                () -> log.debug("Stale device id={} already removed, skipping", deviceId));
+        metricsService.recordNotificationFailed(
+                MetricsService.CHANNEL_PUSH, MetricsService.FailureReason.OTHER);
+    }
+
+    /**
+     * Зафиксировать неудачную push-доставку, не связанную с протухшим токеном
+     * (issue #177): сеть, 5xx провайдера. Токен не трогаем — повтор на следующем
+     * тике.
+     */
+    @Transactional
+    public void onPushFailed() {
+        metricsService.recordNotificationFailed(
+                MetricsService.CHANNEL_PUSH, MetricsService.FailureReason.OTHER);
     }
 
     private void saveNotificationLog(Plant plant, TaskType taskType) {

--- a/src/main/java/com/plantcare/bot/service/NotificationSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/NotificationSchedulerService.java
@@ -1,6 +1,5 @@
 package com.plantcare.bot.service;
 
-import com.plantcare.core.service.PushSender;
 import com.plantcare.core.service.QuietHoursPolicy;
 import com.plantcare.core.service.SchedulerHealthTracker;
 
@@ -60,9 +59,12 @@ public class NotificationSchedulerService {
     private final RateLimitedTelegramSender telegramSender;
     private final NotificationDeliveryCallbacks deliveryCallbacks;
     private final com.plantcare.core.service.LocationSharingService locationSharingService;
-    // Issue #175: push-канал и репозиторий устройств для fan-out на мобильные клиенты
-    private final PushSender pushSender;
+    // Issue #175 / #177: репозиторий устройств читается внутри тика (формируем
+    // примитивные PushTarget'ы), а реальная push-раздача исполняется сервисом
+    // мультиканального fan-out ВНЕ транзакции тика (CLAUDE.md: внешние API не
+    // зовём из открытой транзакции к БД).
     private final UserDeviceRepository userDeviceRepository;
+    private final PushFanOutService pushFanOutService;
 
     // Issue #279: lockAtMostFor > fixedRate (2m > 1m) — если инстанс повис, лок
     // освобождается через 2 мин, следующий тик уже через 1 мин возьмёт его.
@@ -358,10 +360,11 @@ public class NotificationSchedulerService {
                     e -> deliveryCallbacks.onFailed(chatId, e)));
         }
 
-        // Issue #175: fan-out на мобильные устройства пользователя.
+        // Issue #175 / #177: fan-out на мобильные устройства пользователя.
         // Telegram-юзеры тоже могут иметь mobile-устройства (оба канала получат уведомление).
-        // Тихие часы / paused_until уже проверены в shouldSend() выше.
-        fanOutToMobileDevices(user, plant, text);
+        // Тихие часы / paused_until уже проверены в shouldSend() выше. Доставка push'а
+        // вынесена ВНЕ транзакции тика (см. fanOutToMobileDevices).
+        fanOutToMobileDevices(user, schedule.getTaskType(), text);
 
         // Совместный уход (issue #77): тот же push веером уходит caretaker'ам с
         // доступом к локации растения. Клавиатура завязана на scheduleId, а callback
@@ -373,26 +376,26 @@ public class NotificationSchedulerService {
 
     /**
      * Fan-out push-уведомления на все зарегистрированные мобильные устройства
-     * пользователя (issue #175). Quiet hours и paused_until уже проверены выше.
-     * Ошибки отдельного устройства не останавливают остальные.
+     * пользователя (issue #175 / #177). Quiet hours и paused_until уже проверены
+     * канал-нейтрально в {@code shouldSend()} выше — push и Telegram равноправны.
+     *
+     * <p>Внутри транзакции тика мы только читаем устройства и формируем
+     * примитивные {@link PushFanOutService.PushTarget} (никаких detached-entity
+     * между потоками), а реальную доставку отдаём {@link PushFanOutService},
+     * который исполняет её ВНЕ транзакции тика (CLAUDE.md: внешние API не зовём
+     * из открытой транзакции). Ошибки отдельного устройства и bookkeeping
+     * (метрика доставки, удаление протухшего токена) разруливаются там же.
      */
-    private void fanOutToMobileDevices(User user, Plant plant, String text) {
+    private void fanOutToMobileDevices(User user, TaskType taskType, String text) {
         List<UserDevice> devices = userDeviceRepository.findByUserId(user.getId());
         if (devices.isEmpty()) {
             return;
         }
-        String title = "Plants Care";
-        for (UserDevice device : devices) {
-            try {
-                pushSender.send(device.getPushToken(), title, text);
-                log.debug("Push sent to device id={} platform={} for plant id={}",
-                        device.getId(), device.getPlatform(), plant.getId());
-            } catch (Exception e) {
-                log.warn("Push failed for device id={} platform={}: {}",
-                        device.getId(), device.getPlatform(), e.getMessage());
-                Sentry.captureException(e);
-            }
-        }
+        List<PushFanOutService.PushTarget> targets = devices.stream()
+                .map(device -> new PushFanOutService.PushTarget(
+                        device.getId(), device.getPushToken(), text, taskType))
+                .toList();
+        pushFanOutService.enqueue(targets);
     }
 
     /**

--- a/src/main/java/com/plantcare/bot/service/PushFanOutService.java
+++ b/src/main/java/com/plantcare/bot/service/PushFanOutService.java
@@ -1,0 +1,116 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.service.PushSender;
+import com.plantcare.core.service.PushSender.PushResult;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Мультиканальный push-fan-out для шедулера напоминаний (issue #177, ADR-014).
+ *
+ * <p>Шедулер ({@link NotificationSchedulerService}) исполняет тик внутри открытой
+ * {@code @Transactional}-транзакции. CLAUDE.md запрещает вызовы внешних API
+ * (Telegram / FCM / APNs) внутри открытой транзакции к БД — поэтому фактическая
+ * раздача push'ей вынесена сюда и исполняется на выделенном daemon-исполнителе
+ * ВНЕ транзакции тика. Шедулер отдаёт только примитивные DTO ({@link PushTarget}),
+ * не таща detached JPA-entity между потоками.
+ *
+ * <p>Bookkeeping (метрика доставки в канал {@link com.plantcare.core.metrics.MetricsService#CHANNEL_PUSH},
+ * удаление протухшего device-токена на {@link PushResult#STALE_TOKEN}) выполняет
+ * {@link NotificationDeliveryCallbacks}, каждый метод которого открывает
+ * собственную транзакцию на воркер-потоке.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PushFanOutService {
+
+    /** Заголовок push-уведомления (канал-нейтральный, как и текст задачи). */
+    public static final String PUSH_TITLE = "Plants Care";
+
+    private final PushSender pushSender;
+    private final NotificationDeliveryCallbacks deliveryCallbacks;
+
+    /**
+     * Однопоточный daemon-исполнитель: гарантирует, что доставка идёт ВНЕ
+     * транзакции тика, не блокирует шедулер и не держит лишних потоков.
+     */
+    private final ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "push-fanout");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    /**
+     * Поставить push-раздачу по списку устройств в исполнение ВНЕ транзакции
+     * вызывающего тика. Метод не блокирует шедулер: вся доставка и bookkeeping
+     * происходят на воркер-потоке.
+     *
+     * @param targets устройства с готовым канал-нейтральным текстом
+     */
+    public void enqueue(List<PushTarget> targets) {
+        if (targets == null || targets.isEmpty()) {
+            return;
+        }
+        executor.execute(() -> {
+            for (PushTarget target : targets) {
+                deliver(target);
+            }
+        });
+    }
+
+    /**
+     * Доставить один push и сделать bookkeeping по исходу. Package-private —
+     * чтобы юнит-тест мог дёргать синхронно с замоканным {@link PushSender}.
+     * Любая ошибка отдельного устройства не прерывает остальные (вызывающий цикл).
+     */
+    void deliver(PushTarget target) {
+        try {
+            PushResult result = pushSender.send(target.pushToken(), PUSH_TITLE, target.body());
+            switch (result) {
+                case SENT -> deliveryCallbacks.onPushSent(target.taskType());
+                case STALE_TOKEN -> deliveryCallbacks.onPushStaleToken(target.deviceId());
+                case FAILED -> deliveryCallbacks.onPushFailed();
+            }
+        } catch (Exception e) {
+            // Порт по контракту не должен бросать, но защищаемся: падение одного
+            // устройства не должно ронять воркер и остальные устройства.
+            log.warn("Push delivery threw for device id={}: {}", target.deviceId(), e.getMessage());
+            deliveryCallbacks.onPushFailed();
+        }
+    }
+
+    @PreDestroy
+    void shutdown() {
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+        log.info("Push fan-out executor stopped");
+    }
+
+    /**
+     * Канал-нейтральная цель push-доставки (issue #177): примитивы, безопасные
+     * для передачи между потоками (никаких detached-entity).
+     *
+     * @param deviceId  id записи устройства в {@code user_devices} (для удаления на STALE_TOKEN)
+     * @param pushToken push-токен устройства
+     * @param body      готовый канал-нейтральный текст уведомления
+     * @param taskType  тип задачи (для среза метрики доставки)
+     */
+    public record PushTarget(long deviceId, String pushToken, String body, TaskType taskType) {
+    }
+}

--- a/src/main/java/com/plantcare/core/config/NoopPushSender.java
+++ b/src/main/java/com/plantcare/core/config/NoopPushSender.java
@@ -13,7 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 public class NoopPushSender implements PushSender {
 
     @Override
-    public void send(String pushToken, String title, String body) {
+    public PushResult send(String pushToken, String title, String body) {
         log.debug("Push disabled (push.enabled=false) — skipped: token={}, title={}", pushToken, title);
+        return PushResult.SENT;
     }
 }

--- a/src/main/java/com/plantcare/core/metrics/MetricsService.java
+++ b/src/main/java/com/plantcare/core/metrics/MetricsService.java
@@ -48,6 +48,8 @@ public class MetricsService {
     public static final String SCHEDULER_TICK_DURATION     = "scheduler.tick.duration";
 
     public static final String CHANNEL_TELEGRAM = "telegram";
+    /** Канал доставки push-уведомлений на мобильные устройства (issue #177). */
+    public static final String CHANNEL_PUSH = "push";
 
     /**
      * Whitelist разрешённых значений тэга {@code action} для метрики

--- a/src/main/java/com/plantcare/core/service/PushSender.java
+++ b/src/main/java/com/plantcare/core/service/PushSender.java
@@ -10,12 +10,21 @@ package com.plantcare.core.service;
  * </ul>
  *
  * <p>Когда {@code push.enabled=false} (дефолт), {@link com.plantcare.core.config.NoopPushSender}
- * проглатывает все вызовы без обращения к внешним сервисам.
+ * проглатывает все вызовы без обращения к внешним сервисам и возвращает
+ * {@link PushResult#SENT}.
  *
  * <p>Контракт: метод идемпотентен с точки зрения бизнес-логики — повторная
- * отправка на один и тот же токен не является ошибкой. Если токен просрочен
- * или недоступен, реализация логирует предупреждение и возвращает управление
- * без исключения (чтобы не сломать шедулер).
+ * отправка на один и тот же токен не является ошибкой. Реализация НЕ бросает
+ * исключение на ошибки доставки (чтобы не сломать шедулер), а сообщает исход
+ * через {@link PushResult}:
+ * <ul>
+ *   <li>{@link PushResult#SENT} — доставлено провайдеру;</li>
+ *   <li>{@link PushResult#STALE_TOKEN} — токен протух/неизвестен
+ *       (FCM {@code UNREGISTERED} / {@code NOT_FOUND}); вызывающий обязан удалить
+ *       запись устройства из {@code user_devices} (issue #177);</li>
+ *   <li>{@link PushResult#FAILED} — иная ошибка доставки (сеть, 5xx провайдера);
+ *       токен остаётся, повтор возможен на следующем тике.</li>
+ * </ul>
  */
 public interface PushSender {
 
@@ -25,6 +34,23 @@ public interface PushSender {
      * @param pushToken push-токен устройства (FCM registration token / APNs device token)
      * @param title     заголовок уведомления
      * @param body      текст уведомления
+     * @return исход доставки (см. {@link PushResult})
      */
-    void send(String pushToken, String title, String body);
+    PushResult send(String pushToken, String title, String body);
+
+    /**
+     * Исход доставки push-уведомления (issue #177). Мультиканальный fan-out
+     * принимает решения по нему, не зная деталей конкретного провайдера.
+     */
+    enum PushResult {
+        /** Доставлено провайдеру (или проглочено no-op-реализацией). */
+        SENT,
+        /**
+         * Токен протух/неизвестен (FCM {@code UNREGISTERED} / {@code NOT_FOUND}).
+         * Запись устройства подлежит удалению из {@code user_devices}.
+         */
+        STALE_TOKEN,
+        /** Иная ошибка доставки — токен остаётся, повтор на следующем тике. */
+        FAILED
+    }
 }

--- a/src/test/java/com/plantcare/bot/service/NotificationDeliveryCallbacksTest.java
+++ b/src/test/java/com/plantcare/bot/service/NotificationDeliveryCallbacksTest.java
@@ -1,15 +1,18 @@
 package com.plantcare.bot.service;
 
+import com.plantcare.core.domain.DevicePlatform;
 import com.plantcare.core.domain.Location;
 import com.plantcare.core.domain.NotificationLog;
 import com.plantcare.core.domain.Plant;
 import com.plantcare.core.domain.User;
+import com.plantcare.core.domain.UserDevice;
 import com.plantcare.core.domain.enums.NotificationType;
 import com.plantcare.core.domain.enums.TaskType;
 import com.plantcare.core.metrics.MetricsService;
 import com.plantcare.core.repository.LocationRepository;
 import com.plantcare.core.repository.NotificationLogRepository;
 import com.plantcare.core.repository.PlantRepository;
+import com.plantcare.core.repository.UserDeviceRepository;
 import com.plantcare.core.repository.UserRepository;
 import com.plantcare.bot.support.IntegrationTestBase;
 import org.junit.jupiter.api.AfterEach;
@@ -39,12 +42,14 @@ class NotificationDeliveryCallbacksTest extends IntegrationTestBase {
     @Autowired private LocationRepository locationRepository;
     @Autowired private PlantRepository plantRepository;
     @Autowired private NotificationLogRepository notificationLogRepository;
+    @Autowired private UserDeviceRepository userDeviceRepository;
 
     @MockitoBean private MetricsService metricsService;
 
     @AfterEach
     void cleanup() {
         notificationLogRepository.deleteAll();
+        userDeviceRepository.deleteAll();
         plantRepository.deleteAll();
         locationRepository.deleteAll();
         userRepository.deleteAll();
@@ -139,6 +144,59 @@ class NotificationDeliveryCallbacksTest extends IntegrationTestBase {
 
         verify(metricsService).recordNotificationFailed(
                 MetricsService.CHANNEL_TELEGRAM, MetricsService.FailureReason.BLOCKED);
+    }
+
+    // ===== push-канал (issue #177) =====
+
+    @Test
+    @DisplayName("should_record_push_sent_metric_when_on_push_sent")
+    void should_record_push_sent_metric_when_on_push_sent() {
+        // act
+        callbacks.onPushSent(TaskType.WATERING);
+
+        // assert — отдельный канал push, отдельный дедуп-лог по push НЕ пишем
+        verify(metricsService).recordNotificationSent(MetricsService.CHANNEL_PUSH, TaskType.WATERING);
+        assertThat(notificationLogRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should_delete_stale_device_and_record_failure_when_on_push_stale_token")
+    void should_delete_stale_device_and_record_failure_when_on_push_stale_token() {
+        // arrange — у юзера есть устройство, FCM сообщил что токен протух
+        User user = savedUser(104L);
+        UserDevice device = userDeviceRepository.save(new UserDevice(
+                user, DevicePlatform.ANDROID, "stale-fcm-token", java.time.Instant.now()));
+
+        // act
+        callbacks.onPushStaleToken(device.getId());
+
+        // assert — запись устройства удалена, метрика неудачи записана в push-канал
+        assertThat(userDeviceRepository.findById(device.getId())).isEmpty();
+        verify(metricsService).recordNotificationFailed(
+                MetricsService.CHANNEL_PUSH, MetricsService.FailureReason.OTHER);
+    }
+
+    @Test
+    @DisplayName("should_be_idempotent_when_on_push_stale_token_and_device_already_removed")
+    void should_be_idempotent_when_on_push_stale_token_and_device_already_removed() {
+        // arrange: устройства с таким id нет (уже удалено конкурентным тиком)
+        long unknownDeviceId = 888_888L;
+
+        // act + assert — повторный вызов не должен падать
+        assertThatNoException().isThrownBy(() -> callbacks.onPushStaleToken(unknownDeviceId));
+        verify(metricsService).recordNotificationFailed(
+                MetricsService.CHANNEL_PUSH, MetricsService.FailureReason.OTHER);
+    }
+
+    @Test
+    @DisplayName("should_record_push_failure_when_on_push_failed")
+    void should_record_push_failure_when_on_push_failed() {
+        // act
+        callbacks.onPushFailed();
+
+        // assert
+        verify(metricsService).recordNotificationFailed(
+                MetricsService.CHANNEL_PUSH, MetricsService.FailureReason.OTHER);
     }
 
     // ===== helpers =====

--- a/src/test/java/com/plantcare/bot/service/NotificationSchedulerServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/NotificationSchedulerServiceTest.java
@@ -3,7 +3,6 @@ package com.plantcare.bot.service;
 import com.plantcare.core.domain.DevicePlatform;
 import com.plantcare.core.domain.UserDevice;
 import com.plantcare.core.repository.UserDeviceRepository;
-import com.plantcare.core.service.PushSender;
 import com.plantcare.core.service.QuietHoursPolicy;
 import com.plantcare.core.service.SchedulerHealthTracker;
 
@@ -108,12 +107,14 @@ class NotificationSchedulerServiceTest {
     @Mock
     private com.plantcare.core.service.LocationSharingService locationSharingService;
 
-    // Issue #175: mock PushSender и UserDeviceRepository для тестов fan-out
-    @Mock
-    private PushSender pushSender;
-
+    // Issue #175 / #177: mock UserDeviceRepository и PushFanOutService для тестов
+    // мультиканального fan-out. Шедулер только формирует PushTarget'ы и отдаёт их
+    // сервису fan-out — реальная доставка push тестируется в PushFanOutServiceTest.
     @Mock
     private UserDeviceRepository userDeviceRepository;
+
+    @Mock
+    private PushFanOutService pushFanOutService;
 
     /**
      * Реальный экземпляр, не мок: проверки в тестах смотрят на содержимое
@@ -696,34 +697,41 @@ class NotificationSchedulerServiceTest {
         }
     }
 
-    // ===== Push fan-out (issue #175) =====
+    // ===== Мультиканальный push fan-out (issue #177) =====
 
     @Nested
-    @DisplayName("Push fan-out на мобильные устройства (#175)")
+    @DisplayName("Мультиканальный fan-out: резолв транспортов юзера (#177)")
     class PushFanOut {
 
+        /** Захватывает список PushTarget'ов из единственного enqueue в fan-out. */
+        @SuppressWarnings("unchecked")
+        private List<PushFanOutService.PushTarget> captureTargets() {
+            ArgumentCaptor<List<PushFanOutService.PushTarget>> captor =
+                    ArgumentCaptor.forClass(List.class);
+            verify(pushFanOutService).enqueue(captor.capture());
+            return captor.getValue();
+        }
+
         @Test
-        @DisplayName("Telegram-юзер без мобильных устройств → push не вызывается")
-        void should_not_call_push_when_user_has_no_devices() {
-            // arrange — userDeviceRepository возвращает пустой список (стаб из setUp)
+        @DisplayName("Telegram-юзер без устройств → только Telegram, fan-out не вызывается")
+        void should_route_telegram_only_when_user_has_no_devices() {
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(false);
 
-            // act
             service.checkAndSendNotifications();
 
-            // assert — Telegram enqueue вызван, push — нет
             verify(telegramSender).enqueue(any(SendMessage.class), any(SendCallbacks.class));
-            verifyNoInteractions(pushSender);
+            verifyNoInteractions(pushFanOutService);
         }
 
         @Test
-        @DisplayName("Mobile-only юзер (без telegramChatId) получает только push")
-        void should_send_push_to_mobile_only_user_with_no_telegram() {
-            // arrange — mobile-only юзер: нет telegram chat id
+        @DisplayName("Mobile-only юзер (telegram_chat_id == null) → только push, без NPE")
+        void should_route_push_only_for_mobile_only_user_without_telegram() {
+            // arrange — mobile-only юзер без telegramChatId (после #88 поле nullable).
+            // Раньше обращение к telegram_chat_id без null-проверки давало NPE (#177 AC).
             User mobileUser = User.builder()
-                    .timezone("Asia/Almaty")           // не-UTC таймзона — проверка AC
+                    .timezone("Asia/Almaty")           // не-UTC таймзона
                     .quietHoursStart(LocalTime.of(0, 0))
                     .quietHoursEnd(LocalTime.of(0, 0))
                     .blocked(false)
@@ -744,66 +752,74 @@ class NotificationSchedulerServiceTest {
 
             UserDevice device = new UserDevice(mobileUser, DevicePlatform.IOS,
                     "apns-token-almaty", java.time.Instant.now());
+            ReflectionTestUtils.setField(device, "id", 90L);
 
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(mobileSchedule));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(false);
             when(userDeviceRepository.findByUserId(5L)).thenReturn(List.of(device));
 
-            // act
+            // act — не должно бросить NPE
             service.checkAndSendNotifications();
 
-            // assert — Telegram не вызван (нет chatId), push вызван с токеном устройства
+            // assert — Telegram не вызван (нет chatId), push-таргет сформирован
             verifyNoInteractions(telegramSender);
-            verify(pushSender).send("apns-token-almaty", "Plants Care", "Пора полить: Алоэ");
+            List<PushFanOutService.PushTarget> targets = captureTargets();
+            assertThat(targets).singleElement().satisfies(t -> {
+                assertThat(t.deviceId()).isEqualTo(90L);
+                assertThat(t.pushToken()).isEqualTo("apns-token-almaty");
+                assertThat(t.body()).isEqualTo("Пора полить: Алоэ");
+                assertThat(t.taskType()).isEqualTo(TaskType.WATERING);
+            });
         }
 
         @Test
-        @DisplayName("Telegram-юзер с зарегистрированным устройством получает оба канала")
-        void should_send_both_telegram_and_push_for_hybrid_user() {
-            // arrange — у обычного telegram-юзера есть зарегистрированное устройство
+        @DisplayName("Telegram-юзер с устройством → оба канала (Telegram + push)")
+        void should_route_both_channels_for_hybrid_user() {
             UserDevice device = new UserDevice(user, DevicePlatform.ANDROID,
                     "fcm-token-abc", java.time.Instant.now());
+            ReflectionTestUtils.setField(device, "id", 91L);
 
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(false);
             when(userDeviceRepository.findByUserId(1L)).thenReturn(List.of(device));
 
-            // act
             service.checkAndSendNotifications();
 
-            // assert — оба канала задействованы
             verify(telegramSender).enqueue(any(SendMessage.class), any(SendCallbacks.class));
-            verify(pushSender).send("fcm-token-abc", "Plants Care", "Пора полить: Монстера");
+            List<PushFanOutService.PushTarget> targets = captureTargets();
+            assertThat(targets).singleElement().satisfies(t -> {
+                assertThat(t.pushToken()).isEqualTo("fcm-token-abc");
+                assertThat(t.body()).isEqualTo("Пора полить: Монстера");
+            });
         }
 
         @Test
-        @DisplayName("Ошибка push одного устройства не блокирует остальные устройства")
-        void should_continue_fan_out_when_one_device_push_fails() {
-            // arrange — два устройства; первое бросает исключение
-            UserDevice deviceBad = new UserDevice(user, DevicePlatform.ANDROID,
-                    "bad-token", java.time.Instant.now());
-            UserDevice deviceGood = new UserDevice(user, DevicePlatform.IOS,
-                    "good-token", java.time.Instant.now());
+        @DisplayName("Несколько устройств юзера → по PushTarget на каждое")
+        void should_build_one_target_per_device() {
+            UserDevice android = new UserDevice(user, DevicePlatform.ANDROID,
+                    "fcm-token", java.time.Instant.now());
+            ReflectionTestUtils.setField(android, "id", 1L);
+            UserDevice ios = new UserDevice(user, DevicePlatform.IOS,
+                    "apns-token", java.time.Instant.now());
+            ReflectionTestUtils.setField(ios, "id", 2L);
 
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule));
             when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
                     .thenReturn(false);
-            when(userDeviceRepository.findByUserId(1L)).thenReturn(List.of(deviceBad, deviceGood));
-            org.mockito.Mockito.doThrow(new RuntimeException("Push delivery failed"))
-                    .when(pushSender).send("bad-token", "Plants Care", "Пора полить: Монстера");
+            when(userDeviceRepository.findByUserId(1L)).thenReturn(List.of(android, ios));
 
-            // act — не должно бросить исключение
             service.checkAndSendNotifications();
 
-            // assert — второе устройство всё равно получило push
-            verify(pushSender).send("good-token", "Plants Care", "Пора полить: Монстера");
+            assertThat(captureTargets())
+                    .extracting(PushFanOutService.PushTarget::pushToken)
+                    .containsExactly("fcm-token", "apns-token");
         }
 
         @Test
-        @DisplayName("Тихие часы / пауза блокируют push так же как Telegram (тест с Asia/Almaty)")
-        void should_not_send_push_during_quiet_hours_non_utc_timezone() {
+        @DisplayName("Тихие часы блокируют ОБА канала (Asia/Almaty, не-UTC)")
+        void should_block_both_channels_during_quiet_hours_non_utc_timezone() {
             // arrange — mobile-only юзер с таймзоной Asia/Almaty (UTC+5); quiet-hours активны
             User almaty = User.builder()
                     .timezone("Asia/Almaty")
@@ -825,20 +841,17 @@ class NotificationSchedulerServiceTest {
                     .build();
             ReflectionTestUtils.setField(schedule7, "id", 700L);
 
-            // quiet-hours активны для этого юзера
+            // quiet-hours активны для этого юзера (канал-нейтральный гейт shouldSend)
             when(quietHoursPolicy.isQuiet(org.mockito.ArgumentMatchers.eq(almaty), any(java.time.Instant.class)))
                     .thenReturn(true);
 
             when(careScheduleRepository.findDueSchedules(any())).thenReturn(List.of(schedule7));
-            when(userDeviceRepository.findByUserId(7L)).thenReturn(List.of(
-                    new UserDevice(almaty, DevicePlatform.IOS, "ios-almaty", java.time.Instant.now())));
 
-            // act
             service.checkAndSendNotifications();
 
-            // assert — ни Telegram, ни push не вызваны (shouldSend вернул false)
+            // assert — ни Telegram, ни push не задействованы (гейт shouldSend отсёк до резолва каналов)
             verifyNoInteractions(telegramSender);
-            verifyNoInteractions(pushSender);
+            verifyNoInteractions(pushFanOutService);
         }
     }
 

--- a/src/test/java/com/plantcare/bot/service/PushFanOutServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/PushFanOutServiceTest.java
@@ -1,0 +1,139 @@
+package com.plantcare.bot.service;
+
+import com.plantcare.core.config.NoopPushSender;
+import com.plantcare.core.domain.enums.TaskType;
+import com.plantcare.core.service.PushSender;
+import com.plantcare.core.service.PushSender.PushResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit-тесты {@link PushFanOutService} (issue #177) — маршрутизация исхода
+ * {@link PushResult} из порта {@link PushSender} в bookkeeping-колбэки
+ * {@link NotificationDeliveryCallbacks}.
+ *
+ * <p>Доставка отвязана от транзакции тика и исполняется на daemon-исполнителе;
+ * чтобы тесты были детерминированы, дёргаем package-private {@link
+ * PushFanOutService#deliver} напрямую (синхронно), с замоканным {@link PushSender}.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Unit-тесты для PushFanOutService (issue #177)")
+class PushFanOutServiceTest {
+
+    @Mock
+    private PushSender pushSender;
+
+    @Mock
+    private NotificationDeliveryCallbacks deliveryCallbacks;
+
+    @InjectMocks
+    private PushFanOutService service;
+
+    private static PushFanOutService.PushTarget target() {
+        return new PushFanOutService.PushTarget(42L, "token-abc", "Пора полить: Алоэ", TaskType.WATERING);
+    }
+
+    @Test
+    @DisplayName("SENT → onPushSent с типом задачи, токен НЕ удаляется")
+    void should_record_sent_when_push_delivered() {
+        when(pushSender.send(eq("token-abc"), anyString(), eq("Пора полить: Алоэ")))
+                .thenReturn(PushResult.SENT);
+
+        service.deliver(target());
+
+        verify(deliveryCallbacks).onPushSent(TaskType.WATERING);
+        verify(deliveryCallbacks, never()).onPushStaleToken(anyLong());
+        verify(deliveryCallbacks, never()).onPushFailed();
+    }
+
+    @Test
+    @DisplayName("STALE_TOKEN (FCM UNREGISTERED/NOT_FOUND) → удаление протухшего устройства по id")
+    void should_remove_stale_device_when_token_unregistered() {
+        when(pushSender.send(anyString(), anyString(), anyString()))
+                .thenReturn(PushResult.STALE_TOKEN);
+
+        service.deliver(target());
+
+        verify(deliveryCallbacks).onPushStaleToken(42L);
+        verify(deliveryCallbacks, never()).onPushSent(any());
+    }
+
+    @Test
+    @DisplayName("FAILED (сеть/5xx) → onPushFailed, токен остаётся для повтора")
+    void should_record_failed_when_delivery_fails_transiently() {
+        when(pushSender.send(anyString(), anyString(), anyString()))
+                .thenReturn(PushResult.FAILED);
+
+        service.deliver(target());
+
+        verify(deliveryCallbacks).onPushFailed();
+        verify(deliveryCallbacks, never()).onPushStaleToken(anyLong());
+    }
+
+    @Test
+    @DisplayName("Исключение из порта не роняет воркер — считается за onPushFailed")
+    void should_treat_thrown_exception_as_failed() {
+        when(pushSender.send(anyString(), anyString(), anyString()))
+                .thenThrow(new RuntimeException("provider exploded"));
+
+        service.deliver(target());
+
+        verify(deliveryCallbacks).onPushFailed();
+    }
+
+    @Test
+    @DisplayName("enqueue по нескольким устройствам доставляет каждое (single-thread executor)")
+    void should_deliver_each_target_when_enqueued() throws Exception {
+        when(pushSender.send(anyString(), anyString(), anyString())).thenReturn(PushResult.SENT);
+
+        service.enqueue(List.of(
+                new PushFanOutService.PushTarget(1L, "t1", "body", TaskType.WATERING),
+                new PushFanOutService.PushTarget(2L, "t2", "body", TaskType.MISTING)));
+
+        // executor однопоточный — дожидаемся дренирования через PreDestroy shutdown.
+        invokeShutdown();
+
+        verify(pushSender, times(2)).send(anyString(), anyString(), anyString());
+        verify(deliveryCallbacks).onPushSent(TaskType.WATERING);
+        verify(deliveryCallbacks).onPushSent(TaskType.MISTING);
+    }
+
+    @Test
+    @DisplayName("push.enabled=false (NoopPushSender) → SENT, путь не ломается")
+    void should_not_break_when_push_disabled_noop_sender() {
+        PushFanOutService noopService =
+                new PushFanOutService(new NoopPushSender(), deliveryCallbacks);
+
+        noopService.deliver(target());
+
+        verify(deliveryCallbacks).onPushSent(TaskType.WATERING);
+        verifyNoInteractions(pushSender);
+    }
+
+    /** Дёргает @PreDestroy shutdown рефлексией, чтобы дождаться дренирования executor'а. */
+    private void invokeShutdown() throws Exception {
+        var method = PushFanOutService.class.getDeclaredMethod("shutdown");
+        method.setAccessible(true);
+        method.invoke(service);
+    }
+
+    // anyLong — отдельный импорт через статический хелпер, чтобы не тащить весь ArgumentMatchers.
+    private static long anyLong() {
+        return org.mockito.ArgumentMatchers.anyLong();
+    }
+}


### PR DESCRIPTION
Closes #177

Часть #167 (push-уведомления), дизайн — ADR-014. Делает Telegram и Push равноправными транспортами шедулера напоминаний.

## Что сделано
- **Канал-нейтральный резолв транспортов после гейта.** `shouldSend` (pause / quiet-hours / dedup по `notifications_log`) не тронут. После него: `telegram_chat_id != null && !blocked` → Telegram; есть записи в `user_devices` → Push; оба → оба. Предпочтение выводится из наличия каналов — без поля `notification_channel`.
- **Push вне транзакции тика.** Реальная push-раздача вынесена в новый `PushFanOutService` на daemon-executor'е. Шедулер внутри транзакции тика только читает устройства и формирует примитивные `PushTarget` (никаких detached-entity между потоками) и отдаёт их сервису fan-out — доставка идёт ВНЕ открытой транзакции к БД (CLAUDE.md).
- **Порт `PushSender` → `PushResult`** (`SENT`/`STALE_TOKEN`/`FAILED`). На `STALE_TOKEN` (FCM `UNREGISTERED`/`NOT_FOUND`) `NotificationDeliveryCallbacks.onPushStaleToken` удаляет протухшую запись `user_devices` (идемпотентно) и пишет метрику неудачи; `FAILED` оставляет токен для повтора.
- **`MetricsService`: добавлен `CHANNEL_PUSH`** (сигнатура `recordNotificationSent(channel, …)` уже мультиканальна).
- **`NotificationDeliveryCallbacks`** расширены push-bookkeeping'ом: `onPushSent` / `onPushStaleToken` / `onPushFailed` (каждый — своя транзакция на воркер-потоке).
- **Фикс NPE для mobile-only юзеров:** обращение к `telegram_chat_id` под null-guard (mobile-only юзер получает только push, без падения).

## Миграции
нет

## Backward-compat риски
safe — DDL не меняется. Меняется только сигнатура внутреннего порта `PushSender` (`void` → `PushResult`); единственная реализация на develop — `NoopPushSender` — обновлена. FCM-реализация (#176) ещё не смержена, конфликтов с прод-кодом нет.

## Тесты
- `PushFanOutServiceTest` (мок `PushSender`): маршрутизация `SENT → onPushSent`, `STALE_TOKEN → onPushStaleToken` (удаление устройства), `FAILED → onPushFailed`, исключение порта = `onPushFailed`, fan-out по нескольким устройствам, **`push.enabled=false` (`NoopPushSender`) не ломает путь**.
- `NotificationSchedulerServiceTest` (мок fan-out): «telegram-юзер → только telegram», «mobile-only (telegram_chat_id == null) → только push, без NPE», «оба канала для hybrid-юзера», «по PushTarget на каждое устройство», **обязательный не-UTC quiet-hours кейс (Asia/Almaty) блокирует оба канала**.
- `NotificationDeliveryCallbacksTest` (Testcontainers Postgres): метрика `CHANNEL_PUSH` на `onPushSent`; **удаление протухшего `user_devices` на `onPushStaleToken`** + идемпотентность при уже удалённом устройстве; `onPushFailed`.

## Чек
- [x] `mvn verify` зелёное по затронутым модулям (push/notification/metrics). На локальной машине 2 предсуществующих флака (`SpeciesRepositoryTest.topPopularReturnsInCorrectOrder`, `PlantServiceTest.getPopularSpecies_orderedByPopularity` — tie в популярности сидов) воспроизводятся и на pristine develop, к этому PR отношения не имеют.
