### PR TITLE
fix(bot): чинит no Session в /menu — eager-фетч activeLocation

### DIFF
--- a/src/main/java/com/plantcare/core/repository/UserRepository.java
+++ b/src/main/java/com/plantcare/core/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.plantcare.core.repository;
 
 import com.plantcare.core.domain.User;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
@@ -16,6 +17,16 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByTelegramChatId(Long telegramChatId);
 
+    /**
+     * Общий загрузчик юзера по chat_id для бот-путей (/menu, переключение/пауза
+     * локаций). {@code activeLocation} — ленивый {@code @ManyToOne}, а меню
+     * читается уже вне транзакции, поэтому без графа ленивый прокси даёт
+     * {@code LazyInitializationException: no Session}. {@code @EntityGraph} даёт
+     * дешёвый LEFT JOIN по nullable-FK и инициализирует связь в транзакции
+     * загрузки. Срабатывало только при заполненном active_location_id (для NULL
+     * ленивый ManyToOne и так отдаёт null без обращения к БД).
+     */
+    @EntityGraph(attributePaths = "activeLocation")
     Optional<User> findByTelegramChatId(Long telegramChatId);
 
     /** Issue #79: lookup for public {@code GET /calendar/{token}.ics}. */

--- a/src/test/java/com/plantcare/core/repository/UserRepositoryTest.java
+++ b/src/test/java/com/plantcare/core/repository/UserRepositoryTest.java
@@ -1,8 +1,11 @@
 package com.plantcare.core.repository;
 
 import com.plantcare.core.domain.enums.ConversationState;
+import com.plantcare.core.domain.Location;
 import com.plantcare.core.domain.User;
 import com.plantcare.bot.support.IntegrationTestBase;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,8 +21,17 @@ class UserRepositoryTest extends IntegrationTestBase {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
     @AfterEach
     void cleanup() {
+        // Локации ссылаются на users по FK — удаляем их первыми, иначе deleteAll
+        // по users падает на нарушении внешнего ключа active_location_id/user_id.
+        locationRepository.deleteAll();
         userRepository.deleteAll();
     }
 
@@ -46,6 +58,32 @@ class UserRepositoryTest extends IntegrationTestBase {
 
         assertThat(userRepository.findByTelegramChatId(101L)).isPresent();
         assertThat(userRepository.findByTelegramChatId(999L)).isEmpty();
+    }
+
+    @Test
+    void findByTelegramChatIdEagerlyLoadsActiveLocation() {
+        // Регрессия на no Session в /menu: @EntityGraph должен инициализировать
+        // ленивый activeLocation в транзакции загрузки. Чистим контекст, чтобы
+        // прокси нельзя было дочитать через сессию — читаем именно то, что
+        // подтянул граф.
+        User user = userRepository.save(User.builder().telegramChatId(106L).build());
+        Location location = locationRepository.save(Location.builder()
+                .user(user)
+                .name(Location.DEFAULT_NAME)
+                .emoji(Location.DEFAULT_EMOJI)
+                .defaultLocation(true)
+                .build());
+        user.setActiveLocation(location);
+        userRepository.saveAndFlush(user);
+        entityManager.clear();
+
+        User loaded = userRepository.findByTelegramChatId(106L).orElseThrow();
+
+        // Доступ к полю activeLocation вне активной сессии не должен кидать
+        // LazyInitializationException.
+        assertThat(loaded.getActiveLocation()).isNotNull();
+        assertThat(loaded.getActiveLocation().getDisplayName())
+                .isEqualTo(Location.DEFAULT_EMOJI + " " + Location.DEFAULT_NAME);
     }
 
     @Test


### PR DESCRIPTION
## Проблема
При команде боту `/menu` в логах `LazyInitializationException: could not initialize proxy - no Session`.

**Цепочка:** `MenuCommand` грузит юзера через `UserService.findByChatId` → `UserRepository.findByTelegramChatId` (derived-метод без графа). Транзакция закрывается на выходе. Дальше отсоединённый `User` уходит в нетранзакционный `MainMenuService.sendMainMenu`, который читает `user.getActiveLocation()` — `@ManyToOne(fetch = LAZY)`. Обращение к незагруженному прокси вне сессии → `no Session`.

Падает только когда у юзера проставлен `active_location_id` (для null-FK ленивый `@ManyToOne` отдаёт null без БД) — фича #70 «активная локация».

## Фикс
`@EntityGraph(attributePaths = "activeLocation")` на `UserRepository.findByTelegramChatId`. Бот резолвит юзера по chat_id на каждое действие, `activeLocation` нужна во многих меню/коллбэках — поэтому фикс глобальный на общем загрузчике. Цена — один дешёвый `LEFT JOIN` по nullable-FK.

Остальные ленивые связи в пути `/menu` безопасны: `findUserSchedulesDueBefore` уже делает `JOIN FETCH plant + location`.

## Тест
`UserRepositoryTest.findByTelegramChatIdEagerlyLoadsActiveLocation` (Testcontainers Postgres): сохранить User с activeLocation → `flush + clear` → загрузить → прочитать `getActiveLocation().getDisplayName()` без сессии. Проверен мутацией: без `@EntityGraph` тест падает ровно на `LazyInitializationException ... no session`.

`mvn -o -Dtest=UserRepositoryTest test` → 6 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)