### PR TITLE
fix(scheduler): guard digest send for mobile-only users (no telegramChatId)

### DIFF
--- a/src/main/java/com/plantcare/bot/service/NotificationSchedulerService.java
+++ b/src/main/java/com/plantcare/bot/service/NotificationSchedulerService.java
@@ -399,6 +399,31 @@ public class NotificationSchedulerService {
     }
 
     /**
+     * Fan-out push-дайджеста на все мобильные устройства пользователя
+     * (issue #175 / #177). Зеркалит {@link #fanOutToMobileDevices}, но шлёт
+     * один push на устройство с готовым текстом дайджеста (а не по push на задачу),
+     * так как дайджест — это одно сгруппированное уведомление. Для среза метрики
+     * доставки берём тип первой задачи дайджеста (push — коарс-счётчик доставки;
+     * дедуп-лог по каждой задаче ведётся только на Telegram-канале через onDigestSent).
+     *
+     * <p>Как и в {@link #fanOutToMobileDevices}, внутри транзакции тика только читаем
+     * устройства и формируем примитивные {@link PushFanOutService.PushTarget};
+     * доставка исполняется ВНЕ транзакции в {@link PushFanOutService}.
+     */
+    private void fanOutDigestToMobileDevices(User user, List<CareSchedule> schedules, String digestText) {
+        List<UserDevice> devices = userDeviceRepository.findByUserId(user.getId());
+        if (devices.isEmpty()) {
+            return;
+        }
+        TaskType metricTaskType = schedules.get(0).getTaskType();
+        List<PushFanOutService.PushTarget> targets = devices.stream()
+                .map(device -> new PushFanOutService.PushTarget(
+                        device.getId(), device.getPushToken(), digestText, metricTaskType))
+                .toList();
+        pushFanOutService.enqueue(targets);
+    }
+
+    /**
      * Веерная рассылка готового push'а всем caretaker'ам локации растения
      * (issue #77). Никакого нового bookkeeping — это копия уведомления владельца.
      */
@@ -465,35 +490,48 @@ public class NotificationSchedulerService {
 
         NotificationDigest savedDigest = notificationDigestRepository.save(digest);
 
-        SendMessage message = SendMessage.builder()
-                .chatId(user.getTelegramChatId().toString())
-                .text(buildDigestText(items))
-                .replyMarkup(buildDigestKeyboard(savedDigest.getId()))
-                .build();
-
-        // Issue #29: см. комментарий в sendNotification. Каждый сгруппированный пуш
-        // считаем за отправленное уведомление по каждой задаче (срезы по task_type) +
-        // отдельный счётчик дайджестов. Bookkeeping — в колбэке на воркер-потоке.
-        final List<NotificationDeliveryCallbacks.DigestLogItem> logItems = schedules.stream()
-                .map(s -> new NotificationDeliveryCallbacks.DigestLogItem(
-                        s.getPlant().getId(), s.getTaskType()))
-                .toList();
-        final long chatId = user.getTelegramChatId();
+        String digestBody = buildDigestText(items);
         final long digestId = savedDigest.getId();
-        final int taskCount = schedules.size();
-        telegramSender.enqueue(message, new SendCallbacks(
-                () -> {
-                    deliveryCallbacks.onDigestSent(logItems);
-                    log.info("Sent digest id={} with {} tasks to chat {}",
-                            digestId, taskCount, chatId);
-                },
-                e -> deliveryCallbacks.onFailed(chatId, e)));
+
+        // Telegram-канал: только если у юзера привязан Telegram-чат (issue #88:
+        // mobile-only юзеры могут не иметь telegramChatId). Зеркалит гард из
+        // sendNotification — без него вызов getTelegramChatId().toString() ронял
+        // шедулер NPE на mobile-only юзере с 2+ due-задачами.
+        if (user.getTelegramChatId() != null) {
+            SendMessage message = SendMessage.builder()
+                    .chatId(user.getTelegramChatId().toString())
+                    .text(digestBody)
+                    .replyMarkup(buildDigestKeyboard(digestId))
+                    .build();
+
+            // Issue #29: см. комментарий в sendNotification. Каждый сгруппированный пуш
+            // считаем за отправленное уведомление по каждой задаче (срезы по task_type) +
+            // отдельный счётчик дайджестов. Bookkeeping — в колбэке на воркер-потоке.
+            final List<NotificationDeliveryCallbacks.DigestLogItem> logItems = schedules.stream()
+                    .map(s -> new NotificationDeliveryCallbacks.DigestLogItem(
+                            s.getPlant().getId(), s.getTaskType()))
+                    .toList();
+            final long chatId = user.getTelegramChatId();
+            final int taskCount = schedules.size();
+            telegramSender.enqueue(message, new SendCallbacks(
+                    () -> {
+                        deliveryCallbacks.onDigestSent(logItems);
+                        log.info("Sent digest id={} with {} tasks to chat {}",
+                                digestId, taskCount, chatId);
+                    },
+                    e -> deliveryCallbacks.onFailed(chatId, e)));
+        }
+
+        // Issue #175 / #177: fan-out дайджеста на мобильные устройства пользователя
+        // (зеркалит fanOutToMobileDevices в sendNotification). Telegram-юзеры с
+        // mobile-устройствами получат дайджест в оба канала; mobile-only — только push.
+        // Тихие часы / paused_until уже проверены канал-нейтрально в shouldSend() выше.
+        fanOutDigestToMobileDevices(user, schedules, digestBody);
 
         // Совместный уход (issue #77): дайджест веером уходит caretaker'ам всех
         // локаций, чьи растения попали в дайджест. Клавиатура завязана на digestId
         // и закрывает задачи у всех участников. Дедуп по chatId — один caretaker
         // может иметь доступ к нескольким локациям в одном дайджесте.
-        String digestText = buildDigestText(items);
         InlineKeyboardMarkup digestKeyboard = buildDigestKeyboard(digestId);
         java.util.Set<Long> caretakerChatIds = new java.util.LinkedHashSet<>();
         schedules.stream()
@@ -506,7 +544,7 @@ public class NotificationSchedulerService {
         for (Long caretakerChatId : caretakerChatIds) {
             SendMessage copy = SendMessage.builder()
                     .chatId(caretakerChatId.toString())
-                    .text(digestText)
+                    .text(digestBody)
                     .replyMarkup(digestKeyboard)
                     .build();
             final long targetChatId = caretakerChatId;

--- a/src/test/java/com/plantcare/bot/service/NotificationSchedulerServiceTest.java
+++ b/src/test/java/com/plantcare/bot/service/NotificationSchedulerServiceTest.java
@@ -470,6 +470,60 @@ class NotificationSchedulerServiceTest {
         }
 
         @Test
+        @DisplayName("Mobile-only юзер (telegram_chat_id == null) с 2+ задачами → push-дайджест, без NPE")
+        void should_send_push_digest_to_mobile_only_user_with_no_telegram() {
+            // arrange — mobile-only юзер без telegramChatId (после #88 поле nullable) с
+            // несколькими due-задачами. Раньше sendDigest безусловно звал
+            // getTelegramChatId().toString() и ронял шедулер NPE.
+            User mobileUser = User.builder()
+                    .timezone("Asia/Almaty")           // не-UTC таймзона
+                    .quietHoursStart(LocalTime.of(0, 0))
+                    .quietHoursEnd(LocalTime.of(0, 0))
+                    .blocked(false)
+                    .build();
+            ReflectionTestUtils.setField(mobileUser, "id", 5L);
+
+            Plant mobilePlant = Plant.builder().user(mobileUser).name("Алоэ").build();
+            ReflectionTestUtils.setField(mobilePlant, "id", 50L);
+
+            CareSchedule waterSchedule = dueSchedule(mobilePlant, TaskType.WATERING, 500L);
+            CareSchedule mistSchedule = dueSchedule(mobilePlant, TaskType.MISTING, 501L);
+
+            UserDevice device = new UserDevice(mobileUser, DevicePlatform.IOS,
+                    "apns-token-almaty", java.time.Instant.now());
+            ReflectionTestUtils.setField(device, "id", 90L);
+
+            when(careScheduleRepository.findDueSchedules(any()))
+                    .thenReturn(List.of(waterSchedule, mistSchedule));
+            when(notificationLogRepository.existsByPlantIdAndTaskTypeAndSentAtAfter(any(), any(), any()))
+                    .thenReturn(false);
+            when(notificationDigestRepository.save(any(NotificationDigest.class)))
+                    .thenReturn(savedDigest(500L));
+            when(userDeviceRepository.findByUserId(5L)).thenReturn(List.of(device));
+
+            // act — не должно бросить NPE
+            service.checkAndSendNotifications();
+
+            // assert — Telegram не вызван (нет chatId), дайджест ушёл в push одним
+            // сообщением на устройство с текстом дайджеста.
+            verifyNoInteractions(telegramSender);
+
+            ArgumentCaptor<List<PushFanOutService.PushTarget>> captor =
+                    ArgumentCaptor.forClass(List.class);
+            verify(pushFanOutService).enqueue(captor.capture());
+            assertThat(captor.getValue()).singleElement().satisfies(t -> {
+                assertThat(t.deviceId()).isEqualTo(90L);
+                assertThat(t.pushToken()).isEqualTo("apns-token-almaty");
+                assertThat(t.body()).contains("На сегодня:");
+                assertThat(t.body()).contains("Алоэ — полить");
+                assertThat(t.body()).contains("Алоэ — опрыскать");
+            });
+
+            // дайджест по-прежнему сохраняется
+            verify(notificationDigestRepository).save(any(NotificationDigest.class));
+        }
+
+        @Test
         @DisplayName("Если у разных пользователей по одной задаче, digest не создаётся")
         void shouldNotCreateDigestForDifferentUsersWithSingleTaskEach() {
             User secondUser = secondUser();


### PR DESCRIPTION
## Что сделано

Прод-баг: `NotificationSchedulerService.sendDigest` ронял шедулер NPE на mobile-only
юзерах. После V31 (#88) `users.telegram_chat_id` стало nullable, а `sendDigest`
безусловно звал `user.getTelegramChatId().toString()`. У юзера, вошедшего через
email/Apple/Google и имеющего 2+ due-задачи (ветка digest), это NPE — а так как
шедулер крутит всех юзеров в одном тике, падение било по доставке остальным.

Фикс зеркалит уже корректный паттерн `sendNotification`:

- **Telegram-отправка дайджеста** обёрнута в `if (user.getTelegramChatId() != null) { ... }`.
- **Добавлен `fanOutDigestToMobileDevices`** — один push на устройство с готовым
  текстом дайджеста (mirror `fanOutToMobileDevices`), чтобы mobile-only юзер получил
  push-дайджест. Telegram-юзеры с mobile-устройствами теперь получают дайджест в оба
  канала (как и для одиночных уведомлений). Для среза метрики доставки берётся тип
  первой задачи дайджеста; дедуп-лог по каждой задаче по-прежнему ведётся только на
  Telegram-канале через `onDigestSent`.
- Поведение Telegram-юзеров не изменено (текст/клавиатура/bookkeeping те же).

## Миграции

нет

## Backward-compat риски

safe — чистый null-guard + дополнительный канал доставки. Telegram-путь без изменений.

## Тесты

`NotificationSchedulerServiceTest` (`src/test/java/com/plantcare/bot/service/NotificationSchedulerServiceTest.java`):
- Новый кейс `should_send_push_digest_to_mobile_only_user_with_no_telegram`:
  mobile-only юзер (telegram_chat_id == null, не-UTC TZ Asia/Almaty) с 2 due-задачами
  → шедулер не падает, `telegramSender` НЕ вызван, сформирован push-таргет с текстом
  дайджеста («На сегодня: …», обе задачи).
- Существующие digest-тесты (Telegram-юзер) остаются зелёными.

## Чек

- [x] `NotificationSchedulerServiceTest` зелёный локально (34 теста, JDK 21, offline).
- [ ] `./mvnw verify` (Testcontainers IT) — локально не гонялся: Docker недоступен в
      окружении агента. Полный `verify` отрабатывает CI на этом PR.

> Примечание: для этого прод-бага не нашлось открытой issue, поэтому PR без `Closes #N`.
